### PR TITLE
added support for field aliases; some refactoring in phv.[h/c]

### DIFF
--- a/modules/bm_sim/src/P4Objects.cpp
+++ b/modules/bm_sim/src/P4Objects.cpp
@@ -199,6 +199,20 @@ P4Objects::init_objects(std::istream *is, int device_id, size_t cxt_id,
     add_header_stack_id(header_stack_name, header_stack_id);
   }
 
+  if (cfg_root.isMember("field_aliases")) {
+    const Json::Value &cfg_field_aliases = cfg_root["field_aliases"];
+
+    for (const auto &cfg_alias : cfg_field_aliases) {
+      const auto from = cfg_alias[0].asString();
+      const auto tgt = cfg_alias[1];
+      const auto header_name = tgt[0].asString();
+      const auto field_name = tgt[1].asString();
+      assert(field_exists(header_name, field_name));
+      const auto to = header_name + "." + field_name;
+      phv_factory.add_field_alias(from, to);
+    }
+  }
+
   // parsers
 
   const Json::Value &cfg_parsers = cfg_root["parsers"];

--- a/modules/bm_sim/src/phv.cpp
+++ b/modules/bm_sim/src/phv.cpp
@@ -90,4 +90,93 @@ PHV::push_back_header_stack(const std::string &header_stack_name,
   header_stacks.push_back(std::move(header_stack));
 }
 
+void
+PHV::add_field_alias(const std::string &from, const std::string &to) {
+  fields_map.emplace(from, get_field(to));
+}
+
+
+void
+PHVFactory::push_back_header(const std::string &header_name,
+                             const header_id_t header_index,
+                             const HeaderType &header_type,
+                             const bool metadata) {
+  HeaderDesc desc = HeaderDesc(header_name, header_index,
+                               header_type, metadata);
+  // cannot use operator[] because it requires default constructibility
+  header_descs.insert(std::make_pair(header_index, desc));
+}
+
+void
+PHVFactory::push_back_header_stack(const std::string &header_stack_name,
+                                   const header_stack_id_t header_stack_index,
+                                   const HeaderType &header_type,
+                                   const std::vector<header_id_t> &headers) {
+  HeaderStackDesc desc = HeaderStackDesc(
+      header_stack_name, header_stack_index, header_type, headers);
+  // cannot use operator[] because it requires default constructibility
+  header_stack_descs.insert(std::make_pair(header_stack_index, desc));
+}
+
+void
+PHVFactory::add_field_alias(const std::string &from, const std::string &to) {
+  field_aliases[from] = to;
+}
+
+void
+PHVFactory::enable_field_arith(header_id_t header_id, int field_offset) {
+  HeaderDesc &desc = header_descs.at(header_id);
+  desc.arith_offsets.insert(field_offset);
+}
+
+void
+PHVFactory::enable_all_field_arith(header_id_t header_id) {
+  HeaderDesc &desc = header_descs.at(header_id);
+  for (int offset = 0; offset < desc.header_type.get_num_fields(); offset++) {
+    desc.arith_offsets.insert(offset);
+  }
+}
+
+void
+PHVFactory::disable_field_arith(header_id_t header_id, int field_offset) {
+  HeaderDesc &desc = header_descs.at(header_id);
+  desc.arith_offsets.erase(field_offset);
+}
+
+void
+PHVFactory::disable_all_field_arith(header_id_t header_id) {
+  HeaderDesc &desc = header_descs.at(header_id);
+  desc.arith_offsets.clear();
+}
+
+void
+PHVFactory::enable_all_arith() {
+  for (auto it : header_descs)
+    enable_all_field_arith(it.first);
+}
+
+std::unique_ptr<PHV>
+PHVFactory::create() const {
+  std::unique_ptr<PHV> phv(new PHV(header_descs.size(),
+                                   header_stack_descs.size()));
+
+  for (const auto &e : header_descs) {
+    const HeaderDesc &desc = e.second;
+    phv->push_back_header(desc.name, desc.index,
+                          desc.header_type, desc.arith_offsets,
+                          desc.metadata);
+  }
+
+  for (const auto &e : header_stack_descs) {
+    const HeaderStackDesc &desc = e.second;
+    phv->push_back_header_stack(desc.name, desc.index,
+                                desc.header_type, desc.headers);
+  }
+
+  for (const auto &e : field_aliases)
+    phv->add_field_alias(e.first, e.second);
+
+  return phv;
+}
+
 }  // namespace bm

--- a/tests/test_phv.cpp
+++ b/tests/test_phv.cpp
@@ -86,3 +86,16 @@ TEST_F(PHVTest, CopyHeaders) {
   ASSERT_EQ(f48, f48_2);
 }
 
+TEST_F(PHVTest, FieldAlias) {
+  phv_factory.add_field_alias("best.alias.ever", "test1.f16");
+  std::unique_ptr<PHV> phv_2 = phv_factory.create();
+
+  const Field &f = phv_2->get_field("test1.f16");
+  const Field &f_alias = phv_2->get_field("best.alias.ever");
+  const Field &f_other = phv_2->get_field("test1.f48");
+
+  ASSERT_NE(&f_other, &f);
+  ASSERT_NE(&f_other, &f_alias);
+
+  ASSERT_EQ(&f, &f_alias);
+}


### PR DESCRIPTION
Field aliases can now be defined in the JSON file. The aliases will point to the same field as the original field name. For example, if the JSON include the following:
```
field_aliases: [
  ["standard_metadata.egress_spec", ["intrinsic_metadata", "egress_spec"]]
]
```
then accessing `"standard_metadata.egress_spec"` from the target will be equivalent (in terms of performance as well) to accessing `"intrinsic_metadata.egress_spec"`.

This feature is useful if the target requires the existence of a field (e.g. simple switch requires `"standard_metadata.egress_spec"`), but the name you gave to the equivalent field is different in your P4 program.

Aliases can be passed to `p4c-bm` using `--field-aliases`.