### PR TITLE
Make dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,12 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+py-compile
 
 # gcov
 *.gcno
 *.gcda
 *.gcov
+
+# doxygen
+doxygen-out

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,3 +5,56 @@ if COND_TARGETS
 endif
 
 SUBDIRS = thrift_src third_party modules tests $(MAYBE_TARGETS)
+
+bm_p4dbg: tools/p4dbg.py
+	cp $< $@
+	chmod +x $@
+
+bm_CLI: tools/runtime_CLI.py
+	cp $< $@
+	chmod +x $@
+
+bm_nanomsg_events: tools/nanomsg_client.py
+	cp $< $@
+	chmod +x $@
+
+EXTRA_DIST = \
+tools/p4dbg.py \
+tools/runtime_CLI.py \
+tools/nanomsg_client.py
+
+dist_bin_SCRIPTS = \
+bm_p4dbg \
+bm_CLI \
+bm_nanomsg_events
+
+CLEANFILES = $(dist_bin_SCRIPTS)
+
+# needs to be installed because it is needed by bm_p4dbg
+python_PYTHON = \
+tools/runtime_CLI.py
+
+# I am leaving all style-related files (cpplint) out of dist on purpose, maybe
+# will add them later if needed
+
+EXTRA_DIST += \
+Doxyfile \
+Doxymain.md \
+LICENSE \
+README.md \
+install_deps.sh
+
+# tools directory
+EXTRA_DIST += \
+tools/run_valgrind.sh \
+tools/veth_setup.sh \
+tools/veth_teardown.sh
+
+# mininet directory
+EXTRA_DIST += \
+mininet/1sw_demo.py \
+mininet/p4_mininet.py
+
+# docs directory
+EXTRA_DIST += \
+docs/JSON_format.md

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,9 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([modules/bm_sim/src/checksums.cpp])
 AC_CONFIG_HEADERS([config.h])
 
+# Pyhton is optional to the package
+AM_PATH_PYTHON([2.7],, [:])
+
 coverage_enabled=no
 AC_ARG_ENABLE([coverage],
     AS_HELP_STRING([--enable-coverage], [Enable code coverage tracking]))

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -1,15 +1,8 @@
 SUBDIRS = bf_lpm_trie BMI bm_sim bm_runtime bm_apps
 
-lib_LTLIBRARIES = libp4.la libp4runtime.la libbmi.la libp4apps.la
+lib_LTLIBRARIES = libbmp4apps.la
 
-libp4_la_SOURCES =
-libp4_la_LIBADD = bf_lpm_trie/libbflpmtrie.la bm_sim/libbmsim.la
-
-libp4runtime_la_SOURCES =
-libp4runtime_la_LIBADD = bm_runtime/libbmruntime.la ../thrift_src/libruntimestubs.la
-
-libbmi_la_SOURCES =
-libbmi_la_LIBADD = BMI/libbmi.la
-
-libp4apps_la_SOURCES =
-libp4apps_la_LIBADD = bm_apps/libbmapps.la
+libbmp4apps_la_SOURCES =
+# Dummy C++ source to cause C++ linking.
+nodist_EXTRA_libbmp4apps_la_SOURCES = dummy.cpp
+libbmp4apps_la_LIBADD = bm_apps/libbmapps.la

--- a/modules/bm_apps/Makefile.am
+++ b/modules/bm_apps/Makefile.am
@@ -8,7 +8,9 @@ AM_CPPFLAGS += \
 AM_CXXFLAGS = $(PICKY_CXXFLAGS)
 AM_CFLAGS = $(PICKY_CFLAGS)
 
-libbmapps_la_LIBADD = -lnanomsg -lthrift $(top_builddir)/thrift_src/libruntimestubs.la
+libbmapps_la_LIBADD = \
+$(top_builddir)/thrift_src/libruntimestubs.la \
+-lnanomsg -lthrift
 libbmapps_la_LDFLAGS = -pthread
 
 noinst_LTLIBRARIES = libbmapps.la

--- a/modules/bm_apps/examples/Makefile.am
+++ b/modules/bm_apps/examples/Makefile.am
@@ -1,4 +1,4 @@
 AM_CPPFLAGS = -I$(top_srcdir)/modules/bm_apps/include
-bin_PROGRAMS = test_packet_pipe
+noinst_PROGRAMS = test_packet_pipe
 test_packet_pipe_SOURCES = test_packet_pipe.cpp
 test_packet_pipe_LDADD = $(top_builddir)/modules/bm_apps/libbmapps.la

