### PR TITLE
Avoid "what" as field name

### DIFF
--- a/modules/bm_runtime/src/SimplePreLAG_server.ipp
+++ b/modules/bm_runtime/src/SimplePreLAG_server.ipp
@@ -39,7 +39,7 @@ public:
       pre->mc_mgrp_create(mgrp, &mgrp_hdl);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
     return mgrp_hdl;
@@ -51,7 +51,7 @@ public:
       pre->mc_mgrp_destroy(mgrp_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -65,7 +65,7 @@ public:
       pre->mc_node_create(rid, port_map, lag_map, &l1_hdl);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
     return l1_hdl;
@@ -77,7 +77,7 @@ public:
       pre->mc_node_associate(mgrp_handle, l1_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -88,7 +88,7 @@ public:
       pre->mc_node_dissociate(mgrp_handle, l1_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -99,7 +99,7 @@ public:
       pre->mc_node_destroy(l1_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -115,7 +115,7 @@ public:
     );
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -129,7 +129,7 @@ public:
     );
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }

--- a/modules/bm_runtime/src/SimplePre_server.ipp
+++ b/modules/bm_runtime/src/SimplePre_server.ipp
@@ -39,7 +39,7 @@ public:
       pre->mc_mgrp_create(mgrp, &mgrp_hdl);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
     return mgrp_hdl;
@@ -51,7 +51,7 @@ public:
       pre->mc_mgrp_destroy(mgrp_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -63,7 +63,7 @@ public:
       pre->mc_node_create(rid, port_map, &l1_hdl);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
     return l1_hdl;
@@ -75,7 +75,7 @@ public:
       pre->mc_node_associate(mgrp_handle, l1_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -86,7 +86,7 @@ public:
       pre->mc_node_dissociate(mgrp_handle, l1_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -97,7 +97,7 @@ public:
       pre->mc_node_destroy(l1_handle);
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -109,7 +109,7 @@ public:
     );
     if(error_code != McSimplePre::SUCCESS) {
       InvalidMcOperation imo;
-      imo.what = (McOperationErrorCode::type) error_code;
+      imo.code = (McOperationErrorCode::type) error_code;
       throw imo;
     }
   }

--- a/modules/bm_runtime/src/Standard_server.ipp
+++ b/modules/bm_runtime/src/Standard_server.ipp
@@ -121,7 +121,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
     return entry_handle;
@@ -140,7 +140,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -153,7 +153,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -172,7 +172,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -185,7 +185,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -203,7 +203,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
     return mbr_handle;
@@ -216,7 +216,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -232,7 +232,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -247,7 +247,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
     return entry_handle;
@@ -260,7 +260,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -272,7 +272,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -285,7 +285,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -297,7 +297,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -310,7 +310,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
     return grp_handle;
@@ -323,7 +323,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -335,7 +335,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -347,7 +347,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -362,7 +362,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
     return entry_handle;
@@ -375,7 +375,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -387,7 +387,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -403,7 +403,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
     _return.bytes = (int64_t) bytes;
@@ -417,7 +417,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -433,7 +433,7 @@ public:
     );
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
-      ito.what = get_exception_code(error_code);
+      ito.code = get_exception_code(error_code);
       throw ito;
     }
   }
@@ -449,7 +449,7 @@ public:
     );
     if(error_code != Counter::CounterErrorCode::SUCCESS) {
       InvalidCounterOperation ico;
-      ico.what = (CounterOperationErrorCode::type) error_code;
+      ico.code = (CounterOperationErrorCode::type) error_code;
       throw ico;
     }
     _return.bytes = (int64_t) bytes;
@@ -461,7 +461,7 @@ public:
     Counter::CounterErrorCode error_code = switch_->reset_counters(counter_name);
     if(error_code != Counter::CounterErrorCode::SUCCESS) {
       InvalidCounterOperation ico;
-      ico.what = (CounterOperationErrorCode::type) error_code;
+      ico.code = (CounterOperationErrorCode::type) error_code;
       throw ico;
     }
   }
@@ -477,7 +477,7 @@ public:
     );
     if(error_code != Counter::CounterErrorCode::SUCCESS) {
       InvalidCounterOperation ico;
-      ico.what = (CounterOperationErrorCode::type) error_code;
+      ico.code = (CounterOperationErrorCode::type) error_code;
       throw ico;
     }
   }
@@ -498,7 +498,7 @@ public:
       switch_->load_new_config(config_str);
     if(error_code != RuntimeInterface::SUCCESS) {
       InvalidSwapOperation iso;
-      iso.what = (SwapOperationErrorCode::type) error_code;
+      iso.code = (SwapOperationErrorCode::type) error_code;
       throw iso;
     }
   }
@@ -508,7 +508,7 @@ public:
     RuntimeInterface::ErrorCode error_code = switch_->swap_configs();
     if(error_code != RuntimeInterface::SUCCESS) {
       InvalidSwapOperation iso;
-      iso.what = (SwapOperationErrorCode::type) error_code;
+      iso.code = (SwapOperationErrorCode::type) error_code;
       throw iso;
     }
   }
