### PR TITLE
Better logging

### DIFF
--- a/modules/bm_sim/Makefile.am
+++ b/modules/bm_sim/Makefile.am
@@ -13,6 +13,7 @@ noinst_LTLIBRARIES = libbmsim.la
 common_source = \
 src/actions.cpp \
 src/ageing.cpp \
+src/bytecontainer.cpp \
 src/calculations.cpp \
 src/checksums.cpp \
 src/conditionals.cpp \
@@ -45,6 +46,7 @@ src/switch.cpp \
 src/simple_pre.cpp \
 src/simple_pre_lag.cpp \
 src/transport.cpp \
+src/utils.h \
 src/xxhash.c \
 src/xxhash.h
 

--- a/modules/bm_sim/include/bm_sim/actions.h
+++ b/modules/bm_sim/include/bm_sim/actions.h
@@ -525,8 +525,12 @@ class ActionFnEntry {
 
   size_t action_data_size() const { return action_data.size(); }
 
-  const Data &get_action_data(int offset) const {
+  const Data &get_action_data_at(int offset) const {
     return action_data.get(offset);
+  }
+
+  const ActionData &get_action_data() const {
+    return action_data;
   }
 
   void dump(std::ostream *stream) const;
@@ -534,6 +538,10 @@ class ActionFnEntry {
   p4object_id_t get_action_id() const {
     if (!action_fn) return std::numeric_limits<p4object_id_t>::max();
     return action_fn->get_id();
+  }
+
+  const ActionFn *get_action_fn() const {
+    return action_fn;
   }
 
   ActionFnEntry(const ActionFnEntry &other) = default;

--- a/modules/bm_sim/include/bm_sim/bytecontainer.h
+++ b/modules/bm_sim/include/bm_sim/bytecontainer.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <iterator>
 #include <string>
-#include <iostream>
-#include <sstream>
 #include <iomanip>
 
 namespace bm {
@@ -246,21 +244,7 @@ class ByteContainer {
 
   //! Returns the hexadecimal representation of the bytes with a position in the
   //! range [start, start + s) as a string
-  std::string to_hex(size_t start, size_t s, bool upper_case = false) const {
-    assert(start + s <= size());
-
-    std::ostringstream ret;
-
-    for (std::string::size_type i = start; i < start + s; i++) {
-      ret << std::setw(2) << std::setfill('0') << std::hex
-          << (upper_case ? std::uppercase : std::nouppercase)
-          // the int cast was not sufficient 0xab -> 0xffffffab
-          // << static_cast<int>(bytes[i]);
-          << static_cast<int>(static_cast<unsigned char>(bytes[i]));
-    }
-
-    return ret.str();
-  }
+  std::string to_hex(size_t start, size_t s, bool upper_case = false) const;
 
   //! Returns the hexadecimal representation of the byte container as a string
   std::string to_hex(bool upper_case = false) const {

--- a/modules/bm_sim/include/bm_sim/bytecontainer.h
+++ b/modules/bm_sim/include/bm_sim/bytecontainer.h
@@ -155,6 +155,15 @@ class ByteContainer {
     return *this;
   }
 
+  //! Inserts another ByteContainer object into this container, before \p pos
+  // issue with g++-4.8, insert has a non-conforming signature, fixed in g++-4.9
+  // and g++-5.0. However, this signature works for "all" versions
+  // iterator insert(const_iterator pos, const ByteContainer& other) {
+  void insert(iterator pos, const ByteContainer& other) {
+    // return bytes.insert(pos, other.begin(), other.end());
+    bytes.insert(pos, other.begin(), other.end());
+  }
+
   //! Appends a character at the end of the container
   void push_back(char c) {
     bytes.push_back(c);
@@ -235,17 +244,27 @@ class ByteContainer {
       bytes[i] &= mask[i];
   }
 
-  //! Returns the hexadecimal representation of the byte container as a string
-  std::string to_hex(bool upper_case = false) const {
+  //! Returns the hexadecimal representation of the bytes with a position in the
+  //! range [start, start + s) as a string
+  std::string to_hex(size_t start, size_t s, bool upper_case = false) const {
+    assert(start + s <= size());
+
     std::ostringstream ret;
 
-    for (std::string::size_type i = 0; i < size(); i++) {
+    for (std::string::size_type i = start; i < start + s; i++) {
       ret << std::setw(2) << std::setfill('0') << std::hex
           << (upper_case ? std::uppercase : std::nouppercase)
-          << static_cast<int>(bytes[i]);
+          // the int cast was not sufficient 0xab -> 0xffffffab
+          // << static_cast<int>(bytes[i]);
+          << static_cast<int>(static_cast<unsigned char>(bytes[i]));
     }
 
     return ret.str();
+  }
+
+  //! Returns the hexadecimal representation of the byte container as a string
+  std::string to_hex(bool upper_case = false) const {
+    return to_hex(0, size(), upper_case);
   }
 
  private:

--- a/modules/bm_sim/include/bm_sim/match_units.h
+++ b/modules/bm_sim/include/bm_sim/match_units.h
@@ -47,11 +47,13 @@ typedef uint64_t entry_handle_t;
 
 // using string and not ByteContainer for efficiency
 struct MatchKeyParam {
+  // order is important, implementation sorts match fields according to their
+  // match type based on this order
   enum class Type {
+    VALID,
     EXACT,
     LPM,
-    TERNARY,
-    VALID
+    TERNARY
   };
 
   MatchKeyParam(const Type &type, std::string key)
@@ -63,15 +65,31 @@ struct MatchKeyParam {
   MatchKeyParam(const Type &type, std::string key, int prefix_length)
     : type(type), key(std::move(key)), prefix_length(prefix_length) { }
 
+  friend std::ostream& operator<<(std::ostream &out, const MatchKeyParam &p);
+
+  static std::string type_to_string(Type t);
+
   Type type;
   std::string key;
   std::string mask{};  // optional
   int prefix_length{0};  // optional
 };
 
+enum class MatchUnitType {
+  EXACT, LPM, TERNARY
+};
+
+
+namespace detail {
+
+class MatchKeyBuilderHelper;
+
+}  // namespace detail
+
 // Fields should be pushed in the P4 program (i.e. JSON) order. Internally, they
 // will be re-ordered for a more efficient implementation.
-struct MatchKeyBuilder {
+class MatchKeyBuilder {
+  friend class detail::MatchKeyBuilderHelper;
  public:
   void push_back_field(header_id_t header, int field_offset, size_t nbits,
                        MatchKeyParam::Type mtype);
@@ -85,9 +103,22 @@ struct MatchKeyBuilder {
 
   void operator()(const PHV &phv, ByteContainer *key) const;
 
+  std::vector<std::string> key_to_fields(const ByteContainer &key) const;
+
   std::string key_to_string(const ByteContainer &key,
                             std::string separator = "",
                             bool upper_case = false) const;
+
+  void build();
+
+  template <typename E>
+  std::vector<MatchKeyParam> entry_to_match_params(const E &entry) const;
+
+  template <typename E>
+  E match_params_to_entry(const std::vector<MatchKeyParam> &params) const;
+
+  bool match_params_sanity_check(
+      const std::vector<MatchKeyParam> &params) const;
 
   size_t get_nbytes_key() const { return nbytes_key; }
 
@@ -107,11 +138,14 @@ struct MatchKeyBuilder {
   bool has_big_mask{false};
   ByteContainer big_mask{};
   // maps the position of the field in the original P4 key to its actual
-  // position in the implementation-specific key. For example, in "key_input"
-  // (i.e. implementation-specific key), valid matches always come first and LPM
-  // matches come last
-  std::vector<size_t> raw_key_mapping{};
-  std::vector<size_t> raw_key_offsets{};
+  // position in the implementation-specific key. In the implementation, VALID
+  // match keys come first, followed by EXACT, then LPM and TERNARY.
+  std::vector<size_t> key_mapping{};
+  // inverse of key_mapping, could be handy
+  std::vector<size_t> inv_mapping{};
+  std::vector<size_t> key_offsets{};
+  bool built{false};
+  std::vector<ByteContainer> masks{};
 };
 
 namespace MatchUnit {
@@ -175,11 +209,11 @@ struct EntryMeta {
 
 class MatchUnitAbstract_ {
  public:
-  MatchUnitAbstract_(size_t size, const MatchKeyBuilder &match_key_builder)
-    : size(size),
-      nbytes_key(match_key_builder.get_nbytes_key()),
-      match_key_builder(match_key_builder),
-      entry_meta(size) { }
+  MatchUnitAbstract_(size_t size, const MatchKeyBuilder &key_builder)
+    : size(size), nbytes_key(key_builder.get_nbytes_key()),
+      match_key_builder(key_builder), entry_meta(size) {
+    match_key_builder.build();
+  }
 
   size_t get_num_entries() const { return num_entries; }
 
@@ -271,6 +305,24 @@ class MatchUnitAbstract : public MatchUnitAbstract_ {
 
   MatchErrorCode get_value(entry_handle_t handle, const V **value);
 
+  MatchErrorCode get_entry(entry_handle_t handle,
+                           std::vector<MatchKeyParam> *match_key,
+                           const V **value, int *priority = nullptr) const;
+
+  // TODO(antonin): move this one level up in class hierarchy?
+  // will return an empty string if the handle is not valid
+  // otherwise will return a dump of the match entry in a nice format
+  // Dumping entry <handle>
+  // Match key:
+  //   param_1
+  //   param_2 ...
+  // [Priority: ...]
+  // Does not print anything related to the stored value
+  std::string entry_to_string(entry_handle_t handle) const;
+
+  MatchErrorCode dump_match_entry(std::ostream *out,
+                                  entry_handle_t handle) const;
+
   void dump(std::ostream *stream) const {
     return dump_(stream);
   }
@@ -288,6 +340,13 @@ class MatchUnitAbstract : public MatchUnitAbstract_ {
   virtual MatchErrorCode modify_entry_(entry_handle_t handle, V value) = 0;
 
   virtual MatchErrorCode get_value_(entry_handle_t handle, const V **value) = 0;
+
+  virtual MatchErrorCode get_entry_(entry_handle_t handle,
+                                    std::vector<MatchKeyParam> *match_key,
+                                    const V **value, int *priority) const = 0;
+
+  virtual void dump_match_entry_(std::ostream *out,
+                                 entry_handle_t handle) const = 0;
 
   virtual void dump_(std::ostream *stream) const = 0;
 
@@ -309,6 +368,7 @@ class MatchUnitExact : public MatchUnitAbstract<V> {
   }
 
  private:
+  // TODO(antonin): have all Entry structs inherit from a common base?
   struct Entry {
     Entry() { }
 
@@ -318,6 +378,8 @@ class MatchUnitExact : public MatchUnitAbstract<V> {
     ByteContainer key{};
     V value{};
     uint32_t version{0};
+
+    static constexpr MatchUnitType mut = MatchUnitType::EXACT;
   };
 
  private:
@@ -331,6 +393,13 @@ class MatchUnitExact : public MatchUnitAbstract<V> {
   MatchErrorCode modify_entry_(entry_handle_t handle, V value) override;
 
   MatchErrorCode get_value_(entry_handle_t handle, const V **value) override;
+
+  MatchErrorCode get_entry_(entry_handle_t handle,
+                            std::vector<MatchKeyParam> *match_key,
+                            const V **value, int *priority) const override;
+
+  void dump_match_entry_(std::ostream *out,
+                         entry_handle_t handle) const override;
 
   void dump_(std::ostream *stream) const override;
 
@@ -367,6 +436,8 @@ class MatchUnitLPM : public MatchUnitAbstract<V> {
     int prefix_length{0};
     V value{};
     uint32_t version{0};
+
+    static constexpr MatchUnitType mut = MatchUnitType::LPM;
   };
 
  private:
@@ -380,6 +451,13 @@ class MatchUnitLPM : public MatchUnitAbstract<V> {
   MatchErrorCode modify_entry_(entry_handle_t handle, V value) override;
 
   MatchErrorCode get_value_(entry_handle_t handle, const V **value) override;
+
+  MatchErrorCode get_entry_(entry_handle_t handle,
+                            std::vector<MatchKeyParam> *match_key,
+                            const V **value, int *priority) const override;
+
+  void dump_match_entry_(std::ostream *out,
+                         entry_handle_t handle) const override;
 
   void dump_(std::ostream *stream) const override;
 
@@ -416,6 +494,8 @@ class MatchUnitTernary : public MatchUnitAbstract<V> {
     int priority{0};
     V value{};
     uint32_t version{0};
+
+    static constexpr MatchUnitType mut = MatchUnitType::TERNARY;
   };
 
  private:
@@ -429,6 +509,13 @@ class MatchUnitTernary : public MatchUnitAbstract<V> {
   MatchErrorCode modify_entry_(entry_handle_t handle, V value) override;
 
   MatchErrorCode get_value_(entry_handle_t handle, const V **value) override;
+
+  MatchErrorCode get_entry_(entry_handle_t handle,
+                            std::vector<MatchKeyParam> *match_key,
+                            const V **value, int *priority) const override;
+
+  void dump_match_entry_(std::ostream *out,
+                         entry_handle_t handle) const override;
 
   void dump_(std::ostream *stream) const override;
 

--- a/modules/bm_sim/include/bm_sim/options_parse.h
+++ b/modules/bm_sim/include/bm_sim/options_parse.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <map>
 
+#include "logger.h"
+
 namespace bm {
 
 class InterfaceList {
@@ -71,6 +73,8 @@ class OptionsParser {
   std::string event_logger_addr{};
   std::string file_logger{};
   bool console_logging{false};
+  // by default everything is logged
+  Logger::LogLevel log_level{Logger::LogLevel::TRACE};
   std::string notifications_addr{};
   bool debugger{false};
 };

--- a/modules/bm_sim/src/bytecontainer.cpp
+++ b/modules/bm_sim/src/bytecontainer.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <string>
+#include <iostream>
+#include <sstream>
+
+#include "bm_sim/bytecontainer.h"
+
+namespace bm {
+
+std::string
+ByteContainer::to_hex(size_t start, size_t s, bool upper_case) const {
+  assert(start + s <= size());
+
+  std::ostringstream ret;
+
+  for (std::string::size_type i = start; i < start + s; i++) {
+    ret << std::setw(2) << std::setfill('0') << std::hex
+        << (upper_case ? std::uppercase : std::nouppercase)
+        // the int cast was not sufficient 0xab -> 0xffffffab
+        // << static_cast<int>(bytes[i]);
+        << static_cast<int>(static_cast<unsigned char>(bytes[i]));
+  }
+
+  return ret.str();
+}
+
+}  // namespace bm

--- a/modules/bm_sim/src/match_tables.cpp
+++ b/modules/bm_sim/src/match_tables.cpp
@@ -77,6 +77,8 @@ MatchTableAbstract::apply_action(Packet *pkt) {
     BMELOG(table_hit, *pkt, *this, handle);
     BMLOG_DEBUG_PKT(*pkt, "Table '{}': hit with handle {}",
                     get_name(), handle);
+    // TODO(antonin): change to trace?
+    BMLOG_DEBUG_PKT(*pkt, "{}", dump_entry_string(handle));
   } else {
     BMELOG(table_miss, *pkt, *this);
     BMLOG_DEBUG_PKT(*pkt, "Table '{}': miss", get_name());
@@ -634,6 +636,8 @@ MatchTableIndirectWS::lookup(const Packet &pkt, bool *hit,
     grp_hdl_t grp = index.get_grp();
     assert(is_valid_grp(grp));
     mbr = choose_from_group(grp, pkt);
+    // TODO(antonin): change to trace?
+    BMLOG_DEBUG_PKT(pkt, "Choosing member {} from group {}", mbr, grp);
   }
   assert(is_valid_mbr(mbr));
 
@@ -838,7 +842,7 @@ MatchTableIndirectWS::dump_entry(std::ostream *out,
   } else {
     *out << "Group members:\n";
     for (const auto mbr : group_entries[index->get_grp()])
-      *out << "  " << "mbr " << action_entries[mbr] << "\n";
+      *out << "  " << "mbr " << mbr << ": " << action_entries[mbr] << "\n";
   }
   return MatchErrorCode::SUCCESS;
 }

--- a/modules/bm_sim/src/match_tables.cpp
+++ b/modules/bm_sim/src/match_tables.cpp
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <limits>  // std::numeric_limits
 
 #include "bm_sim/match_tables.h"
 #include "bm_sim/logger.h"
@@ -208,6 +209,17 @@ MatchTableAbstract::get_next_node_default(p4object_id_t action_id) const {
   return next_nodes.at(action_id);
 }
 
+std::string
+MatchTableAbstract::dump_entry_string(entry_handle_t handle) const {
+  std::ostringstream ret;
+  if (dump_entry(&ret, handle) != MatchErrorCode::SUCCESS) {
+    Logger::get()->error("dump_entry_string() called on invalid handle, "
+                         "returning empty string");
+    return "";
+  }
+  return ret.str();
+}
+
 const ActionEntry &
 MatchTable::lookup(const Packet &pkt, bool *hit, entry_handle_t *handle) {
   MatchUnitAbstract<ActionEntry>::MatchUnitLookup res = match_unit->lookup(pkt);
@@ -263,12 +275,42 @@ MatchTable::set_default_action(const ActionFn *action_fn,
   return MatchErrorCode::SUCCESS;
 }
 
+MatchErrorCode
+MatchTable::get_entry(entry_handle_t handle,
+                      std::vector<MatchKeyParam> *match_key,
+                      const ActionFn **action_fn, ActionData *action_data,
+                      int *priority) const {
+  const ActionEntry *entry;
+  ReadLock lock = lock_read();
+  MatchErrorCode rc = match_unit->get_entry(handle, match_key, &entry,
+                                            priority);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+
+  *action_fn = entry->action_fn.get_action_fn();
+  *action_data = entry->action_fn.get_action_data();
+
+  return MatchErrorCode::SUCCESS;
+}
+
 void
 MatchTable::dump(std::ostream *stream) const {
   ReadLock lock = lock_read();
   (*stream) << name << ":\n";
   match_unit->dump(stream);
   (*stream) << "default: " << default_entry << "\n";
+}
+
+MatchErrorCode
+MatchTable::dump_entry(std::ostream *out, entry_handle_t handle) const {
+  ReadLock lock = lock_read();
+  MatchErrorCode rc;
+  rc = match_unit->dump_match_entry(out, handle);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+  const ActionEntry *entry;
+  rc = match_unit->get_value(handle, &entry);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+  *out << "Action entry: " << *entry << "\n";
+  return MatchErrorCode::SUCCESS;
 }
 
 void
@@ -431,6 +473,36 @@ MatchTableIndirect::set_default_member(mbr_hdl_t mbr) {
   return MatchErrorCode::SUCCESS;
 }
 
+MatchErrorCode
+MatchTableIndirect::get_entry(entry_handle_t handle,
+                              std::vector<MatchKeyParam> *match_key,
+                              mbr_hdl_t *mbr, int *priority) const {
+  const IndirectIndex *index;
+  ReadLock lock = lock_read();
+  MatchErrorCode rc = match_unit->get_entry(handle, match_key, &index,
+                                            priority);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+
+  assert(index->is_mbr());
+  *mbr = index->get_mbr();
+
+  return MatchErrorCode::SUCCESS;
+}
+
+MatchErrorCode
+MatchTableIndirect::get_member(mbr_hdl_t mbr, const ActionFn **action_fn,
+                               ActionData *action_data) const {
+  ReadLock lock = lock_read();
+
+  if (!is_valid_mbr(mbr)) return MatchErrorCode::INVALID_MBR_HANDLE;
+
+  const ActionEntry &entry = action_entries[mbr];
+  *action_fn = entry.action_fn.get_action_fn();
+  *action_data = entry.action_fn.get_action_data();
+
+  return MatchErrorCode::SUCCESS;
+}
+
 void
 MatchTableIndirect::dump_(std::ostream *stream) const {
   (*stream) << name << ":\n";
@@ -447,6 +519,31 @@ void
 MatchTableIndirect::dump(std::ostream *stream) const {
   ReadLock lock = lock_read();
   dump_(stream);
+}
+
+MatchErrorCode
+MatchTableIndirect::dump_entry_(std::ostream *out,
+                                entry_handle_t handle,
+                                const IndirectIndex **index) const {
+  MatchErrorCode rc;
+  rc = match_unit->dump_match_entry(out, handle);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+  rc = match_unit->get_value(handle, index);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+  const IndirectIndex *index_ptr = *index;
+  *out << "Index: " << *index_ptr << "\n";
+  return MatchErrorCode::SUCCESS;
+}
+
+MatchErrorCode
+MatchTableIndirect::dump_entry(std::ostream *out, entry_handle_t handle) const {
+  ReadLock lock = lock_read();
+  const IndirectIndex *index;
+  MatchErrorCode rc;
+  rc = dump_entry_(out, handle, &index);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+  *out << "Action entry: " << action_entries[index->get_mbr()] << "\n";
+  return MatchErrorCode::SUCCESS;
 }
 
 void
@@ -668,6 +765,42 @@ MatchTableIndirectWS::set_default_group(grp_hdl_t grp) {
 }
 
 MatchErrorCode
+MatchTableIndirectWS::get_entry(entry_handle_t handle,
+                                std::vector<MatchKeyParam> *match_key,
+                                mbr_hdl_t *mbr, grp_hdl_t *grp,
+                                int *priority) const {
+  const IndirectIndex *index;
+  ReadLock lock = lock_read();
+  MatchErrorCode rc = match_unit->get_entry(handle, match_key, &index,
+                                            priority);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+
+  if (index->is_mbr()) {
+    *mbr = index->get_mbr();
+    *grp = std::numeric_limits<grp_hdl_t>::max();
+  } else {
+    *mbr = std::numeric_limits<mbr_hdl_t>::max();
+    *grp = index->get_grp();
+  }
+
+  return MatchErrorCode::SUCCESS;
+}
+
+MatchErrorCode
+MatchTableIndirectWS::get_group(grp_hdl_t grp,
+                                std::vector<mbr_hdl_t> *mbrs) const {
+  mbrs->clear();
+  ReadLock lock = lock_read();
+
+  if (!is_valid_grp(grp)) return MatchErrorCode::INVALID_GRP_HANDLE;
+
+  for (const auto &mbr : group_entries[grp])
+    mbrs->push_back(mbr);
+
+  return MatchErrorCode::SUCCESS;
+}
+
+MatchErrorCode
 MatchTableIndirectWS::get_num_members_in_group(grp_hdl_t grp,
                                                size_t *nb) const {
   ReadLock lock = lock_read();
@@ -690,6 +823,24 @@ MatchTableIndirectWS::dump(std::ostream *stream) const {
     group_entries[grp].dump(stream);
     (*stream) << "\n";
   }
+}
+
+MatchErrorCode
+MatchTableIndirectWS::dump_entry(std::ostream *out,
+                                 entry_handle_t handle) const {
+  ReadLock lock = lock_read();
+  const IndirectIndex *index;
+  MatchErrorCode rc;
+  rc = dump_entry_(out, handle, &index);
+  if (rc != MatchErrorCode::SUCCESS) return rc;
+  if (index->is_mbr()) {
+    *out << "Action entry: " << action_entries[index->get_mbr()] << "\n";
+  } else {
+    *out << "Group members:\n";
+    for (const auto mbr : group_entries[index->get_grp()])
+      *out << "  " << "mbr " << action_entries[mbr] << "\n";
+  }
+  return MatchErrorCode::SUCCESS;
 }
 
 void

--- a/modules/bm_sim/src/match_units.cpp
+++ b/modules/bm_sim/src/match_units.cpp
@@ -456,8 +456,10 @@ MatchUnitLPM<V>::add_entry_(const std::vector<MatchKeyParam> &match_key,
   const MatchKeyParam *lpm_param = nullptr;
 
   for (const MatchKeyParam &param : match_key) {
-    if (param.type == MatchKeyParam::Type::VALID)
+    if (param.type == MatchKeyParam::Type::VALID) {
       new_key.append(param.key);
+      prefix_length += 8;
+    }
   }
 
   for (const MatchKeyParam &param : match_key) {

--- a/modules/bm_sim/src/match_units.cpp
+++ b/modules/bm_sim/src/match_units.cpp
@@ -818,7 +818,8 @@ MatchUnitExact<V>::dump_(std::ostream *stream) const {
   for (internal_handle_t handle_ : this->handles) {
     const Entry &entry = entries[handle_];
     (*stream) << HANDLE_SET(entry.version, handle_) << ": "
-              << entry.key.to_hex() << " => ";
+              << this->match_key_builder.key_to_string(entry.key, " ")
+              << " => ";
     entry.value.dump(stream);
     (*stream) << "\n";
   }
@@ -958,7 +959,8 @@ MatchUnitLPM<V>::dump_(std::ostream *stream) const {
   for (internal_handle_t handle_ : this->handles) {
     const Entry &entry = entries[handle_];
     (*stream) << HANDLE_SET(entry.version, handle_) << ": "
-              << entry.key.to_hex() << "/" << entry.prefix_length << " => ";
+              << this->match_key_builder.key_to_string(entry.key, " ")
+              << " / " << entry.prefix_length << " => ";
     entry.value.dump(stream);
     (*stream) << "\n";
   }
@@ -1139,7 +1141,8 @@ MatchUnitTernary<V>::dump_(std::ostream *stream) const {
   for (internal_handle_t handle_ : this->handles) {
     const Entry &entry = entries[handle_];
     (*stream) << HANDLE_SET(entry.version, handle_) << ": "
-              << entry.key.to_hex() << " &&& " << entry.mask.to_hex() << " => ";
+              << this->match_key_builder.key_to_string(entry.key, " ")
+              << " &&& " << entry.mask.to_hex() << " => ";
     entry.value.dump(stream);
     (*stream) << "\n";
   }

--- a/modules/bm_sim/src/options_parse.cpp
+++ b/modules/bm_sim/src/options_parse.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <unordered_map>
 
 #include <cassert>
 
@@ -103,6 +104,9 @@ OptionsParser::parse(int argc, char *argv[]) {
        "Enable logging on stdout")
       ("log-file", po::value<std::string>(),
        "Enable logging to given file")
+      ("log-level,L", po::value<std::string>(),
+       "Set log level, supported values are "
+       "'trace', 'debug', 'info', 'warn', 'error', off'")
       ("notifications-addr", po::value<std::string>(),
        "Specify the nanomsg address to use for notifications "
        "(e.g. learning, ageing, ...); "
@@ -182,6 +186,23 @@ OptionsParser::parse(int argc, char *argv[]) {
 
   if (vm.count("log-file")) {
     file_logger = vm["log-file"].as<std::string>();
+  }
+
+  if (vm.count("log-level")) {
+    const std::string log_level_str = vm["log-level"].as<std::string>();
+    std::unordered_map<std::string, Logger::LogLevel> levels_map = {
+      {"trace", Logger::LogLevel::TRACE},
+      {"debug", Logger::LogLevel::DEBUG},
+      {"info", Logger::LogLevel::INFO},
+      {"warn", Logger::LogLevel::WARN},
+      {"error", Logger::LogLevel::ERROR},
+      {"off", Logger::LogLevel::OFF} };
+    if (!levels_map.count(log_level_str)) {
+      std::cout << "Invalid value " << log_level_str << " for --log-level\n"
+                << "Run with -h to see possible values\n";
+      exit(1);
+    }
+    log_level = levels_map[log_level_str];
   }
 
   if (vm.count("interface")) {

--- a/modules/bm_sim/src/switch.cpp
+++ b/modules/bm_sim/src/switch.cpp
@@ -122,6 +122,8 @@ SwitchWContexts::init_from_command_line_options(int argc, char *argv[]) {
   if (parser.file_logger != "")
     Logger::set_logger_file(parser.file_logger);
 
+  Logger::set_log_level(parser.log_level);
+
   if (parser.use_files)
     set_dev_mgr_files(parser.wait_time);
   else if (parser.packet_in)

--- a/modules/bm_sim/src/utils.h
+++ b/modules/bm_sim/src/utils.h
@@ -1,0 +1,47 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef BM_SIM_SRC_UTILS_H_
+#define BM_SIM_SRC_UTILS_H_
+
+namespace bm {
+
+namespace utils {
+
+// Saves the internal state of a stream and restores it in the destructor
+struct StreamStateSaver final {
+  explicit StreamStateSaver(std::ios &s)  // NOLINT(runtime/references)
+      : ref(s) {
+    state.copyfmt(s);
+  }
+
+  ~StreamStateSaver() {
+    ref.copyfmt(state);
+  }
+
+  std::ios &ref;
+  std::ios state{nullptr};
+};
+
+}  // namespace utils
+
+}  // namespace bm
+
+#endif  // BM_SIM_SRC_UTILS_H_

--- a/tests/test_ageing.cpp
+++ b/tests/test_ageing.cpp
@@ -76,7 +76,7 @@ protected:
     phv_factory.push_back_header("test1", testHeader1, testHeaderType);
     phv_factory.push_back_header("test2", testHeader2, testHeaderType);
 
-    key_builder.push_back_field(testHeader1, 0, 16);
+    key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::EXACT);
 
     typedef MatchTableAbstract::ActionEntry ActionEntry;
     typedef MatchUnitExact<ActionEntry> MUExact;

--- a/tests/test_tables.cpp
+++ b/tests/test_tables.cpp
@@ -406,7 +406,8 @@ TYPED_TEST(TableSizeTwo, ModifyEntry) {
   const ActionEntry &entry_2 = this->table->lookup(pkt, &hit, &lookup_handle);
   ASSERT_TRUE(hit);
   ASSERT_NE(0, entry_2.action_fn.action_data_size());
-  ASSERT_EQ((unsigned) 0xaba, entry_2.action_fn.get_action_data(0).get_uint());
+  ASSERT_EQ((unsigned) 0xaba,
+            entry_2.action_fn.get_action_data_at(0).get_uint());
 }
 
 TYPED_TEST(TableSizeTwo, Counters) {
@@ -794,7 +795,7 @@ TEST_F(TableIndirect, LookupEntry) {
   f.set("0xaba");
   const ActionEntry &entry = table->lookup(pkt, &hit, &lookup_handle);
   ASSERT_TRUE(hit);
-  ASSERT_EQ(data, entry.action_fn.get_action_data(0).get_uint());
+  ASSERT_EQ(data, entry.action_fn.get_action_data_at(0).get_uint());
 
   f.set("0xabb");
   table->lookup(pkt, &hit, &lookup_handle);
@@ -887,14 +888,14 @@ TEST_F(TableIndirect, ModifyMember) {
 
   const ActionEntry &entry_1 = table->lookup(pkt, &hit, &lookup_handle);
   ASSERT_TRUE(hit);
-  ASSERT_EQ(data_1, entry_1.action_fn.get_action_data(0).get_uint());
+  ASSERT_EQ(data_1, entry_1.action_fn.get_action_data_at(0).get_uint());
 
   rc = modify_member(mbr, data_2);
   ASSERT_EQ(rc, MatchErrorCode::SUCCESS);
 
   const ActionEntry &entry_2 = table->lookup(pkt, &hit, &lookup_handle);
   ASSERT_TRUE(hit);
-  ASSERT_EQ(data_2, entry_2.action_fn.get_action_data(0).get_uint());
+  ASSERT_EQ(data_2, entry_2.action_fn.get_action_data_at(0).get_uint());
 }
 
 TEST_F(TableIndirect, ResetState) {
@@ -1162,7 +1163,7 @@ TEST_F(TableIndirectWS, LookupEntryWS) {
     h2_f48.set(dis(gen));
     const ActionEntry &entry = table->lookup(pkt, &hit, &lookup_handle);
     ASSERT_TRUE(hit);
-    ASSERT_EQ(data_1, entry.action_fn.get_action_data(0).get_uint());
+    ASSERT_EQ(data_1, entry.action_fn.get_action_data_at(0).get_uint());
   }
 
   // add a second member
@@ -1180,7 +1181,7 @@ TEST_F(TableIndirectWS, LookupEntryWS) {
     h2_f48.set(dis(gen));
     const ActionEntry &entry = table->lookup(pkt, &hit, &lookup_handle);
     ASSERT_TRUE(hit);
-    unsigned int data = entry.action_fn.get_action_data(0).get_uint();
+    unsigned int data = entry.action_fn.get_action_data_at(0).get_uint();
     if (data == data_1) hits_1++;
     else if (data == data_2) hits_2++;
     else FAIL();
@@ -1294,9 +1295,9 @@ TableBigMask<MULPM>::add_entry(const std::string &key_1,
 template<>
 void
 TableBigMask<MULPM>::make_key_builder() {
-  key_builder.push_back_field(testHeader2, 1, 48, mask_2,
-                              MatchKeyParam::Type::LPM);
   key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::LPM);
+  key_builder.push_back_field(testHeader2, 1, 48, mask_2,
+                              MatchKeyParam::Type::EXACT);
 }
 
 template<>
@@ -1319,7 +1320,7 @@ void
 TableBigMask<MUTernary>::make_key_builder() {
   key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::TERNARY);
   key_builder.push_back_field(testHeader2, 1, 48, mask_2,
-                              MatchKeyParam::Type::TERNARY);
+                              MatchKeyParam::Type::EXACT);
 }
 
 typedef Types<MUExact,
@@ -1388,7 +1389,7 @@ class MatchKeyBuilderTest : public ::testing::Test {
     phv_source->set_phv_factory(0, &phv_factory);
   }
 
-  Packet get_pkt() {
+  Packet get_pkt() const {
     // dummy packet, won't be parsed
     Packet packet = Packet::make_new(
         128, PacketBuffer(256), phv_source.get());
@@ -1401,24 +1402,42 @@ class MatchKeyBuilderTest : public ::testing::Test {
   // virtual void TearDown() { }
 };
 
-TEST_F(MatchKeyBuilderTest, KeyToString) {
-  key_builder.push_back_field(testHeader1, 0, 16,
-                              MatchKeyParam::Type::EXACT);  // h1.f16
-  key_builder.push_back_field(testHeader2, 2, 17,
-                              MatchKeyParam::Type::LPM);  // h2.f17
-  key_builder.push_back_field(testHeader2, 0, 16,
-                              MatchKeyParam::Type::TERNARY);  // h2.f16
-  key_builder.push_back_valid_header(testHeader3);
+class MatchKeyBuilderTest1 : public MatchKeyBuilderTest {
+ protected:
+  virtual void SetUp() {
+    MatchKeyBuilderTest::SetUp();
 
-  Packet pkt = get_pkt();
+    key_builder.push_back_field(testHeader1, 0, 16,
+                                MatchKeyParam::Type::EXACT);  // h1.f16
+    key_builder.push_back_field(testHeader2, 2, 17,
+                                MatchKeyParam::Type::LPM);  // h2.f17
+    key_builder.push_back_field(testHeader2, 0, 16,
+                                MatchKeyParam::Type::TERNARY);  // h2.f16
+    key_builder.push_back_valid_header(testHeader3);
+
+    key_builder.build();
+  }
+
+  // virtual void TearDown() { }
+
+  Packet gen_pkt() const {
+    Packet pkt = get_pkt();
+    PHV *phv = pkt.get_phv();
+    Field &h1_f16 = phv->get_field(testHeader1, 0);
+    Field &h2_f17 = phv->get_field(testHeader2, 2);
+    Field &h2_f16 = phv->get_field(testHeader2, 0);
+
+    h1_f16.set("0xabcd");
+    h2_f17.set("0x10044");
+    h2_f16.set("0x7001");
+
+    return pkt;
+  }
+};
+
+TEST_F(MatchKeyBuilderTest1, KeyToString) {
+  Packet pkt = gen_pkt();
   PHV *phv = pkt.get_phv();
-  Field &h1_f16 = phv->get_field(testHeader1, 0);
-  Field &h2_f17 = phv->get_field(testHeader2, 2);
-  Field &h2_f16 = phv->get_field(testHeader2, 0);
-
-  h1_f16.set("0xabcd");
-  h2_f17.set("0x10044");
-  h2_f16.set("0x7001");
 
   ByteContainer key;
   key_builder(*phv, &key);
@@ -1427,9 +1446,24 @@ TEST_F(MatchKeyBuilderTest, KeyToString) {
   ASSERT_EQ("abcd 010044 7001 01", s);
 }
 
-// was added after I discovered a bug in LPM match (when a table contains both a
-// LPM match field and a valid match field)
-class AdvancedLPMTest : public ::testing::Test {
+TEST_F(MatchKeyBuilderTest1, KeyToFields) {
+  Packet pkt = gen_pkt();
+  PHV *phv = pkt.get_phv();
+
+  ByteContainer key;
+  key_builder(*phv, &key);
+
+  const auto v = key_builder.key_to_fields(key);
+  std::vector<std::string> expected = {"\xab\xcd",
+                                       // necessary because of null character
+                                       std::string("\x01\x00\x44", 3),
+                                       "\x70\x01", "\x01"};
+  ASSERT_EQ(expected, v);
+}
+
+
+// added after exposing some hidden nasty bugs
+class AdvancedTest : public ::testing::Test {
  protected:
   static constexpr size_t t_size = 128u;
 
@@ -1444,7 +1478,7 @@ class AdvancedLPMTest : public ::testing::Test {
 
   std::unique_ptr<PHVSourceIface> phv_source{nullptr};
 
-  AdvancedLPMTest()
+  AdvancedTest()
       : testHeaderType("test_t", 0), action_fn("actionA", 0),
         phv_source(PHVSourceIface::make_phv_source()) {
     testHeaderType.push_back_field("f16", 16);
@@ -1460,13 +1494,25 @@ class AdvancedLPMTest : public ::testing::Test {
     phv_source->set_phv_factory(0, &phv_factory);
   }
 
+  Packet get_pkt() const {
+    // dummy packet, won't be parsed
+    Packet packet = Packet::make_new(
+        128, PacketBuffer(256), phv_source.get());
+    packet.get_phv()->get_header(testHeader1).mark_valid();
+    packet.get_phv()->get_header(testHeader2).mark_valid();
+    packet.get_phv()->get_header(testHeader3).mark_valid();
+    return packet;
+  }
+
   // virtual void TearDown() { }
 };
 
-class AdvancedLPMTest1 : public AdvancedLPMTest {
+// was added after I discovered a bug in LPM match (when a table contains both a
+// LPM match field and a valid match field)
+class AdvancedLPMTest : public AdvancedTest {
  protected:
-  AdvancedLPMTest1()
-      : AdvancedLPMTest() {
+  AdvancedLPMTest()
+      : AdvancedTest() {
     key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::LPM);
     key_builder.push_back_field(testHeader2, 0, 16, MatchKeyParam::Type::EXACT);
     key_builder.push_back_valid_header(testHeader3);
@@ -1480,7 +1526,7 @@ class AdvancedLPMTest1 : public AdvancedLPMTest {
   }
 
   virtual void SetUp() {
-    AdvancedLPMTest::SetUp();
+    AdvancedTest::SetUp();
   }
 
   MatchErrorCode add_entry(entry_handle_t *handle) {
@@ -1492,16 +1538,6 @@ class AdvancedLPMTest1 : public AdvancedLPMTest {
                            std::string("\xab\xcd", 2));
     match_key.emplace_back(MatchKeyParam::Type::VALID, std::string("\x01", 1));
     return table->add_entry(match_key, &action_fn, ActionData(), handle);
-  }
-
-  Packet get_pkt() const {
-    // dummy packet, won't be parsed
-    Packet packet = Packet::make_new(
-        128, PacketBuffer(256), phv_source.get());
-    packet.get_phv()->get_header(testHeader1).mark_valid();
-    packet.get_phv()->get_header(testHeader2).mark_valid();
-    packet.get_phv()->get_header(testHeader3).mark_valid();
-    return packet;
   }
 
   Packet gen_pkt(const std::string &h1_f16_v,
@@ -1519,7 +1555,7 @@ class AdvancedLPMTest1 : public AdvancedLPMTest {
 };
 
 // TODO(antonin): use value-parametrized test to cover every case?
-TEST_F(AdvancedLPMTest1, Lookup1) {
+TEST_F(AdvancedLPMTest, Lookup1) {
   entry_handle_t handle;
   entry_handle_t lookup_handle;
   bool hit;
@@ -1531,7 +1567,7 @@ TEST_F(AdvancedLPMTest1, Lookup1) {
   ASSERT_TRUE(hit);
 }
 
-TEST_F(AdvancedLPMTest1, Lookup2) {
+TEST_F(AdvancedLPMTest, Lookup2) {
   entry_handle_t handle;
   entry_handle_t lookup_handle;
   bool hit;
@@ -1543,7 +1579,7 @@ TEST_F(AdvancedLPMTest1, Lookup2) {
   ASSERT_TRUE(hit);
 }
 
-TEST_F(AdvancedLPMTest1, Lookup3) {
+TEST_F(AdvancedLPMTest, Lookup3) {
   entry_handle_t handle;
   entry_handle_t lookup_handle;
   bool hit;
@@ -1553,4 +1589,292 @@ TEST_F(AdvancedLPMTest1, Lookup3) {
   Packet pkt = gen_pkt("0x0ad0", "0xabcd");
   table->lookup(pkt, &hit, &lookup_handle);
   ASSERT_FALSE(hit);
+}
+
+
+class AdvancedTernaryTest : public AdvancedTest {
+ protected:
+  AdvancedTernaryTest()
+      : AdvancedTest() {
+    key_builder.push_back_field(testHeader1, 0, 16,
+                                MatchKeyParam::Type::TERNARY);
+    key_builder.push_back_field(testHeader2, 0, 16, MatchKeyParam::Type::EXACT);
+    key_builder.push_back_valid_header(testHeader3);
+
+    std::unique_ptr<MUTernary> match_unit;
+    match_unit = std::unique_ptr<MUTernary>(new MUTernary(t_size, key_builder));
+    table = std::unique_ptr<MatchTable>(
+      new MatchTable("test_table", 0, std::move(match_unit), false)
+    );
+    table->set_next_node(0, nullptr);
+  }
+
+  virtual void SetUp() {
+    AdvancedTest::SetUp();
+  }
+
+  MatchErrorCode add_entry(entry_handle_t *handle) {
+    std::vector<MatchKeyParam> match_key;
+    //10.00/12
+    match_key.emplace_back(MatchKeyParam::Type::TERNARY,
+                           std::string("\x12\x34", 2),
+                           std::string("\x0f\xf0", 2));
+    match_key.emplace_back(MatchKeyParam::Type::EXACT,
+                           std::string("\xab\xcd", 2));
+    match_key.emplace_back(MatchKeyParam::Type::VALID, std::string("\x01", 1));
+    return table->add_entry(match_key, &action_fn, ActionData(), handle);
+  }
+
+  Packet gen_pkt(const std::string &h1_f16_v,
+                 const std::string &h2_f16_v) const {
+    Packet packet = get_pkt();
+    PHV *phv = packet.get_phv();
+    Field &h1_f16 = phv->get_field(testHeader1, 0);
+    Field &h2_f16 = phv->get_field(testHeader2, 0);
+
+    h1_f16.set(h1_f16_v);
+    h2_f16.set(h2_f16_v);
+
+    return packet;
+  }
+};
+
+TEST_F(AdvancedTernaryTest, Lookup1) {
+  entry_handle_t handle;
+  entry_handle_t lookup_handle;
+  bool hit;
+
+  ASSERT_EQ(MatchErrorCode::SUCCESS, add_entry(&handle));
+
+  Packet pkt = gen_pkt("0x5235", "0xabcd");
+  // Packet pkt = gen_pkt("0xabcd", "0x5235");
+  table->lookup(pkt, &hit, &lookup_handle);
+  ASSERT_TRUE(hit);
+}
+
+
+template <typename MUType>
+class TableEntryDebug : public ::testing::Test {
+ protected:
+  static constexpr size_t t_size = 128u;
+
+  MatchKeyBuilder key_builder;
+  std::unique_ptr<MatchTable> table;
+
+  HeaderType testHeaderType;
+  header_id_t testHeader1{0}, testHeader2{1}, testHeader3{2};
+  ActionFn action_fn;
+  unsigned int action_data_v = 0xaba;
+  ActionData action_data;
+  int priority = 12;
+
+  TableEntryDebug()
+      : testHeaderType("test_t", 0), action_fn("actionA", 0) {
+    testHeaderType.push_back_field("f16", 16);
+    testHeaderType.push_back_field("f48", 48);
+    testHeaderType.push_back_field("f17", 17);
+    testHeaderType.push_back_field("f7", 7);
+
+    action_data.push_back_action_data(action_data_v);
+
+    std::unique_ptr<MUType> match_unit;
+
+    set_key_builder();
+
+    // true enables counters
+    match_unit = std::unique_ptr<MUType>(new MUType(t_size, key_builder));
+    table = std::unique_ptr<MatchTable>(
+      new MatchTable("test_table", 0, std::move(match_unit), false)
+    );
+    table->set_next_node(0, nullptr);
+  }
+
+  std::vector<MatchKeyParam> gen_match_key() const;
+
+  std::string gen_entry_string() const;
+
+  MatchErrorCode add_entry(entry_handle_t *handle) {
+    return table->add_entry(gen_match_key(), &action_fn, action_data, handle,
+                            priority);
+  }
+
+ private:
+  void set_key_builder();
+};
+
+template <>
+void TableEntryDebug<MUExact>::set_key_builder() {
+  key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::EXACT);
+  key_builder.push_back_field(testHeader2, 0, 16, MatchKeyParam::Type::EXACT);
+  key_builder.push_back_valid_header(testHeader3);
+}
+
+template <>
+void TableEntryDebug<MULPM>::set_key_builder() {
+  key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::LPM);
+  key_builder.push_back_field(testHeader2, 0, 16, MatchKeyParam::Type::EXACT);
+  key_builder.push_back_valid_header(testHeader3);
+}
+
+template <>
+void TableEntryDebug<MUTernary>::set_key_builder() {
+  key_builder.push_back_field(testHeader1, 0, 16, MatchKeyParam::Type::LPM);
+  key_builder.push_back_field(testHeader2, 0, 16, MatchKeyParam::Type::TERNARY);
+  key_builder.push_back_valid_header(testHeader3);
+}
+
+template <>
+std::vector<MatchKeyParam> TableEntryDebug<MUExact>::gen_match_key() const {
+  std::vector<MatchKeyParam> match_key;
+  match_key.emplace_back(MatchKeyParam::Type::EXACT,
+                         std::string("\x12\x34", 2));
+  match_key.emplace_back(MatchKeyParam::Type::EXACT,
+                         std::string("\xab\xcd", 2));
+  match_key.emplace_back(MatchKeyParam::Type::VALID, std::string("\x01", 1));
+  return match_key;
+}
+
+template <>
+std::vector<MatchKeyParam> TableEntryDebug<MULPM>::gen_match_key() const {
+  std::vector<MatchKeyParam> match_key;
+  match_key.emplace_back(MatchKeyParam::Type::LPM,
+                         std::string("\x12\x34", 2), 12);
+  match_key.emplace_back(MatchKeyParam::Type::EXACT,
+                         std::string("\xab\xcd", 2));
+  match_key.emplace_back(MatchKeyParam::Type::VALID, std::string("\x01", 1));
+  return match_key;
+}
+
+template <>
+std::vector<MatchKeyParam> TableEntryDebug<MUTernary>::gen_match_key() const {
+  std::vector<MatchKeyParam> match_key;
+  match_key.emplace_back(MatchKeyParam::Type::LPM,
+                         std::string("\x12\x34", 2), 12);
+  match_key.emplace_back(MatchKeyParam::Type::TERNARY,
+                         std::string("\xab\xcd", 2),
+                         std::string("\x0f\xf0", 2));
+  match_key.emplace_back(MatchKeyParam::Type::VALID, std::string("\x01", 1));
+  return match_key;
+}
+
+// not very resistant...
+template <>
+std::string TableEntryDebug<MUExact>::gen_entry_string() const {
+  return std::string(
+      "Dumping entry 0\n"
+      "Match key:\n"
+      "  EXACT     1234\n"
+      "  EXACT     abcd\n"
+      "  VALID     10\n"
+      "Action entry: actionA - aba,\n");
+}
+
+template <>
+std::string TableEntryDebug<MULPM>::gen_entry_string() const {
+  return std::string(
+      "Dumping entry 0\n"
+      "Match key:\n"
+      "  LPM       1234/12\n"
+      "  EXACT     abcd\n"
+      "  VALID     10\n"
+      "Action entry: actionA - aba,\n");
+}
+
+template <>
+std::string TableEntryDebug<MUTernary>::gen_entry_string() const {
+  return std::string(
+      "Dumping entry 0\n"
+      "Match key:\n"
+      "  LPM       1230/12\n"
+      "  TERNARY   b0c0 &&& f0f0\n"
+      "  VALID     10\n"
+      "Priority: 12\n"
+      "Action entry: actionA - aba,\n");
+}
+
+typedef Types<MUExact,
+	      MULPM,
+	      MUTernary> TableTypes;
+
+TYPED_TEST_CASE(TableEntryDebug, TableTypes);
+
+namespace {
+
+// I initially overloaded the == operator for MatchKeyParam, but it was
+// polluting the bm namespace
+
+bool cmp_LPM(const std::string &k1, const std::string &k2, int pref) {
+  if (k1.size() != k2.size()) return false;
+  if (k1.compare(0, pref / 8, k2, 0, pref / 8) != 0) return false;
+  if (pref % 8 != 0) {
+    char mask = static_cast<char>(0xff) << (8 - (pref % 8));
+    if ((k1[pref / 8] & mask) != (k2[pref / 8] & mask)) return false;
+  }
+  return true;
+}
+
+bool cmp_ternary(const std::string &k1, const std::string &k2,
+                 const std::string &mask) {
+  if (k1.size() != k2.size()) return false;
+  for (size_t i = 0; i < k1.size(); i++) {
+    if ((k1[i] & mask[i]) != (k2[i] & mask[i])) return false;
+  }
+  return true;
+}
+
+bool cmp_match_params(const MatchKeyParam &p1, const MatchKeyParam &p2) {
+  if (p1.type != p2.type) return false;
+  switch (p1.type) {
+    case MatchKeyParam::Type::EXACT:
+    case MatchKeyParam::Type::VALID:
+      return (p1.key == p2.key);
+    case MatchKeyParam::Type::LPM:
+      return (p1.prefix_length == p2.prefix_length &&
+              cmp_LPM(p1.key, p2.key, p1.prefix_length));
+    case MatchKeyParam::Type::TERNARY:
+      return (p1.mask == p2.mask &&
+              cmp_ternary(p1.key, p2.key, p1.mask));
+  }
+  return true;
+}
+
+bool cmp_match_keys(const std::vector<MatchKeyParam> &k1,
+                    const std::vector<MatchKeyParam> &k2) {
+  if (k1.size() != k2.size()) return false;
+  for (size_t i = 0; i < k1.size(); i++) {
+    if (!cmp_match_params(k1[i], k2[i])) return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+TYPED_TEST(TableEntryDebug, GetEntry) {
+  entry_handle_t handle;
+  ASSERT_EQ(MatchErrorCode::SUCCESS, this->add_entry(&handle));
+
+  std::vector<MatchKeyParam> key_;
+  const ActionFn *action_fn_;
+  ActionData action_data_;
+  int priority_;
+  this->table->get_entry(handle, &key_, &action_fn_, &action_data_, &priority_);
+  ASSERT_TRUE(cmp_match_keys(this->gen_match_key(), key_));
+  ASSERT_EQ(this->action_data.get(0), action_data_.get(0));
+}
+
+TYPED_TEST(TableEntryDebug, DumpEntry) {
+  entry_handle_t handle;
+  entry_handle_t bad_handle = 99;
+  ASSERT_EQ(MatchErrorCode::SUCCESS, this->add_entry(&handle));
+
+  std::stringstream os;
+  this->table->dump_entry(&os, handle);
+  // std::cout << os.str();
+  ASSERT_EQ(this->gen_entry_string(), os.str());
+
+  ASSERT_EQ(this->gen_entry_string(), this->table->dump_entry_string(handle));
+
+  ASSERT_NE(MatchErrorCode::SUCCESS, this->table->dump_entry(&os, bad_handle));
+
+  ASSERT_EQ("", this->table->dump_entry_string(bad_handle));
 }


### PR DESCRIPTION
Many changes, most of them logging related.
Major change is refactoring of match_units / match_tables to have a cleaner mapping between the user provided (p4-oriented) vector of match params and the (implementation-specific) format of the stored match entry. It is important to be able to go back and forth between the two for logging / debugging.