--- a/modules/bm_runtime/Makefile.am
+++ b/modules/bm_runtime/Makefile.am
@@ -6,7 +6,10 @@ AM_CFLAGS = $(PICKY_CFLAGS)
 noinst_LTLIBRARIES = libbmruntime.la
 
 common_source = \
-src/server.cpp
+src/server.cpp \
+src/Standard_server.ipp \
+src/SimplePre_server.ipp \
+src/SimplePreLAG_server.ipp
 
 common_include = \
 include/bm_runtime/bm_runtime.h

--- a/modules/bm_sim/Makefile.am
+++ b/modules/bm_sim/Makefile.am
@@ -18,6 +18,7 @@ src/checksums.cpp \
 src/conditionals.cpp \
 src/context.cpp \
 src/counters.cpp \
+src/crc_tables.h \
 src/debugger.cpp \
 src/deparser.cpp \
 src/dev_mgr.cpp \
@@ -26,6 +27,7 @@ src/dev_mgr_packet_in.cpp \
 src/event_logger.cpp \
 src/expressions.cpp \
 src/extern.cpp \
+src/extract.h \
 src/fields.cpp \
 src/headers.cpp \
 src/learning.cpp \
@@ -56,6 +58,7 @@ include/bm_sim/actions.h \
 include/bm_sim/ageing.h \
 include/bm_sim/bignum.h \
 include/bm_sim/bytecontainer.h \
+include/bm_sim/calculations.h \
 include/bm_sim/checksums.h \
 include/bm_sim/conditionals.h \
 include/bm_sim/context.h \
@@ -73,16 +76,21 @@ include/bm_sim/fields.h \
 include/bm_sim/field_lists.h \
 include/bm_sim/handle_mgr.h \
 include/bm_sim/headers.h \
+include/bm_sim/header_stacks.h \
 include/bm_sim/learning.h \
 include/bm_sim/logger.h \
 include/bm_sim/lpm_trie.h \
+include/bm_sim/match_error_codes.h \
+include/bm_sim/match_tables.h \
+include/bm_sim/match_units.h \
 include/bm_sim/meters.h \
 include/bm_sim/named_p4object.h \
 include/bm_sim/nn.h \
 include/bm_sim/options_parse.h \
 include/bm_sim/P4Objects.h \
-include/bm_sim/packet_buffer.h \
 include/bm_sim/packet.h \
+include/bm_sim/packet_buffer.h \
+include/bm_sim/packet_handler.h \
 include/bm_sim/parser.h \
 include/bm_sim/pcap_file.h \
 include/bm_sim/phv.h \
@@ -90,8 +98,10 @@ include/bm_sim/phv_forward.h \
 include/bm_sim/phv_source.h \
 include/bm_sim/pipeline.h \
 include/bm_sim/port_monitor.h \
+include/bm_sim/pre.h \
 include/bm_sim/queue.h \
 include/bm_sim/queueing.h \
+include/bm_sim/ras.h \
 include/bm_sim/runtime_interface.h \
 include/bm_sim/stateful.h \
 include/bm_sim/switch.h \

--- a/targets/l2_switch/Makefile.am
+++ b/targets/l2_switch/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = . learn_client
 AM_CPPFLAGS += \
 -I$(top_srcdir)/modules/bm_sim/include \
 -I$(top_srcdir)/modules/bm_runtime/include
-bin_PROGRAMS = l2_switch
+noinst_PROGRAMS = l2_switch
 l2_switch_SOURCES = l2_switch.cpp primitives.cpp
 l2_switch_LDADD = $(top_builddir)/modules/bm_runtime/libbmruntime.la $(top_builddir)/modules/bm_sim/libbmsim.la $(top_builddir)/modules/bf_lpm_trie/libbflpmtrie.la $(top_builddir)/thrift_src/libruntimestubs.la $(top_builddir)/modules/BMI/libbmi.la $(top_builddir)/third_party/jsoncpp/libjson.la -lboost_system -lboost_thread -lthrift -lboost_program_options
 l2_switch_LDFLAGS = -pthread

--- a/targets/l2_switch/learn_client/Makefile.am
+++ b/targets/l2_switch/learn_client/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = \
 -I$(top_builddir)/thrift_src/gen-cpp \
 -I$(top_srcdir)/modules/bm_apps/include
