### PR TITLE
Fixes warning comparing integers of different signs

### DIFF
--- a/modules/bm_sim/include/bm_sim/handle_mgr.h
+++ b/modules/bm_sim/include/bm_sim/handle_mgr.h
@@ -149,7 +149,7 @@ class HandleMgr {
   : handles(other.handles) {}
 
   ~HandleMgr() {
-    Word_t bytes_freed;
+    int bytes_freed;
     J1FA(bytes_freed, handles);
   }
 
@@ -210,7 +210,7 @@ class HandleMgr {
   }
 
   void clear() {
-    Word_t Rc_word;
+    int Rc_word;
     J1FA(Rc_word, handles);
   }
 

--- a/modules/bm_sim/include/bm_sim/ras.h
+++ b/modules/bm_sim/include/bm_sim/ras.h
@@ -134,7 +134,7 @@ class RandAccessUIntSet {
     : members((Pvoid_t) NULL) { }
 
   ~RandAccessUIntSet() {
-    Word_t bytes_freed;
+    int bytes_freed;
     J1FA(bytes_freed, members);
   }
 


### PR DESCRIPTION
Changes the type of a variable storing a return code from
Judy1FreeArray from the unsigned type `Word_t` to `int`.

This variable was unused, but the unsigned type was causing a
warning with my compiler settings