### PR TITLE
set sswitch_CLI args.pre to SimplePreLAG

### DIFF
--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -41,6 +41,8 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
 def main():
     args = runtime_CLI.get_parser().parse_args()
 
+    args.pre = runtime_CLI.PreType.SimplePreLAG
+
     runtime_CLI.load_json(args.json)
 
     services = runtime_CLI.RuntimeAPI.get_thrift_services(args.pre)


### PR DESCRIPTION
sswitch_CLI is assumed to use SimplePreLAG but the default argument is set to use SimplePre.