-bin_PROGRAMS = learn_client
+noinst_PROGRAMS = learn_client
 learn_client_SOURCES = learn_client.cpp
 learn_client_LDADD = $(top_builddir)/modules/bm_apps/libbmapps.la
 learn_client_LDFLAGS = -pthread

--- a/targets/simple_router/Makefile.am
+++ b/targets/simple_router/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS += \
 -I$(top_srcdir)/modules/bm_sim/include \
 -I$(top_srcdir)/modules/bm_runtime/include
-bin_PROGRAMS = simple_router
+noinst_PROGRAMS = simple_router
 simple_router_SOURCES = simple_router.cpp primitives.cpp
 simple_router_LDADD = $(top_builddir)/modules/bm_runtime/libbmruntime.la $(top_builddir)/modules/bm_sim/libbmsim.la $(top_builddir)/modules/bf_lpm_trie/libbflpmtrie.la $(top_builddir)/thrift_src/libruntimestubs.la $(top_builddir)/modules/BMI/libbmi.la $(top_builddir)/third_party/jsoncpp/libjson.la -lboost_system -lboost_thread -lthrift -lboost_program_options
 simple_router_LDFLAGS = -pthread

--- a/targets/simple_switch/CPPLINT.cfg
+++ b/targets/simple_switch/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# in case the src dir is used as the build dir
+exclude_files=gen-cpp

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -93,7 +93,10 @@ gen-cpp/simple_switch_types.h
 
 
 CLEANFILES = $(BUILT_SOURCES) \
-thrift_files.ts
+thrift_files.ts \
+gen-cpp/SimpleSwitch_server.skeleton.cpp
 
+# I used to do a rm on gen-cpp, but it was removing a .deps directory, instead I
+# am adding the skeleton file to CLEANFILES
 clean-local:
-	rm -rf gen-cpp gen-py
+	rm -rf gen-py

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -18,6 +18,17 @@ BUILT_SOURCES = $(simple_switch_thrift_files) $(simple_switch_thrift_py_files)
 sswitchpydir = $(pythondir)/sswitch_runtime
 sswitchpy_PYTHON = $(simple_switch_thrift_py_files)
 
+simple_switch_CLI: sswitch_CLI.py
+	cp $< $@
+	chmod +x $@
+
+EXTRA_DIST = \
+sswitch_CLI.py \
+sswitch_CLI
+
+dist_bin_SCRIPTS = \
+simple_switch_CLI
+
 AM_CPPFLAGS += \
 -I$(top_srcdir)/modules/bm_sim/include \
 -I$(top_srcdir)/modules/bm_runtime/include \
@@ -58,13 +69,21 @@ libsimpleswitch_thrift_la_SOURCES = \
 
 THRIFT_IDL = $(srcdir)/thrift/simple_switch.thrift
 
-EXTRA_DIST = $(THRIFT_IDL)
+EXTRA_DIST += $(THRIFT_IDL)
 
+# We copy the generated Python code to srcdir/ if we have permissions (i.e. not
+# for 'make distcheck'). This is to ensure we can run the CLI easily. Maybe I
+# will think of a better solution later.
 thrift_files.ts: $(THRIFT_IDL)
 	@rm -f thrift_files.tmp
 	@touch thrift_files.tmp
 	$(THRIFT) -o $(builddir) --gen cpp -r $(THRIFT_IDL)
 	$(THRIFT) -o $(builddir) --gen py -r $(THRIFT_IDL)
+	if mkdir $(srcdir)/sswitch_runtime.test 2>/dev/null; then \
+	  rm -rf $(srcdir)/sswitch_runtime/; \
+	  cp -r $(builddir)/gen-py/sswitch_runtime/ $(srcdir)/; \
+	  rm -rf $(srcdir)/sswitch_runtime.test; else :; \
+        fi
 	@mv -f thrift_files.tmp $@
 
 $(BUILT_SOURCES): thrift_files.ts
@@ -94,7 +113,8 @@ gen-cpp/simple_switch_types.h
 
 CLEANFILES = $(BUILT_SOURCES) \
 thrift_files.ts \
-gen-cpp/SimpleSwitch_server.skeleton.cpp
+gen-cpp/SimpleSwitch_server.skeleton.cpp \
+$(dist_bin_SCRIPTS)
 
 # I used to do a rm on gen-cpp, but it was removing a .deps directory, instead I
 # am adding the skeleton file to CLEANFILES

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -1,7 +1,11 @@
 SUBDIRS = . tests
 
