### PR TITLE
Action param register ref

### DIFF
--- a/modules/bm_sim/include/bm_sim/actions.h
+++ b/modules/bm_sim/include/bm_sim/actions.h
@@ -230,8 +230,6 @@ struct ActionParam {
 // can only be a field or a register reference
 template <> inline
 Data &ActionParam::to<Data &>(ActionEngineState *state) const {
-  /* Should probably be able to return a register reference here, but not
-     needed right now */
   static thread_local Data data_temp;
 
   switch (tag) {
@@ -255,8 +253,6 @@ const Data &ActionParam::to<const Data &>(ActionEngineState *state) const {
   static thread_local unsigned int data_temps_size = 4;
   static thread_local std::vector<Data> data_temps(data_temps_size);
 
-  /* Should probably be able to return a register reference here, but not
-     needed right now */
   switch (tag) {
     case ActionParam::CONST:
       return state->const_values[const_offset];

--- a/modules/bm_sim/include/bm_sim/actions.h
+++ b/modules/bm_sim/include/bm_sim/actions.h
@@ -48,8 +48,8 @@
 //!
 //! Valid functor parameters for an action primitive include:
 //!   - `const Data &` for any P4 numerical values (it can be a P4 constant, a
-//! field, action data or the result of an expression). Note that `Data &` is
-//! not a valid parameter for a primitive.
+//! field, action data or the result of an expression).
+//!   - `Data &` for a writable P4 numerical value (essentially a field)
 //!   - `[const] Field &` for P4 field references
 //!   - `[const] Header &` for P4 header references
 //!   - `const NamedCalculation &` for P4 field list calculations
@@ -71,6 +71,7 @@
 #include <string>
 #include <iostream>
 #include <limits>
+#include <tuple>
 
 #include <cassert>
 
@@ -124,6 +125,39 @@ class ActionOpcodesMap {
           primitive_name,                                               \
           std::unique_ptr<bm::ActionPrimitive_>(new primitive()));
 
+struct ActionData {
+  const Data &get(int offset) const { return action_data[offset]; }
+
+  void push_back_action_data(const Data &data) {
+    action_data.push_back(data);
+  }
+
+  void push_back_action_data(unsigned int data) {
+    action_data.emplace_back(data);
+  }
+
+  void push_back_action_data(const char *bytes, int nbytes) {
+    action_data.emplace_back(bytes, nbytes);
+  }
+
+  size_t size() const { return action_data.size(); }
+
+  std::vector<Data> action_data{};
+};
+
+struct ActionEngineState {
+  Packet &pkt;
+  PHV &phv;
+  const ActionData &action_data;
+  const std::vector<Data> &const_values;
+
+  ActionEngineState(Packet *pkt,
+                    const ActionData &action_data,
+                    const std::vector<Data> &const_values)
+    : pkt(*pkt), phv(*pkt->get_phv()),
+      action_data(action_data), const_values(const_values) {}
+};
+
 // A simple tagged union, which holds the definition of an action parameter. For
 // example, if an action parameter is a field, this struct will hold the header
 // id and the offset for this field. If an action parameter is a meter array,
@@ -170,115 +204,141 @@ struct ActionParam {
       ArithExpression *ptr;
     } expression;
   };
+
+  // convert to the correct type when calling a primitive
+  template <typename T> T to(ActionEngineState *state) const;
 };
 
-struct ActionData {
-  const Data &get(int offset) const { return action_data[offset]; }
+// template specializations for ActionParam "casting"
+// they have to be declared outside of the class declaration, and "inline" is
+// necessary to avoid linker errors
 
-  void push_back_action_data(const Data &data) {
-    action_data.push_back(data);
-  }
-
-  void push_back_action_data(unsigned int data) {
-    action_data.emplace_back(data);
-  }
-
-  void push_back_action_data(const char *bytes, int nbytes) {
-    action_data.emplace_back(bytes, nbytes);
-  }
-
-  size_t size() const { return action_data.size(); }
-
-  std::vector<Data> action_data{};
-};
-
-struct ActionEngineState {
-  Packet &pkt;
-  PHV &phv;
-  const ActionData &action_data;
-  const std::vector<Data> &const_values;
-
-  ActionEngineState(Packet *pkt,
-                    const ActionData &action_data,
-                    const std::vector<Data> &const_values)
-    : pkt(*pkt), phv(*pkt->get_phv()),
-      action_data(action_data), const_values(const_values) {}
-};
-
-struct ActionParamWithState {
-  const ActionParam &ap;
-  ActionEngineState *state;
-
-  ActionParamWithState(const ActionParam &ap, ActionEngineState *state)
-    : ap(ap), state(state) {}
-
-  /* I cannot think of an alternate solution to this. Is there any danger to
-     overload cast operators like this ? */
-
-  /* If you want to modify it, don't ask for data..., can I improve this? */
-  operator const Data &() {
-    // thread_local sounds like a good choice here
-    // alternative would be to have one vector for each ActionFnEntry
-    static thread_local unsigned int data_temps_size = 4;
-    static thread_local std::vector<Data> data_temps(data_temps_size);
-
-    /* Should probably be able to return a register reference here, but not
-       needed right now */
-    switch (ap.tag) {
-    case ActionParam::CONST:
-      return state->const_values[ap.const_offset];
+// can only be a field or a register reference
+template <> inline
+Data &ActionParam::to<Data &>(ActionEngineState *state) const {
+  /* Should probably be able to return a register reference here, but not
+     needed right now */
+  switch (tag) {
     case ActionParam::FIELD:
-      return state->phv.get_field(ap.field.header, ap.field.field_offset);
+      return state->phv.get_field(field.header, field.field_offset);
+    default:
+      assert(0);
+  }
+}
+
+template <> inline
+const Data &ActionParam::to<const Data &>(ActionEngineState *state) const {
+  // thread_local sounds like a good choice here
+  // alternative would be to have one vector for each ActionFnEntry
+  static thread_local unsigned int data_temps_size = 4;
+  static thread_local std::vector<Data> data_temps(data_temps_size);
+
+  /* Should probably be able to return a register reference here, but not
+     needed right now */
+  switch (tag) {
+    case ActionParam::CONST:
+      return state->const_values[const_offset];
+    case ActionParam::FIELD:
+      return state->phv.get_field(field.header, field.field_offset);
     case ActionParam::ACTION_DATA:
-      return state->action_data.get(ap.action_data_offset);
+      return state->action_data.get(action_data_offset);
     case ActionParam::EXPRESSION:
-      while (data_temps_size <= ap.expression.offset) {
+      while (data_temps_size <= expression.offset) {
         data_temps.emplace_back();
         data_temps_size++;
       }
-      ap.expression.ptr->eval(state->phv, &data_temps[ap.expression.offset],
+      expression.ptr->eval(state->phv, &data_temps[expression.offset],
                               state->action_data.action_data);
-      return data_temps[ap.expression.offset];
+      return data_temps[expression.offset];
     default:
       assert(0);
-    }
   }
+}
 
-  operator Field &() {
-    assert(ap.tag == ActionParam::FIELD);
-    return state->phv.get_field(ap.field.header, ap.field.field_offset);
-  }
+// TODO(antonin): maybe I should use meta-programming for const type handling,
+// but I cannot think of an easy way, so I am leaving it as is for now
 
-  operator Header &() {
-    assert(ap.tag == ActionParam::HEADER);
-    return state->phv.get_header(ap.header);
-  }
+template <> inline
+Field &ActionParam::to<Field &>(ActionEngineState *state) const {
+  assert(tag == ActionParam::FIELD);
+  return state->phv.get_field(field.header, field.field_offset);
+}
 
-  operator HeaderStack &() {
-    assert(ap.tag == ActionParam::HEADER_STACK);
-    return state->phv.get_header_stack(ap.header_stack);
-  }
+template <> inline
+const Field &ActionParam::to<const Field &>(ActionEngineState *state) const {
+  return ActionParam::to<Field &>(state);
+}
 
-  operator const NamedCalculation &() {
-    assert(ap.tag == ActionParam::CALCULATION);
-    return *(ap.calculation);
-  }
+template <> inline
+Header &ActionParam::to<Header &>(ActionEngineState *state) const {
+  assert(tag == ActionParam::HEADER);
+  return state->phv.get_header(header);
+}
 
-  operator MeterArray &() {
-    assert(ap.tag == ActionParam::METER_ARRAY);
-    return *(ap.meter_array);
-  }
+template <> inline
+const Header &ActionParam::to<const Header &>(ActionEngineState *state) const {
+  return ActionParam::to<Header &>(state);
+}
 
-  operator CounterArray &() {
-    assert(ap.tag == ActionParam::COUNTER_ARRAY);
-    return *(ap.counter_array);
-  }
+template <> inline
+HeaderStack &ActionParam::to<HeaderStack &>(ActionEngineState *state) const {
+  assert(tag == ActionParam::HEADER_STACK);
+  return state->phv.get_header_stack(header_stack);
+}
 
-  operator RegisterArray &() {
-    assert(ap.tag == ActionParam::REGISTER_ARRAY);
-    return *(ap.register_array);
-  }
-};
+template <> inline
+const HeaderStack &ActionParam::to<const HeaderStack &>(
+    ActionEngineState *state) const {
+  return ActionParam::to<HeaderStack &>(state);
+}
+
+template <> inline
+const NamedCalculation &ActionParam::to<const NamedCalculation &>(
+    ActionEngineState *state) const {
+  (void) state;
+  assert(tag == ActionParam::CALCULATION);
+  return *(calculation);
+}
+
+template <> inline
+MeterArray &ActionParam::to<MeterArray &>(ActionEngineState *state) const {
+  (void) state;
+  assert(tag == ActionParam::METER_ARRAY);
+  return *(meter_array);
+}
+
+template <> inline
+const MeterArray &ActionParam::to<const MeterArray &>(
+    ActionEngineState *state) const {
+  return ActionParam::to<MeterArray &>(state);
+}
+
+template <> inline
+CounterArray &ActionParam::to<CounterArray &>(ActionEngineState *state) const {
+  (void) state;
+  assert(tag == ActionParam::COUNTER_ARRAY);
+  return *(counter_array);
+}
+
+template <> inline
+const CounterArray &ActionParam::to<const CounterArray &>(
+    ActionEngineState *state) const {
+  return ActionParam::to<CounterArray &>(state);
+}
+
+template <> inline
+RegisterArray &ActionParam::to<RegisterArray &>(
+    ActionEngineState *state) const {
+  (void) state;
+  assert(tag == ActionParam::REGISTER_ARRAY);
+  return *(register_array);
+}
+
+template <> inline
+const RegisterArray &ActionParam::to<const RegisterArray &>(
+    ActionEngineState *state) const {
+  return ActionParam::to<RegisterArray &>(state);
+}
 
 /* This is adapted from stack overflow code:
    http://stackoverflow.com/questions/11044504/any-solution-to-unpack-a-vector-to-function-arguments-in-c
@@ -302,22 +362,24 @@ struct build_indices<0> {
 template <std::size_t N>
 using BuildIndices = typename build_indices<N>::type;
 
-template <size_t num_args>
+template <typename... Args>
 struct unpack_caller {
  private:
   template <typename T, size_t... I>
   void call(T *pObj, ActionEngineState *state,
             const ActionParam *args,
             const indices<I...>) {
-    (*pObj)(ActionParamWithState(args[I], state)...);
+#define ELEM_TYPE typename std::tuple_element<I, std::tuple<Args...>>::type
+    (*pObj)(args[I].to<ELEM_TYPE>(state)...);
+#undef ELEM_TYPE
   }
 
  public:
   template <typename T>
   void operator () (T* pObj, ActionEngineState *state,
                     const ActionParam *args){
-    // assert(args.size() == num_args); // just to be sure
-    call(pObj, state, args, BuildIndices<num_args>{});
+    // assert(args.size() == sizeof...(Args)); // just to be sure
+    call(pObj, state, args, BuildIndices<sizeof...(Args)>{});
   }
 };
 
@@ -374,7 +436,7 @@ class ActionPrimitive :  public ActionPrimitive_ {
   }
 
  private:
-  unpack_caller<sizeof...(Args)> caller;
+  unpack_caller<Args...> caller;
   PHV *phv;
   Packet *pkt;
 };

--- a/modules/bm_sim/include/bm_sim/expressions.h
+++ b/modules/bm_sim/include/bm_sim/expressions.h
@@ -27,11 +27,12 @@
 
 #include "data.h"
 #include "phv_forward.h"
+#include "stateful.h"
 
 namespace bm {
 
 enum class ExprOpcode {
-  LOAD_FIELD, LOAD_HEADER, LOAD_BOOL, LOAD_CONST, LOAD_LOCAL,
+  LOAD_FIELD, LOAD_HEADER, LOAD_BOOL, LOAD_CONST, LOAD_LOCAL, LOAD_REGISTER_REF,
   ADD, SUB, MOD, MUL, SHIFT_LEFT, SHIFT_RIGHT,
   EQ_DATA, NEQ_DATA, GT_DATA, LT_DATA, GET_DATA, LET_DATA,
   AND, OR, NOT,
@@ -70,6 +71,15 @@ struct Op {
     int const_offset;
 
     int local_offset;
+
+    // In theory, if registers cannot be resized, I could directly store a
+    // pointer to the correct register cell, i.e. &(*array)[idx]. However, this
+    // gives me more flexibility in case I want to be able to resize the
+    // registers arbitrarily in the future.
+    struct {
+      RegisterArray *array;
+      unsigned int idx;
+    } register_ref;
   };
 };
 
@@ -82,6 +92,8 @@ class Expression {
   void push_back_load_header(header_id_t header);
   void push_back_load_const(const Data &data);
   void push_back_load_local(const int offset);
+  void push_back_load_register_ref(RegisterArray *register_array,
+                                   unsigned int idx);
   void push_back_op(ExprOpcode opcode);
 
   void build();

--- a/modules/bm_sim/include/bm_sim/expressions.h
+++ b/modules/bm_sim/include/bm_sim/expressions.h
@@ -32,7 +32,8 @@
 namespace bm {
 
 enum class ExprOpcode {
-  LOAD_FIELD, LOAD_HEADER, LOAD_BOOL, LOAD_CONST, LOAD_LOCAL, LOAD_REGISTER_REF,
+  LOAD_FIELD, LOAD_HEADER, LOAD_BOOL, LOAD_CONST, LOAD_LOCAL,
+  LOAD_REGISTER_REF, LOAD_REGISTER_GEN,
   ADD, SUB, MOD, MUL, SHIFT_LEFT, SHIFT_RIGHT,
   EQ_DATA, NEQ_DATA, GT_DATA, LT_DATA, GET_DATA, LET_DATA,
   AND, OR, NOT,
@@ -80,6 +81,8 @@ struct Op {
       RegisterArray *array;
       unsigned int idx;
     } register_ref;
+
+    RegisterArray *register_array;
   };
 };
 
@@ -94,6 +97,7 @@ class Expression {
   void push_back_load_local(const int offset);
   void push_back_load_register_ref(RegisterArray *register_array,
                                    unsigned int idx);
+  void push_back_load_register_gen(RegisterArray *register_array);
   void push_back_op(ExprOpcode opcode);
 
   void build();
@@ -136,6 +140,7 @@ class ArithExpression : public Expression {
     eval_arith(phv, data, locals);
   }
 };
+
 
 class VLHeaderExpression {
  public:

--- a/modules/bm_sim/include/bm_sim/stateful.h
+++ b/modules/bm_sim/include/bm_sim/stateful.h
@@ -38,9 +38,11 @@
 #include <array>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "data.h"
 #include "bignum.h"
+#include "named_p4object.h"
 
 namespace bm {
 

--- a/modules/bm_sim/src/P4Objects.cpp
+++ b/modules/bm_sim/src/P4Objects.cpp
@@ -32,6 +32,17 @@ using std::string;
 
 typedef unsigned char opcode_t;
 
+namespace {
+
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+T hexstr_to_int(const std::string &hexstr) {
+  // TODO(antonin): temporary trick to avoid code duplication
+  return Data(hexstr).get<T>();
+}
+
+}  // namespace
+
 void
 P4Objects::build_expression(const Json::Value &json_expression,
                             Expression *expr) {
@@ -66,10 +77,21 @@ P4Objects::build_expression(const Json::Value &json_expression,
   } else if (type == "local") {  // runtime data for expressions in actions
     expr->push_back_load_local(json_value.asInt());
   } else if (type == "register") {
+    // TODO(antonin): cheap optimization
+    // this may not be worth doing, and probably does not belong here
     const string register_array_name = json_value[0].asString();
-    const unsigned int idx = json_value[1].asUInt();
-    expr->push_back_load_register_ref(
-        get_register_array(register_array_name), idx);
+    auto &json_index = json_value[1];
+    assert(json_index.size() == 2);
+    if (json_index["type"].asString() == "hexstr") {
+      const unsigned int idx = hexstr_to_int<unsigned int>(
+          json_index["value"].asString());
+      expr->push_back_load_register_ref(
+          get_register_array(register_array_name), idx);
+    } else {
+      build_expression(json_index, expr);
+      expr->push_back_load_register_gen(
+          get_register_array(register_array_name));
+    }
   } else {
     assert(0);
   }
@@ -524,7 +546,7 @@ P4Objects::init_objects(std::istream *is, int device_id, size_t cxt_id,
           header_id_t header_stack_id = get_header_stack_id(header_stack_name);
           action_fn->parameter_push_back_header_stack(header_stack_id);
         } else if (type == "expression") {
-          // TODO(Antonin): shold this make the field case (and other) obsolete
+          // TODO(Antonin): should this make the field case (and other) obsolete
           // maybe if we can optimize this case
           ArithExpression *expr = new ArithExpression();
           build_expression(cfg_parameter["value"], expr);
@@ -532,11 +554,25 @@ P4Objects::init_objects(std::istream *is, int device_id, size_t cxt_id,
           action_fn->parameter_push_back_expression(
             std::unique_ptr<ArithExpression>(expr));
         } else if (type == "register") {
+          // TODO(antonin): cheap optimization
+          // this may not be worth doing, and probably does not belong here
           const Json::Value &cfg_register = cfg_parameter["value"];
           const string register_array_name = cfg_register[0].asString();
-          const unsigned int idx = cfg_register[1].asUInt();
-          action_fn->parameter_push_back_register_ref(
-              get_register_array(register_array_name), idx);
+          auto &json_index = cfg_register[1];
+          assert(json_index.size() == 2);
+          if (json_index["type"].asString() == "hexstr") {
+            const unsigned int idx = hexstr_to_int<unsigned int>(
+                json_index["value"].asString());
+            action_fn->parameter_push_back_register_ref(
+                get_register_array(register_array_name), idx);
+          } else {
+            ArithExpression *idx_expr = new ArithExpression();
+            build_expression(json_index, idx_expr);
+            idx_expr->build();
+            action_fn->parameter_push_back_register_gen(
+                get_register_array(register_array_name),
+                std::unique_ptr<ArithExpression>(idx_expr));
+          }
         } else {
           assert(0 && "parameter not supported");
         }

--- a/modules/bm_sim/src/P4Objects.cpp
+++ b/modules/bm_sim/src/P4Objects.cpp
@@ -65,6 +65,11 @@ P4Objects::build_expression(const Json::Value &json_expression,
     expr->push_back_load_const(Data(json_value.asString()));
   } else if (type == "local") {  // runtime data for expressions in actions
     expr->push_back_load_local(json_value.asInt());
+  } else if (type == "register") {
+    const string register_array_name = json_value[0].asString();
+    const unsigned int idx = json_value[1].asUInt();
+    expr->push_back_load_register_ref(
+        get_register_array(register_array_name), idx);
   } else {
     assert(0);
   }
@@ -526,6 +531,12 @@ P4Objects::init_objects(std::istream *is, int device_id, size_t cxt_id,
           expr->build();
           action_fn->parameter_push_back_expression(
             std::unique_ptr<ArithExpression>(expr));
+        } else if (type == "register") {
+          const Json::Value &cfg_register = cfg_parameter["value"];
+          const string register_array_name = cfg_register[0].asString();
+          const unsigned int idx = cfg_register[1].asUInt();
+          action_fn->parameter_push_back_register_ref(
+              get_register_array(register_array_name), idx);
         } else {
           assert(0 && "parameter not supported");
         }

--- a/modules/bm_sim/src/actions.cpp
+++ b/modules/bm_sim/src/actions.cpp
@@ -26,7 +26,9 @@
 
 namespace bm {
 
-size_t ActionFn::nb_data_tmps = 0;
+// the first tmp data register is reserved for internal engine use (register
+// index evaluation)
+size_t ActionFn::nb_data_tmps = 1;
 
 void
 ActionFn::parameter_push_back_field(header_id_t header, int field_offset) {
@@ -80,6 +82,17 @@ ActionFn::parameter_push_back_register_ref(RegisterArray *register_array,
 }
 
 void
+ActionFn::parameter_push_back_register_gen(
+    RegisterArray *register_array, std::unique_ptr<ArithExpression> idx) {
+  ActionParam param;
+  param.tag = ActionParam::REGISTER_GEN;
+  param.register_gen.array = register_array;
+  expressions.push_back(std::move(idx));
+  param.register_gen.idx = expressions.back().get();
+  params.push_back(param);
+}
+
+void
 ActionFn::parameter_push_back_calculation(const NamedCalculation *calculation) {
   ActionParam param;
   param.tag = ActionParam::CALCULATION;
@@ -115,7 +128,7 @@ void
 ActionFn::parameter_push_back_expression(
   std::unique_ptr<ArithExpression> expr
 ) {
-  size_t nb_expression_params = 0;
+  size_t nb_expression_params = 1;
   for (const ActionParam &p : params)
     if (p.tag == ActionParam::EXPRESSION) nb_expression_params += 1;
 

--- a/modules/bm_sim/src/actions.cpp
+++ b/modules/bm_sim/src/actions.cpp
@@ -70,6 +70,16 @@ ActionFn::parameter_push_back_action_data(int action_data_offset) {
 }
 
 void
+ActionFn::parameter_push_back_register_ref(RegisterArray *register_array,
+                                           unsigned int idx) {
+  ActionParam param;
+  param.tag = ActionParam::REGISTER_REF;
+  param.register_ref.array = register_array;
+  param.register_ref.idx = idx;
+  params.push_back(param);
+}
+
+void
 ActionFn::parameter_push_back_calculation(const NamedCalculation *calculation) {
   ActionParam param;
   param.tag = ActionParam::CALCULATION;

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -226,6 +226,29 @@ TEST_F(ActionsTest, SetFromField) {
   ASSERT_EQ((unsigned) 0xaba, dst.get_uint());
 }
 
+TEST_F(ActionsTest, SetFromRegister) {
+  constexpr size_t register_size = 1024;
+  constexpr int register_bw = 16;
+  RegisterArray register_array("register_test", 0, register_size, register_bw);
+  unsigned int value_i(0xaba);
+  const unsigned int register_idx = 68;
+  SetField primitive;
+  testActionFn.push_back_primitive(&primitive);
+  testActionFn.parameter_push_back_field(testHeader1, 3); // f16
+  testActionFn.parameter_push_back_register_ref(&register_array, register_idx);
+
+  Field &dst = phv->get_field(testHeader1, 3); // f16
+  dst.set(0);
+
+  register_array.at(register_idx).set(value_i);
+
+  ASSERT_EQ(0u, dst.get_uint());
+
+  testActionFnEntry(pkt.get());
+
+  ASSERT_EQ(value_i, dst.get_uint());
+}
+
 TEST_F(ActionsTest, SetFromExpression) {
   std::unique_ptr<ArithExpression> expr(new ArithExpression());
   expr->push_back_load_field(testHeader1, 0); // f32
@@ -282,6 +305,22 @@ TEST_F(ActionsTest, Set) {
   ASSERT_EQ(0u, f.get_uint());
   testActionFnEntry(pkt.get());
   ASSERT_EQ(value_i, f.get_uint());
+}
+
+TEST_F(ActionsTest, SetRegister) {
+  constexpr size_t register_size = 1024;
+  constexpr int register_bw = 16;
+  RegisterArray register_array("register_test", 0, register_size, register_bw);
+  unsigned int value_i(0xaba);
+  Data value(value_i);
+  const unsigned int register_idx = 68;
+  Set primitive;
+  testActionFn.push_back_primitive(&primitive);
+  testActionFn.parameter_push_back_register_ref(&register_array, register_idx);
+  testActionFn.parameter_push_back_const(value);
+
+  testActionFnEntry(pkt.get());
+  ASSERT_EQ(value_i, register_array.at(register_idx).get_uint());
 }
 
 TEST_F(ActionsTest, CopyHeader) {

--- a/tests/test_conditionals.cpp
+++ b/tests/test_conditionals.cpp
@@ -341,6 +341,31 @@ TEST_F(ConditionalsTest, RegisterRef) {
   ASSERT_FALSE(c.eval(*phv));
 }
 
+TEST_F(ConditionalsTest, RegisterGen) {
+  Conditional c("ctest", 0);
+  constexpr size_t register_size = 1024;
+  constexpr int register_bw = 16;
+  RegisterArray register_array("register_test", 0, register_size, register_bw);
+  const unsigned int register_idx = 68;
+  const unsigned int value_start = 0x33;
+  const unsigned int value_add = 0xa5;
+  c.push_back_load_const(Data(register_idx));
+  c.push_back_load_register_gen(&register_array);
+  c.push_back_load_const(Data(value_add));
+  c.push_back_op(ExprOpcode::ADD);
+  c.push_back_load_const(Data(value_start + value_add));
+  c.push_back_op(ExprOpcode::EQ_DATA);
+  c.build();
+
+  Data &reg = register_array.at(register_idx);
+
+  reg.set(value_start);
+  ASSERT_TRUE(c.eval(*phv));
+
+  reg.set(value_start + 1);
+  ASSERT_FALSE(c.eval(*phv));
+}
+
 TEST_F(ConditionalsTest, Stress) {
   Conditional c("ctest", 0);
   // (valid(testHeader1) && (false || (testHeader1.f16 + 1 == 2))) && !valid(testHeader2)

--- a/tests/test_conditionals.cpp
+++ b/tests/test_conditionals.cpp
@@ -22,6 +22,9 @@
 
 #include "bm_sim/conditionals.h"
 
+// This is where expressions are tested (essentially the same thing as
+// conditionals)
+
 using namespace bm;
 
 TEST(ExprOpcodesMap, GetOpcode) {
@@ -311,6 +314,30 @@ TEST_F(ConditionalsTest, ValidHeader) {
 
   hdr1.mark_invalid();
 
+  ASSERT_FALSE(c.eval(*phv));
+}
+
+TEST_F(ConditionalsTest, RegisterRef) {
+  Conditional c("ctest", 0);
+  constexpr size_t register_size = 1024;
+  constexpr int register_bw = 16;
+  RegisterArray register_array("register_test", 0, register_size, register_bw);
+  const unsigned int register_idx = 68;
+  const unsigned int value_start = 0x33;
+  const unsigned int value_add = 0xa5;
+  c.push_back_load_register_ref(&register_array, register_idx);
+  c.push_back_load_const(Data(value_add));
+  c.push_back_op(ExprOpcode::ADD);
+  c.push_back_load_const(Data(value_start + value_add));
+  c.push_back_op(ExprOpcode::EQ_DATA);
+  c.build();
+
+  Data &reg = register_array.at(register_idx);
+
+  reg.set(value_start);
+  ASSERT_TRUE(c.eval(*phv));
+
+  reg.set(value_start + 1);
   ASSERT_FALSE(c.eval(*phv));
 }
 


### PR DESCRIPTION
Added support for register references in expressions and as action primitive parameters.
Register references are handled in 2 ways, depending on whether the index is a constant integer or an expression. This is unnecessary and there will be probably be changes in the future, but the "constant integer" case is probably faster than the general case, and I had already written the code anyway...