### PR TITLE
added logging for control-driven table operations (e.g. add_entry)

### DIFF
--- a/modules/bm_sim/include/bm_sim/match_tables.h
+++ b/modules/bm_sim/include/bm_sim/match_tables.h
@@ -84,9 +84,6 @@ class MatchTableAbstract : public NamedP4Object {
 
   virtual void dump(std::ostream *stream) const = 0;
 
-  virtual MatchErrorCode dump_entry(std::ostream *out,
-                                    entry_handle_t handle) const = 0;
-
   std::string dump_entry_string(entry_handle_t handle) const;
 
   void reset_state();
@@ -154,6 +151,12 @@ class MatchTableAbstract : public NamedP4Object {
 
  private:
   virtual void reset_state_() = 0;
+
+  virtual MatchErrorCode dump_entry(std::ostream *out,
+                                    entry_handle_t handle) const = 0;
+
+  // the internal (_int) version does not acquire the lock
+  std::string dump_entry_string_int(entry_handle_t handle) const;
 
  private:
   mutable boost::shared_mutex t_mutex{};

--- a/modules/bm_sim/include/bm_sim/match_units.h
+++ b/modules/bm_sim/include/bm_sim/match_units.h
@@ -252,6 +252,10 @@ class MatchUnitAbstract_ {
 
   void sweep_entries(std::vector<entry_handle_t> *entries) const;
 
+  void dump_key_params(std::ostream *out,
+                       const std::vector<MatchKeyParam> &params,
+                       int priority = -1) const;
+
  protected:
   MatchErrorCode get_and_set_handle(internal_handle_t *handle);
   MatchErrorCode unset_handle(internal_handle_t handle);
@@ -363,8 +367,8 @@ class MatchUnitAbstract : public MatchUnitAbstract_ {
                                     std::vector<MatchKeyParam> *match_key,
                                     const V **value, int *priority) const = 0;
 
-  virtual void dump_match_entry_(std::ostream *out,
-                                 entry_handle_t handle) const = 0;
+  virtual MatchErrorCode dump_match_entry_(std::ostream *out,
+                                           entry_handle_t handle) const = 0;
 
   virtual void dump_(std::ostream *stream) const = 0;
 
@@ -420,8 +424,8 @@ class MatchUnitExact : public MatchUnitAbstract<V> {
                             std::vector<MatchKeyParam> *match_key,
                             const V **value, int *priority) const override;
 
-  void dump_match_entry_(std::ostream *out,
-                         entry_handle_t handle) const override;
+  MatchErrorCode dump_match_entry_(std::ostream *out,
+                                   entry_handle_t handle) const override;
 
   void dump_(std::ostream *stream) const override;
 
@@ -478,8 +482,8 @@ class MatchUnitLPM : public MatchUnitAbstract<V> {
                             std::vector<MatchKeyParam> *match_key,
                             const V **value, int *priority) const override;
 
-  void dump_match_entry_(std::ostream *out,
-                         entry_handle_t handle) const override;
+  MatchErrorCode dump_match_entry_(std::ostream *out,
+                                   entry_handle_t handle) const override;
 
   void dump_(std::ostream *stream) const override;
 
@@ -536,8 +540,8 @@ class MatchUnitTernary : public MatchUnitAbstract<V> {
                             std::vector<MatchKeyParam> *match_key,
                             const V **value, int *priority) const override;
 
-  void dump_match_entry_(std::ostream *out,
-                         entry_handle_t handle) const override;
+  MatchErrorCode dump_match_entry_(std::ostream *out,
+                                   entry_handle_t handle) const override;
 
   void dump_(std::ostream *stream) const override;
 


### PR DESCRIPTION
I have a few issues with this PR:
- some "duplicated code" between the MatchTable implementations, but couldn't think of a good way to avoid it (could think of several bad ways though...)
- dumping the entry instead of the method parameters. This gives a nice output but:
  - kind of silly for add_entry to serialize then deserialize
  - because we release the write lock, then re-acquire a read lock, there is a possibility of the entry being removed "in-between", in which case we print an empty string, should I use a boost upgrade lock?
- control flow has been made slightly more complicated in paces with more branches