-simple_switch_thrift_files = \
+simple_switch_thrift_py_files = \
+gen-py/sswitch_runtime/constants.py \
 gen-py/sswitch_runtime/__init__.py \
+gen-py/sswitch_runtime/SimpleSwitch.py \
+gen-py/sswitch_runtime/ttypes.py
+simple_switch_thrift_files = \
 gen-cpp/simple_switch_constants.cpp \
 gen-cpp/simple_switch_constants.h \
 gen-cpp/SimpleSwitch.cpp \
@@ -9,7 +13,10 @@ gen-cpp/SimpleSwitch.h \
 gen-cpp/simple_switch_types.cpp \
 gen-cpp/simple_switch_types.h
 
-BUILT_SOURCES = $(simple_switch_thrift_files)
+BUILT_SOURCES = $(simple_switch_thrift_files) $(simple_switch_thrift_py_files)
+
+sswitchpydir = $(pythondir)/sswitch_runtime
+sswitchpy_PYTHON = $(simple_switch_thrift_py_files)
 
 AM_CPPFLAGS += \
 -I$(top_srcdir)/modules/bm_sim/include \
@@ -29,7 +36,8 @@ libsimpleswitch_la_LDFLAGS = -pthread
 noinst_LTLIBRARIES = libsimpleswitch.la
 
 libsimpleswitch_la_SOURCES = \
-simple_switch.cpp simple_switch.h primitives.cpp
+simple_switch.cpp simple_switch.h primitives.cpp \
+thrift/src/SimpleSwitch_server.ipp
 
 bin_PROGRAMS = simple_switch
 
@@ -50,11 +58,13 @@ libsimpleswitch_thrift_la_SOURCES = \
 
 THRIFT_IDL = $(srcdir)/thrift/simple_switch.thrift
 
+EXTRA_DIST = $(THRIFT_IDL)
+
 thrift_files.ts: $(THRIFT_IDL)
 	@rm -f thrift_files.tmp
 	@touch thrift_files.tmp
-	$(THRIFT) --gen cpp -r $(THRIFT_IDL)
-	$(THRIFT) --gen py -r $(THRIFT_IDL)
+	$(THRIFT) -o $(builddir) --gen cpp -r $(THRIFT_IDL)
+	$(THRIFT) -o $(builddir) --gen py -r $(THRIFT_IDL)
 	@mv -f thrift_files.tmp $@
 
 $(BUILT_SOURCES): thrift_files.ts
@@ -84,3 +94,6 @@ gen-cpp/simple_switch_types.h
 
 CLEANFILES = $(BUILT_SOURCES) \
 thrift_files.ts
+
+clean-local:
+	rm -rf gen-cpp gen-py

--- a/targets/simple_switch/gen-cpp/CPPLINT.cfg
+++ b/targets/simple_switch/gen-cpp/CPPLINT.cfg
@@ -1,1 +1,0 @@
-exclude_files=.*\.[cpp|h]

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -2,8 +2,6 @@ import runtime_CLI
 
 import sys
 import os
-_THIS_DIR = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(_THIS_DIR, "gen-py"))
 
 from sswitch_runtime import SimpleSwitch
 

--- a/targets/simple_switch/tests/Makefile.am
+++ b/targets/simple_switch/tests/Makefile.am
@@ -3,11 +3,12 @@ AM_CPPFLAGS += \
 -I$(top_srcdir)/modules/bm_sim/include \
 -I$(top_srcdir)/modules/bm_apps/include \
 -I$(srcdir)/.. \
--I$(srcdir)/
+-I$(srcdir)/ \
+-DTESTDATADIR=\"$(srcdir)/testdata\"
 AM_CXXFLAGS = -pthread
-LDADD = $(srcdir)/../libsimpleswitch.la \
-$(top_srcdir)/third_party/gtest/libgtest.la \
-$(top_srcdir)/modules/bm_apps/libbmapps.la \
+LDADD = $(builddir)/../libsimpleswitch.la \
+$(top_builddir)/third_party/gtest/libgtest.la \
+$(top_builddir)/modules/bm_apps/libbmapps.la \
 -lboost_filesystem
 
 # Define unit tests
