### PR TITLE
Extern support

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -188,10 +188,20 @@ call, with the following attributes:
   object with the following attributes:
     - `type`: one of `hexstr`, `runtime_data`, `header`, `field`, `calculation`,
     `meter_array`, `counter_array`, `register_array`, `header_stack`,
-    `expression`
+    `expression`, `extern`
     - `value`: the appropriate parameter value. If `type` is `runtime_data`,
     this is an integer representing an index into the `runtime_data` (attribute
-    of action) array. See [here] (#the-type-value-object) for other types.
+    of action) array. If `type` is `extern`, this is the name of the extern
+    instance. See [here] (#the-type-value-object) for other types.
+
+*Important note about extern instance methods*: even though in P4 these are
+invoked using object-oriented style, bmv2 treats them as regular primitives for
+which the first parameter is the extern instance. For example, if the P4 call is
+`extern1.methodA(x, y)`, where `extern1` is an extern instance of type
+`my_extern_type`, the bmv2 compiler needs to translate this into a call to
+primitive `_my_extern_type_methodA`, with the first parameter being `{"type":
+"extern", "value": "extern1"}` and the second parameter being the appropriate
+representation for `x` and `y`.
 
 ### `pipelines`
 
@@ -286,3 +296,16 @@ the following attributes:
 
 Not documented yet, use empty JSON array.
 
+### `extern_instances`
+
+It is a JSON array of all the extern instances in the P4 program. Each array
+item has the following attributes:
+- `name`
+- `id`: a unique integer (unique with respect to other extern instances)
+- `type`: the name of the extern type, the target switch needs to support this
+type
+- `attribute_values`: a JSON array with the initial values for the attributes of
+this extern instance. Each array item has the following attributes:
+- `name`: the name of the attribute
+- `type`: the type of the attribute, only `hexstr` is supported for now
+- `value`: the initial value for the attribute

--- a/modules/bm_sim/Makefile.am
+++ b/modules/bm_sim/Makefile.am
@@ -25,6 +25,7 @@ src/dev_mgr_bmi.cpp \
 src/dev_mgr_packet_in.cpp \
 src/event_logger.cpp \
 src/expressions.cpp \
+src/extern.cpp \
 src/fields.cpp \
 src/headers.cpp \
 src/learning.cpp \
@@ -67,6 +68,7 @@ include/bm_sim/dev_mgr.h \
 include/bm_sim/entries.h \
 include/bm_sim/event_logger.h \
 include/bm_sim/expressions.h \
+include/bm_sim/extern.h \
 include/bm_sim/fields.h \
 include/bm_sim/field_lists.h \
 include/bm_sim/handle_mgr.h \

--- a/modules/bm_sim/include/bm_sim/P4Objects.h
+++ b/modules/bm_sim/include/bm_sim/P4Objects.h
@@ -47,6 +47,7 @@
 #include "stateful.h"
 #include "ageing.h"
 #include "field_lists.h"
+#include "extern.h"
 
 namespace bm {
 
@@ -129,6 +130,10 @@ class P4Objects {
 
   FieldList *get_field_list(const p4object_id_t field_list_id) {
     return field_lists.at(field_list_id).get();
+  }
+
+  ExternType *get_extern_instance(const std::string &name) {
+    return extern_instances.at(name).get();
   }
 
   bool field_exists(const std::string &header_name,
@@ -220,6 +225,11 @@ class P4Objects {
     field_lists[field_list_id] = std::move(field_list);
   }
 
+  void add_extern_instance(const std::string &name,
+                           std::unique_ptr<ExternType> extern_instance) {
+    extern_instances[name] = std::move(extern_instance);
+  }
+
   void build_expression(const Json::Value &json_expression, Expression *expr);
 
   std::set<int> build_arith_offsets(const Json::Value &json_actions,
@@ -282,6 +292,10 @@ class P4Objects {
 
   // field lists
   std::unordered_map<p4object_id_t, std::unique_ptr<FieldList> > field_lists{};
+
+  // extern instances
+  std::unordered_map<std::string, std::unique_ptr<ExternType> >
+    extern_instances{};
 
   std::unordered_map<std::string, header_field_pair> field_aliases{};
 

--- a/modules/bm_sim/include/bm_sim/extern.h
+++ b/modules/bm_sim/include/bm_sim/extern.h
@@ -1,0 +1,133 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+//! @file extern.h
+
+#ifndef BM_SIM_INCLUDE_BM_SIM_EXTERN_H_
+#define BM_SIM_INCLUDE_BM_SIM_EXTERN_H_
+
+#include <unordered_map>
+#include <string>
+#include <memory>
+#include <type_traits>
+#include <mutex>
+
+#include "actions.h"
+#include "named_p4object.h"
+
+namespace bm {
+
+class ExternType;
+
+class ExternFactoryMap {
+ public:
+  typedef std::function<std::unique_ptr<ExternType>()> ExternFactoryFn;
+
+  static ExternFactoryMap *get_instance();
+
+  int register_extern_type(const char *extern_type_name, ExternFactoryFn fn);
+
+  std::unique_ptr<ExternType> get_extern_instance(
+      const std::string &extern_type_name) const;
+
+ private:
+  std::unordered_map<std::string, ExternFactoryFn> factory_map{};
+};
+
+#define BM_REGISTER_EXTERN(extern_name)                                 \
+  static_assert(std::is_default_constructible<extern_name>::value,      \
+                "User-defined extern type " #extern_name                \
+                " needs to be default-constructible");                  \
+  int _extern_##extern_name##_create_ =                                 \
+      ::bm::ExternFactoryMap::get_instance()->register_extern_type(     \
+           #extern_name,                                                \
+           [](){ return std::unique_ptr<ExternType>(new extern_name()); });
+
+#define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...) \
+  template <typename... Args>                                           \
+  struct _##extern_name##_##extern_method_name##_0                      \
+      : public ActionPrimitive<ExternType *, Args...> {                 \
+    void operator ()(ExternType *instance, Args... args) override {     \
+      auto lock = instance->_unique_lock();                             \
+      instance->_set_packet_ptr(&this->get_packet());                   \
+      dynamic_cast<extern_name *>(instance)->extern_method_name(args...); \
+    }                                                                   \
+  };                                                                    \
+  struct _##extern_name##_##extern_method_name                          \
+      : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {}; \
+  REGISTER_PRIMITIVE(_##extern_name##_##extern_method_name)
+
+#define BM_EXTERN_ATTRIBUTES void _register_attributes() override
+
+#define BM_EXTERN_ATTRIBUTE_ADD(attr_name)                      \
+  _add_attribute(#attr_name, static_cast<void *>(&attr_name));
+
+
+// TODO(Antonin): have it inherit from NamedP4Object? It is a bit tricky because
+// extern types need to be default constructible
+class ExternType {
+ public:
+  virtual ~ExternType() { }
+
+  template <typename T>
+  void _set_attribute(const std::string &attr_name, const T &v) {
+    T *attr = static_cast<T *>(attributes.at(attr_name));
+    *attr = v;
+  }
+
+  bool _has_attribute(const std::string &attr_name) const {
+    return attributes.find(attr_name) != attributes.end();
+  }
+
+  void _set_packet_ptr(Packet *pkt_ptr) { pkt = pkt_ptr; }
+
+  // called in P4Objects after constructing the instance
+  void _set_name_and_id(const std::string &name, p4object_id_t id);
+
+  const std::string &get_name() const { return name; }
+  p4object_id_t get_id() const { return id; }
+
+  using UniqueLock = std::unique_lock<std::mutex>;
+  UniqueLock _unique_lock() { return UniqueLock(mutex); }
+
+  virtual void _register_attributes() = 0;
+
+  virtual void init() { }
+
+ protected:
+  void _add_attribute(const std::string &name, void *ptr) {
+    attributes[name] = ptr;
+  }
+
+  Packet &get_packet() { return *pkt; }
+
+ private:
+  // will use static_cast to cast from T * to void * and vice-versa
+  std::unordered_map<std::string, void *> attributes;
+  mutable std::mutex mutex{};
+  Packet *pkt{nullptr};
+  // set by _set_name_and_id
+  std::string name{};
+  p4object_id_t id{};
+};
+
+}  // namespace bm
+
+#endif  // BM_SIM_INCLUDE_BM_SIM_EXTERN_H_

--- a/modules/bm_sim/src/actions.cpp
+++ b/modules/bm_sim/src/actions.cpp
@@ -156,6 +156,14 @@ ActionFn::parameter_push_back_expression(
 }
 
 void
+ActionFn::parameter_push_back_extern_instance(ExternType *extern_instance) {
+  ActionParam param;
+  param.tag = ActionParam::EXTERN_INSTANCE;
+  param.extern_instance = extern_instance;
+  params.push_back(param);
+}
+
+void
 ActionFn::push_back_primitive(ActionPrimitive_ *primitive) {
   primitives.push_back(primitive);
 }

--- a/modules/bm_sim/src/extern.cpp
+++ b/modules/bm_sim/src/extern.cpp
@@ -1,0 +1,57 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "bm_sim/extern.h"
+
+#include <string>
+
+namespace bm {
+
+ExternFactoryMap *
+ExternFactoryMap::get_instance() {
+  static ExternFactoryMap instance;
+  return &instance;
+}
+
+int
+ExternFactoryMap::register_extern_type(const char *extern_type_name,
+                                       ExternFactoryFn fn) {
+  const std::string str_name = std::string(extern_type_name);
+  auto it = factory_map.find(str_name);
+  if (it != factory_map.end()) return 0;
+  factory_map[str_name] = std::move(fn);
+  return 1;
+}
+
+std::unique_ptr<ExternType>
+ExternFactoryMap::get_extern_instance(
+    const std::string &extern_type_name) const {
+  auto it = factory_map.find(extern_type_name);
+  if (it == factory_map.end()) return nullptr;
+  return it->second();
+}
+
+void
+ExternType::_set_name_and_id(const std::string &name, p4object_id_t id) {
+  this->name = name;
+  this->id = id;
+}
+
+}  // namespace bm

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,7 +34,8 @@ test_counters \
 test_pcap \
 test_fields \
 test_devmgr \
-test_packet
+test_packet \
+test_extern
 
 check_PROGRAMS = $(TESTS) test_all
 
@@ -61,6 +62,7 @@ test_fields_SOURCES   	   = $(common_source) test_fields.cpp
 test_pcap_SOURCES          = $(common_source) test_pcap.cpp
 test_devmgr_SOURCES        = $(common_source) test_devmgr.cpp
 test_packet_SOURCES        = $(common_source) test_packet.cpp
+test_extern_SOURCES        = $(common_source) test_extern.cpp
 test_all_SOURCES = $(common_source) \
 test_actions.cpp \
 test_checksums.cpp \
@@ -83,4 +85,5 @@ test_counters.cpp \
 test_pcap.cpp \
 test_fields.cpp \
 test_devmgr.cpp \
-test_packet.cpp
+test_packet.cpp \
+test_extern.cpp

--- a/tests/test_extern.cpp
+++ b/tests/test_extern.cpp
@@ -1,0 +1,197 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <cassert>
+
+#include "bm_sim/extern.h"
+
+using namespace bm;
+
+class ExternCounter : public ExternType {
+ public:
+  static constexpr unsigned int PACKETS = 0;
+  static constexpr unsigned int BYTES = 1;
+
+  BM_EXTERN_ATTRIBUTES {
+    BM_EXTERN_ATTRIBUTE_ADD(init_count);
+    BM_EXTERN_ATTRIBUTE_ADD(type);
+  }
+
+  void reset() {
+    count = init_count_;
+  }
+
+  void init() override {
+    init_count_ = init_count.get<size_t>();
+    type_ = type.get<unsigned int>();
+    reset();
+  }
+
+  void increment() {
+    if (type_ == PACKETS) {
+      count++;
+    } else if (type_ == BYTES) {
+      count += get_packet().get_ingress_length();
+    } else {
+      assert(0);
+    }
+  }
+
+  void increment_by(const Data &d) {
+    count += d.get<size_t>();
+  }
+
+  size_t get() const {
+    return count;
+  }
+
+ private:
+  // declared attributes
+  Data init_count{0};
+  Data type{PACKETS};
+
+  // implementation members
+  unsigned int type_{0};
+  size_t init_count_{0};
+  size_t count{0};
+};
+
+BM_REGISTER_EXTERN(ExternCounter);
+BM_REGISTER_EXTERN_METHOD(ExternCounter, increment);
+BM_REGISTER_EXTERN_METHOD(ExternCounter, increment_by, const Data &);
+BM_REGISTER_EXTERN_METHOD(ExternCounter, reset);
+BM_REGISTER_EXTERN_METHOD(ExternCounter, get);
+
+constexpr unsigned int ExternCounter::PACKETS;
+constexpr unsigned int ExternCounter::BYTES;
+
+// Google Test fixture for extern tests
+class ExternTest : public ::testing::Test {
+ protected:
+  PHVFactory phv_factory;
+  PHV *phv{nullptr};
+
+  HeaderType testHeaderType;
+  header_id_t testHeader1{0}, testHeader2{1};
+
+  ActionFn testActionFn;
+  ActionFnEntry testActionFnEntry;
+
+  std::unique_ptr<PHVSourceIface> phv_source{nullptr};
+
+  // pkt needs to be destroyed BEFORE phv_source, otherwise segfault
+  // not a very clean design...
+  std::unique_ptr<Packet> pkt{nullptr};
+
+  ExternTest()
+      : testHeaderType("test_t", 0),
+        testActionFn("test_action", 0),
+        testActionFnEntry(&testActionFn),
+        phv_source(PHVSourceIface::make_phv_source()) {
+    testHeaderType.push_back_field("f32", 32);
+    testHeaderType.push_back_field("f48", 48);
+    testHeaderType.push_back_field("f8", 8);
+    testHeaderType.push_back_field("f16", 16);
+    testHeaderType.push_back_field("f128", 128);
+
+    phv_factory.push_back_header("test1", testHeader1, testHeaderType);
+    phv_factory.push_back_header("test2", testHeader2, testHeaderType);
+  }
+
+  static ActionPrimitive_ *get_extern_primitive(
+      const std::string &extern_name, const std::string &method_name) {
+    return ActionOpcodesMap::get_instance()->get_primitive(
+        "_" + extern_name + "_" + method_name);
+  }
+
+  virtual void SetUp() {
+    phv_source->set_phv_factory(0, &phv_factory);
+    pkt = std::unique_ptr<Packet>(new Packet(
+        Packet::make_new(phv_source.get())));
+    phv = pkt->get_phv();
+  }
+
+  // virtual void TearDown() { }
+};
+
+TEST_F(ExternTest, ExternCounterExecute) {
+  auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
+      "ExternCounter");
+  extern_instance->_register_attributes();
+  extern_instance->init();
+  auto counter_instance = dynamic_cast<ExternCounter *>(extern_instance.get());
+  ASSERT_NE(nullptr, counter_instance);
+
+  auto primitive = get_extern_primitive("ExternCounter", "increment_by");
+
+  size_t increment_value = 44u;
+  testActionFn.push_back_primitive(primitive);
+  testActionFn.parameter_push_back_extern_instance(extern_instance.get());
+  testActionFn.parameter_push_back_const(Data(increment_value));
+
+  ASSERT_EQ(0u, counter_instance->get());
+  testActionFnEntry(pkt.get());
+  ASSERT_EQ(increment_value, counter_instance->get());
+
+  counter_instance->reset();
+
+  ASSERT_EQ(0u, counter_instance->get());
+  testActionFnEntry(pkt.get());
+  ASSERT_EQ(increment_value, counter_instance->get());
+}
+
+TEST_F(ExternTest, ExternCounterSetAttribute) {
+  size_t init_value = 999u;
+
+  auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
+      "ExternCounter");
+  extern_instance->_register_attributes();
+  ASSERT_TRUE(extern_instance->_has_attribute("init_count"));
+  ASSERT_FALSE(extern_instance->_has_attribute("bad_attribute_name"));
+  extern_instance->_set_attribute<Data>("init_count", Data(init_value));
+  extern_instance->init();
+  auto counter_instance = dynamic_cast<ExternCounter *>(extern_instance.get());
+  ASSERT_NE(nullptr, counter_instance);
+
+  auto primitive = get_extern_primitive("ExternCounter", "increment_by");
+
+  size_t increment_value = 44u;
+  testActionFn.push_back_primitive(primitive);
+  testActionFn.parameter_push_back_extern_instance(extern_instance.get());
+  testActionFn.parameter_push_back_const(Data(increment_value));
+
+  testActionFnEntry(pkt.get());
+  ASSERT_EQ(increment_value + init_value, counter_instance->get());
+}
+
+TEST_F(ExternTest, NameAndId) {
+  auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
+      "ExternCounter");
+  const std::string name = "my_extern_instance";
+  const p4object_id_t id = 22;
+  extern_instance->_set_name_and_id(name, id);
+  extern_instance->_register_attributes();
+  extern_instance->init();
+
+  ASSERT_EQ(name, extern_instance->get_name());
+  ASSERT_EQ(id, extern_instance->get_id());
+}


### PR DESCRIPTION
This is a first prototype. It does not come with standard library extern types, like meters (whether these should actually use an extern or the existing Meter implementation is up-to-debate IMO, and I'd rather stick with the existing implementation for counters / meters / checksums). As of now, extern methods can only be called from actions, not from parse states or directly from control flows.