### PR TITLE
simplified passing compile time options to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,16 @@ information on the Ubuntu 12.04 dependencies.
     2. ./configure
     3. make
 
-To enable logging, you probably want to use the following flags when running
-configure:
+Debug logging is enabled by default. If you want to disable it for performance
+reasons, you can pass `--disable-logging-macros` to the `configure` script.
 
-    ./configure 'CPPFLAGS=-DBMLOG_DEBUG_ON'
+In 'debug mode', you probably want to disable compiler optimization and enable
+symbols in the binary:
 
-In 'debug mode', you probably want to also use the following as well:
+    ./configure 'CXXFLAGS=-O0 -g'
 
-    'CXXFLAGS=-O0 -g'
-
-The new bmv2 debugger can be enabled by adding `-DBMDEBUG_ON` to the `CPPFLAGS`
-or simply by passing `--enable-debugger` to `configure`.
+The new bmv2 debugger can be enabled by passing `--enable-debugger` to
+`configure`.
 
 ## Running the tests
 
@@ -128,10 +127,9 @@ used.
 
 ## Using the debugger
 
-To enable the debugger, make sure that you added `-DBMDEBUG_ON` to the
-`CPPFLAGS` when running `./configure`, or that you passed the
-`--enable-debugger` flag to `configure`. You will also need to use the
-`--debugger` command line flag when starting the switch.
+To enable the debugger, make sure that you passed the `--enable-debugger` flag
+to `configure`. You will also need to use the `--debugger` command line flag
+when starting the switch.
 
 Use [tools/p4dbg.py](tools/p4dbg.py) as follows when the switch is running to
 attach the debugger to the switch:

--- a/configure.ac
+++ b/configure.ac
@@ -7,9 +7,11 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([modules/bm_sim/src/checksums.cpp])
 AC_CONFIG_HEADERS([config.h])
 
+coverage_enabled=no
 AC_ARG_ENABLE([coverage],
     AS_HELP_STRING([--enable-coverage], [Enable code coverage tracking]))
 AS_IF([test "x$enable_coverage" = "xyes"], [
+    coverage_enabled=yes
     AC_DEFINE([COVERAGE], [], ["Link with gcov."])
     COVERAGE_FLAGS="-coverage"
 ])
@@ -24,13 +26,22 @@ AM_CONDITIONAL([COND_TARGETS], [test "$want_targets" = yes])
 
 MY_CPPFLAGS=""
 
+debugger_enabled=no
 AC_ARG_ENABLE([debugger],
     AS_HELP_STRING([--enable-debugger], [Enable bmv2 remote debugger]))
 AS_IF([test "x$enable_debugger" = "xyes"], [
+    debugger_enabled=yes
     MY_CPPFLAGS="$MY_CPPFLAGS -DBMDEBUG_ON"
 ])
 
-AC_SUBST([COVERAGE_FLAGS])
+logging_macros_enabled=no
+AC_ARG_ENABLE([logging_macros],
+    AS_HELP_STRING([--disable-logging-macros],
+                   [Disable compile time debug and trace logging macros]))
+AS_IF([test "x$enable_logging_macros" != "xno"], [
+    logging_macros_enabled=yes
+    MY_CPPFLAGS="$MY_CPPFLAGS -DBMLOG_DEBUG_ON -DBMLOG_TRACE_ON"
+])
 
 # Checks for programs.
 AC_PROG_CXX
@@ -123,4 +134,11 @@ AC_CONFIG_FILES([Makefile
 		targets/simple_switch/Makefile
 		targets/simple_switch/tests/Makefile
 		tests/Makefile])
+
 AC_OUTPUT
+
+AS_ECHO("")
+AS_ECHO("Features recap ......................")
+AS_ECHO("Coverage enabled .............. : $coverage_enabled")
+AS_ECHO("Debugger enabled .............. : $debugger_enabled")
+AS_ECHO("Logging macros enabled ........ : $logging_macros_enabled")


### PR DESCRIPTION
Logging macros are enabled by default, they can be disabled by passing `--disable-logging-macros` to configure.