@@ -30,3 +31,10 @@ test_packet_redirect.cpp \
 test_truncate.cpp \
 test_swap.cpp \
 test_queueing.cpp
+
+EXTRA_DIST = \
+testdata/packet_redirect.json \
+testdata/truncate.json \
+testdata/swap_1.json \
+testdata/swap_2.json \
+testdata/queueing.json

--- a/targets/simple_switch/tests/test_packet_redirect.cpp
+++ b/targets/simple_switch/tests/test_packet_redirect.cpp
@@ -152,7 +152,7 @@ const std::string SimpleSwitch_PacketRedirectP4::packet_in_addr =
 
 SimpleSwitch *SimpleSwitch_PacketRedirectP4::test_switch = nullptr;
 
-const std::string SimpleSwitch_PacketRedirectP4::testdata_dir = "testdata";
+const std::string SimpleSwitch_PacketRedirectP4::testdata_dir = TESTDATADIR;
 const std::string SimpleSwitch_PacketRedirectP4::test_json =
     "packet_redirect.json";
 

--- a/targets/simple_switch/tests/test_queueing.cpp
+++ b/targets/simple_switch/tests/test_queueing.cpp
@@ -139,7 +139,7 @@ const std::string SimpleSwitch_QueueingP4::packet_in_addr =
 
 SimpleSwitch *SimpleSwitch_QueueingP4::test_switch = nullptr;
 
-const std::string SimpleSwitch_QueueingP4::testdata_dir = "testdata";
+const std::string SimpleSwitch_QueueingP4::testdata_dir = TESTDATADIR;
 const std::string SimpleSwitch_QueueingP4::test_json =
     "queueing.json";
 

--- a/targets/simple_switch/tests/test_swap.cpp
+++ b/targets/simple_switch/tests/test_swap.cpp
@@ -137,7 +137,7 @@ const std::string SimpleSwitch_SwapP4::packet_in_addr =
 
 SimpleSwitch *SimpleSwitch_SwapP4::test_switch = nullptr;
 
-const std::string SimpleSwitch_SwapP4::testdata_dir = "testdata";
+const std::string SimpleSwitch_SwapP4::testdata_dir = TESTDATADIR;
 const std::string SimpleSwitch_SwapP4::test_json_1 = "swap_1.json";
 const std::string SimpleSwitch_SwapP4::test_json_2 = "swap_2.json";
 

--- a/targets/simple_switch/tests/test_truncate.cpp
+++ b/targets/simple_switch/tests/test_truncate.cpp
@@ -110,7 +110,7 @@ const std::string SimpleSwitch_TruncateP4::packet_in_addr =
 
 SimpleSwitch *SimpleSwitch_TruncateP4::test_switch = nullptr;
 
-const std::string SimpleSwitch_TruncateP4::testdata_dir = "testdata";
+const std::string SimpleSwitch_TruncateP4::testdata_dir = TESTDATADIR;
 const std::string SimpleSwitch_TruncateP4::test_json =
     "truncate.json";
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,18 +1,19 @@
 AM_CPPFLAGS += \
 -isystem $(top_srcdir)/third_party \
 -I$(top_srcdir)/modules/bm_sim/include \
--I$(top_srcdir)/modules/bm_apps/include
+-I$(top_srcdir)/modules/bm_apps/include \
+-DTESTDATADIR=\"$(srcdir)/testdata\"
 AM_CXXFLAGS = -pthread
 LDADD = \
-$(top_srcdir)/third_party/gtest/libgtest.la \
-$(top_srcdir)/modules/bm_sim/libbmsim.la \
-$(top_srcdir)/modules/bf_lpm_trie/libbflpmtrie.la \
-$(top_srcdir)/modules/bm_apps/libbmapps.la \
-$(top_srcdir)/third_party/jsoncpp/libjson.la \
+$(top_builddir)/third_party/gtest/libgtest.la \
+$(top_builddir)/modules/bm_sim/libbmsim.la \
+$(top_builddir)/modules/bf_lpm_trie/libbflpmtrie.la \
+$(top_builddir)/modules/bm_apps/libbmapps.la \
+$(top_builddir)/third_party/jsoncpp/libjson.la \
 -lboost_system -lboost_thread -lboost_filesystem
 
 # Define unit tests
-common_source = main.cpp
+common_source = main.cpp utils.h
 TESTS = test_actions \
 test_checksums \
 test_conditionals \