@@ -526,7 +526,7 @@ public:
       switch_->meter_array_set_rates(meter_array_name, rates_);
     if(error_code != Meter::MeterErrorCode::SUCCESS) {
       InvalidMeterOperation imo;
-      imo.what = (MeterOperationErrorCode::type) error_code;
+      imo.code = (MeterOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -545,7 +545,7 @@ public:
     );
     if(error_code != Meter::MeterErrorCode::SUCCESS) {
       InvalidMeterOperation imo;
-      imo.what = (MeterOperationErrorCode::type) error_code;
+      imo.code = (MeterOperationErrorCode::type) error_code;
       throw imo;
     }
   }
@@ -558,7 +558,7 @@ public:
     );
     if(error_code != Register::RegisterErrorCode::SUCCESS) {
       InvalidRegisterOperation iro;
-      iro.what = (RegisterOperationErrorCode::type) error_code;
+      iro.code = (RegisterOperationErrorCode::type) error_code;
       throw iro;
     }
     return value.get<int64_t>();
@@ -571,7 +571,7 @@ public:
     );
     if(error_code != Register::RegisterErrorCode::SUCCESS) {
       InvalidRegisterOperation iro;
-      iro.what = (RegisterOperationErrorCode::type) error_code;
+      iro.code = (RegisterOperationErrorCode::type) error_code;
       throw iro;
     }
   }
@@ -584,7 +584,7 @@ public:
     error_code = switch_->port_add(iface_name, port_num, pcap, pcap);
     if(error_code != DevMgr::ReturnCode::SUCCESS) {
       InvalidDevMgrOperation idmo;
-      idmo.what = (DevMgrErrorCode::type) 1; // TODO
+      idmo.code = (DevMgrErrorCode::type) 1; // TODO
       throw idmo;
     }
   }
@@ -595,7 +595,7 @@ public:
     error_code = switch_->port_remove(port_num);
     if(error_code != DevMgr::ReturnCode::SUCCESS) {
       InvalidDevMgrOperation idmo;
-      idmo.what = (DevMgrErrorCode::type) 1; // TODO
+      idmo.code = (DevMgrErrorCode::type) 1; // TODO
       throw idmo;
     }
   }

--- a/thrift_src/simple_pre.thrift
+++ b/thrift_src/simple_pre.thrift
@@ -37,7 +37,7 @@ enum McOperationErrorCode {
 }
 
 exception InvalidMcOperation {
-  1:McOperationErrorCode what
+  1:McOperationErrorCode code
 }
 
 service SimplePre {

--- a/thrift_src/simple_pre_lag.thrift
+++ b/thrift_src/simple_pre_lag.thrift
@@ -40,7 +40,7 @@ enum McOperationErrorCode {
 }
 
 exception InvalidMcOperation {
-  1:McOperationErrorCode what
+  1:McOperationErrorCode code
 }
 
 service SimplePreLAG {

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -103,7 +103,7 @@ enum TableOperationErrorCode {
 }
 
 exception InvalidTableOperation {
-  1:TableOperationErrorCode what
+  1:TableOperationErrorCode code
 }
 
 enum CounterOperationErrorCode {
@@ -113,7 +113,7 @@ enum CounterOperationErrorCode {
 }
 
 exception InvalidCounterOperation {
-  1:CounterOperationErrorCode what
+  1:CounterOperationErrorCode code
 }
 
 enum SwapOperationErrorCode {
@@ -123,7 +123,7 @@ enum SwapOperationErrorCode {
 }
 
 exception InvalidSwapOperation {
-  1:SwapOperationErrorCode what
+  1:SwapOperationErrorCode code
 }
 
 enum MeterOperationErrorCode {
@@ -135,7 +135,7 @@ enum MeterOperationErrorCode {
 }
 
 exception InvalidMeterOperation {
- 1:MeterOperationErrorCode what
+ 1:MeterOperationErrorCode code
 }
 
 typedef i64 BmRegisterValue
@@ -146,7 +146,7 @@ enum RegisterOperationErrorCode {
 }
 
 exception InvalidRegisterOperation {
- 1:RegisterOperationErrorCode what
+ 1:RegisterOperationErrorCode code
 }
 
 // TODO
@@ -155,7 +155,7 @@ enum DevMgrErrorCode {
 }
 
 exception InvalidDevMgrOperation {
- 1:DevMgrErrorCode what
+ 1:DevMgrErrorCode code
 }
 
 service Standard {


### PR DESCRIPTION
I'm not sure if this has to do with the version of Apache Thrift that
I'm using, but I'm seeing errors

In file included from gen-cpp/standard_constants.h:10:0,
                 from gen-cpp/standard_constants.cpp:7:
gen-cpp/standard_types.h:616:34: error: 'const char* bm_runtime::standard::InvalidTableOperation::what() const' conflicts with a previous declaration
   const char* what() const throw();
                                  ^
gen-cpp/standard_types.h:593:33: note: previous declaration 'bm_runtime::standard::TableOperationErrorCode::type bm_runtime::standard::InvalidTableOperation::what'
   TableOperationErrorCode::type what;
                                 ^

If you squint hard enough you'll see that the problem is that there's a
method called "what" (to be compatible with std::exception, I guess) and
a field called "what" as well. The method comes from the base class.

By changing the .thrift file to use a field name other than "what", the
compilation issue is resolved.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@hpe.com>