@@ -87,3 +88,7 @@ test_fields.cpp \
 test_devmgr.cpp \
 test_packet.cpp \
 test_extern.cpp
+
+EXTRA_DIST = \
+testdata/en0.pcap \
+testdata/lo0.pcap

--- a/tests/test_pcap.cpp
+++ b/tests/test_pcap.cpp
@@ -24,11 +24,15 @@ using namespace bm;
 
 namespace fs = boost::filesystem;
 
+#ifndef TESTDATADIR
+#define TESTDATADIR "testdata"
+#endif
+
 // Google Test fixture for pcap tests
 class PcapTest : public ::testing::Test {
 protected:
   PcapTest()
-    : testDataFolder("testdata"), testfile1("en0.pcap"), testfile2("lo0.pcap"),
+    : testDataFolder(TESTDATADIR), testfile1("en0.pcap"), testfile2("lo0.pcap"),
       tmpfile("tmp.pcap"), received(0), receiver(nullptr) {}
 
   virtual void SetUp()  {}
@@ -49,7 +53,7 @@ protected:
   }
 
   std::string getTmpFile() {
-    fs::path path = fs::path(testDataFolder) / fs::path(tmpfile);
+    fs::path path = fs::path(tmpfile);
     return path.string();
   }
 

--- a/thrift_src/Makefile.am
+++ b/thrift_src/Makefile.am
@@ -1,5 +1,9 @@
+standard_thrift_py_files = \
+gen-py/bm_runtime/standard/constants.py \
+gen-py/bm_runtime/standard/__init__.py \
+gen-py/bm_runtime/standard/Standard.py \
+gen-py/bm_runtime/standard/ttypes.py
 standard_thrift_files = \
-$(srcdir)/../tools/bm_runtime/standard/__init__.py \
 gen-cpp/standard_constants.cpp \
 gen-cpp/standard_constants.h \
 gen-cpp/Standard.cpp \
@@ -7,8 +11,12 @@ gen-cpp/Standard.h \
 gen-cpp/standard_types.cpp \
 gen-cpp/standard_types.h
 
+simple_pre_thrift_py_files = \
+gen-py/bm_runtime/simple_pre/constants.py \
+gen-py/bm_runtime/simple_pre/__init__.py \
+gen-py/bm_runtime/simple_pre/SimplePre.py \
+gen-py/bm_runtime/simple_pre/ttypes.py
 simple_pre_thrift_files = \
-$(srcdir)/../tools/bm_runtime/simple_pre/__init__.py \
 gen-cpp/simple_pre_constants.cpp \
 gen-cpp/simple_pre_constants.h \
 gen-cpp/SimplePre.cpp \
@@ -16,8 +24,12 @@ gen-cpp/SimplePre.h \
 gen-cpp/simple_pre_types.cpp \
 gen-cpp/simple_pre_types.h
 
+simple_pre_lag_thrift_py_files = \
+gen-py/bm_runtime/simple_pre_lag/constants.py \
+gen-py/bm_runtime/simple_pre_lag/__init__.py \
+gen-py/bm_runtime/simple_pre_lag/SimplePreLAG.py \
+gen-py/bm_runtime/simple_pre_lag/ttypes.py
 simple_pre_lag_thrift_files = \
-$(srcdir)/../tools/bm_runtime/simple_pre_lag/__init__.py \
 gen-cpp/simple_pre_lag_constants.cpp \
 gen-cpp/simple_pre_lag_constants.h \
 gen-cpp/SimplePreLAG.cpp \
@@ -27,40 +39,67 @@ gen-cpp/simple_pre_lag_types.h
 
 BUILT_SOURCES = \
 $(standard_thrift_files) \
+$(standard_thrift_py_files) \
 $(simple_pre_thrift_files) \
-$(simple_pre_lag_thrift_files)
+$(simple_pre_thrift_py_files) \
+$(simple_pre_lag_thrift_files) \
+$(simple_pre_lag_thrift_py_files) \
+gen-py/bm_runtime/__init__.py
+
+rootpydir = $(pythondir)/bm_runtime/
+rootpy_PYTHON = gen-py/bm_runtime/__init__.py
+
+standardpydir = $(pythondir)/bm_runtime/standard
+standardpy_PYTHON = $(standard_thrift_py_files)
+
+simple_prepydir = $(pythondir)/bm_runtime/simple_pre
+simple_prepy_PYTHON = $(simple_pre_thrift_py_files)
+
+simple_pre_lagpydir = $(pythondir)/bm_runtime/simple_pre_lag
+simple_pre_lagpy_PYTHON = $(simple_pre_lag_thrift_py_files)
 
 AUTOMAKE_OPTIONS = foreign no-dependencies subdir-objects
 
 lib_LTLIBRARIES = libruntimestubs.la
 libruntimestubs_la_SOURCES = \
-	$(BUILT_SOURCES)
+$(BUILT_SOURCES)
 
 pkginclude_HEADERS = \
-       gen-cpp/standard_constants.h \
-       gen-cpp/Standard.h \
-       gen-cpp/standard_types.h \
-       gen-cpp/simple_pre_constants.h \
-       gen-cpp/SimplePre.h \
-       gen-cpp/simple_pre_types.h \
-       gen-cpp/simple_pre_lag_constants.h \
-       gen-cpp/SimplePreLAG.h \
-       gen-cpp/simple_pre_lag_types.h
+gen-cpp/standard_constants.h \
+gen-cpp/Standard.h \
+gen-cpp/standard_types.h \
+gen-cpp/simple_pre_constants.h \
+gen-cpp/SimplePre.h \
+gen-cpp/simple_pre_types.h \
+gen-cpp/simple_pre_lag_constants.h \
+gen-cpp/SimplePreLAG.h \
+gen-cpp/simple_pre_lag_types.h
 
 # See http://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
 
-thrift_files.ts: standard.thrift simple_pre.thrift simple_pre_lag.thrift
+# We copy the generated Python code to tools/ if we have permissions (i.e. not
+# for 'make distcheck'). This is to ensure we can run the Python scripts in
+# tools easily. Maybe I will think of a better solution later.
+thrift_files.ts: $(srcdir)/standard.thrift $(srcdir)/simple_pre.thrift $(srcdir)/simple_pre_lag.thrift
 	@rm -f thrift_files.tmp
 	@touch thrift_files.tmp
-	$(THRIFT) --gen cpp -r $(srcdir)/standard.thrift
-	$(THRIFT) --gen py -r $(srcdir)/standard.thrift
-	$(THRIFT) --gen cpp -r $(srcdir)/simple_pre.thrift
-	$(THRIFT) --gen py -r $(srcdir)/simple_pre.thrift
-	$(THRIFT) --gen cpp -r $(srcdir)/simple_pre_lag.thrift
-	$(THRIFT) --gen py -r $(srcdir)/simple_pre_lag.thrift
-	rm -rf $(srcdir)/../tools/bm_runtime/
-	cp -r gen-py/bm_runtime/ $(srcdir)/../tools/
+	$(THRIFT) -o $(builddir) --gen cpp -r $(srcdir)/standard.thrift
+	$(THRIFT) -o $(builddir) --gen py -r $(srcdir)/standard.thrift
+	$(THRIFT) -o $(builddir) --gen cpp -r $(srcdir)/simple_pre.thrift
+	$(THRIFT) -o $(builddir) --gen py -r $(srcdir)/simple_pre.thrift
+	$(THRIFT) -o $(builddir) --gen cpp -r $(srcdir)/simple_pre_lag.thrift
+	$(THRIFT) -o $(builddir) --gen py -r $(srcdir)/simple_pre_lag.thrift
+	if mkdir $(top_srcdir)/tools/bm_runtime.test 2>/dev/null; then \
+	  rm -rf $(top_srcdir)/tools/bm_runtime/; \
+	  cp -r $(builddir)/gen-py/bm_runtime/ $(top_srcdir)/tools/; \
+	  rm -rf $(top_srcdir)/tools/bm_runtime.test; else :; \
+        fi
 	@mv -f thrift_files.tmp $@
+
+EXTRA_DIST = \
+$(srcdir)/standard.thrift \
+$(srcdir)/simple_pre.thrift \
+$(srcdir)/simple_pre_lag.thrift
 
 $(BUILT_SOURCES): thrift_files.ts
 ## Recover from the removal of $@


### PR DESCRIPTION
- ensured that `make distcheck` is running successfully
- removed useless libraries
- Python scripts are now installed to `prefix/bin` with the following names:
  - debugger: `bm_p4dbg`
  - CLI: `bm_CLI`
  - nanomsg client: `bm_nanomsg_events`
  - simple switch CLI: `simple_switch_CLI`
