### PR TITLE
Add support for arbitrary data structures in MatchUnits

### DIFF
--- a/modules/bm_sim/Makefile.am
+++ b/modules/bm_sim/Makefile.am
@@ -31,6 +31,7 @@ src/extract.h \
 src/fields.cpp \
 src/headers.cpp \
 src/learning.cpp \
+src/lookup_structures.cpp \
 src/logger.cpp \
 src/match_units.cpp \
 src/match_tables.cpp \
@@ -82,9 +83,11 @@ include/bm_sim/header_stacks.h \
 include/bm_sim/learning.h \
 include/bm_sim/logger.h \
 include/bm_sim/lpm_trie.h \
+include/bm_sim/lookup_structures.h \
 include/bm_sim/match_error_codes.h \
 include/bm_sim/match_tables.h \
 include/bm_sim/match_units.h \
+include/bm_sim/match_key_types.h \
 include/bm_sim/meters.h \
 include/bm_sim/named_p4object.h \
 include/bm_sim/nn.h \

--- a/modules/bm_sim/include/bm_sim/P4Objects.h
+++ b/modules/bm_sim/include/bm_sim/P4Objects.h
@@ -61,7 +61,9 @@ class P4Objects {
   explicit P4Objects(std::ostream &outstream = std::cout)
       : outstream(outstream) { }
 
-  int init_objects(std::istream *is, int device_id = 0, size_t cxt_id = 0,
+  int init_objects(std::istream *is,
+                   LookupStructureFactory * lookup_factory,
+                   int device_id = 0, size_t cxt_id = 0,
                    std::shared_ptr<TransportIface> transport = nullptr,
                    const std::set<header_field_pair> &required_fields =
                      std::set<header_field_pair>(),

--- a/modules/bm_sim/include/bm_sim/context.h
+++ b/modules/bm_sim/include/bm_sim/context.h
@@ -59,6 +59,7 @@
 #include "P4Objects.h"
 #include "match_tables.h"
 #include "runtime_interface.h"
+#include "lookup_structures.h"
 
 namespace bm {
 
@@ -337,6 +338,7 @@ class Context final {
 
   typedef P4Objects::header_field_pair header_field_pair;
   int init_objects(std::istream *is,
+                   LookupStructureFactory * lookup_factory,
                    const std::set<header_field_pair> &required_fields =
                      std::set<header_field_pair>(),
                    const std::set<header_field_pair> &arith_fields =
@@ -344,6 +346,7 @@ class Context final {
 
   ErrorCode load_new_config(
       std::istream *is,
+      LookupStructureFactory * lookup_factory,
       const std::set<header_field_pair> &required_fields =
         std::set<header_field_pair>(),
       const std::set<header_field_pair> &arith_fields =

--- a/modules/bm_sim/include/bm_sim/lookup_structures.h
+++ b/modules/bm_sim/include/bm_sim/lookup_structures.h
@@ -1,0 +1,186 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Gordon Bailey (gb@gordonbailey.net)
+ *
+ */
+
+//! @file lookup_structures.h
+//! This file contains 2 classes: bm::LookupStructure and
+//! bm::LookupStructureFactory. When implementing your target, you may wish
+//! to provide custom implementations of the data structures used to perform
+//! matches. This can be done by inheriting from one or more of
+//! bm::ExactLookupStructure, bm::LPMMatchStructure, and
+//! bm::TernaryMatchStructure. Each of these is a specialization of the
+//! bm::LookupStructure template for the corresponding match key type.
+//!
+//! Once the implementation of the new lookup structure is complete, you must
+//! extend the bm::LookupStructureFactory class to build instances of it. This
+//! is relatively simple. An (abridged) example of creating a new bm::Switch
+//! using a custom lookup structure is as follows
+//!
+//! @code
+//!
+//! // Extend the appropriate LookupStructure type
+//! class MyExactLookupStructure : public bm::ExactLookupStructure {
+//!  public:
+//!   virtual ~MyExactLookupStructure() = default;
+//!
+//!  bool lookup(const bm::ByteContainer &key_data,
+//!              bm::internal_handle_t *handle) const override {
+//!    // ...
+//!  }
+//!
+//!  bool entry_exists(const bm::ExactMatchKey &key) const override {
+//!    // ...
+//!  }
+//!
+//!  void add_entry(const bm::ExactMatchKey &key,
+//!                 bm::internal_handle_t handle) override {
+//!    // ...
+//!  }
+//!
+//!  void delete_entry(const bm::ExactMatchKey &key) override {
+//!    // ...
+//!  }
+//!
+//!  void clear() override {
+//!    // ...
+//!  }
+//!
+//!  private:
+//!   // implementation details ...
+//! };
+//!
+//! // Create a factory subclass which creates your new structure
+//! class MyFactory : public bm::LookupStructureFactory {
+//!  public:
+//!   virtual ~MyFactory() = default;
+//!
+//!   // Note that it's only necessary to override the create function for the
+//!   // particular match types you are interested in, the others will use the
+//!   // default implementations.
+//!   std::unique_ptr<bm::ExactLookupStructure>
+//!   create_for_exact(size_t size, size_t nbytes_key) override {
+//!     return std::unique_ptr<bm::ExactLookupStructure>(
+//!                new MyExactLookupStructure(/* parameters */));
+//!   }
+//! };
+//!
+//! // Override bm::Switch to create your target
+//! class MySwitch : public bm::Switch {
+//!    // ...
+//! };
+//!
+//! int main(int argc, const char *argv[]) {
+//!   // Create an instance of your switch object
+//!   auto switch = new MySwitch();
+//!
+//!   // Pass it an instance of your factory class.
+//!   switch->set_lookup_factory(std::shared_ptr<bm::LookupStructureFactory>(
+//!                                  new MyFactory()));
+//!
+//!   // Initialize the switch. Note that this must be done *after* calling
+//!   // `set_lookup_factory`, otherwise the default lookup structures will
+//!   // be used.
+//!   int status = switch->init_from_command_line(argc, argv);
+//!   // ...
+//! }
+//!
+//! @endcode
+
+#ifndef BM_SIM_INCLUDE_BM_SIM_LOOKUP_STRUCTURES_H_
+#define BM_SIM_INCLUDE_BM_SIM_LOOKUP_STRUCTURES_H_
+
+#include "match_key_types.h"
+#include "bytecontainer.h"
+
+namespace bm {
+
+//! This class defines an interface for all data structures used
+//! in Match Units to perform lookups. Custom data strucures can
+//! be created by implementing this interface, and creating a
+//! LookupStructureFactory subclass which will create them.
+template <typename K>
+class LookupStructure {
+ public:
+  virtual ~LookupStructure() = default;
+
+  //! Look up a given key in the data structure.
+  //! Return true and set handle to the found value if there is a match
+  //! Return false if there is no match (value in handle is undefined)
+  virtual bool lookup(const ByteContainer &key_data,
+                      internal_handle_t *handle) const = 0;
+
+  //! Check whether an entry exists. This is distinct from a lookup operation
+  //! in that this will also match against the prefix length in the case of
+  //! an LPM structure, and against the mask and priority in the case of a
+  //! Ternary structure.
+  virtual bool entry_exists(const K &key) const = 0;
+
+  //! Store an entry in the lookup structure. Associates the given handle
+  //! with the given entry.
+  virtual void add_entry(const K &key, internal_handle_t handle) = 0;
+
+  //! Remove a given entry from the structure. Has no effect if the entry
+  //! does not exist.
+  virtual void delete_entry(const K &key) = 0;
+
+  //! Completely remove all entries from the data structure.
+  virtual void clear() = 0;
+};
+
+// Convenience typedefs to simplify the code needed to override LookupStructure
+// and LookupStructureFactory
+typedef LookupStructure<ExactMatchKey>   ExactLookupStructure;
+typedef LookupStructure<LPMMatchKey>     LPMLookupStructure;
+typedef LookupStructure<TernaryMatchKey> TernaryLookupStructure;
+
+//! This class is used by match units to create instances of the appropriate
+//! LookupStructure implementation. In order to use custom data structures in
+//! a target, the data structures should be defined, and then a new subclass
+//! of LookupStructureFactory should be created, overriding the
+//! `create_for_<match type>` function or functions corresponding to the new
+//! data structure.
+class LookupStructureFactory {
+ public:
+  virtual ~LookupStructureFactory() = default;
+
+  //! This is a utility to call the correct `create_for_<type>` function based
+  //! on the bm::MatchKey subtype passed as the template parameter K. This is
+  //! used by bm::MatchUnitGeneric when creating its lookup structure.
+  template <typename K>
+  static std::unique_ptr<LookupStructure<K> > create(
+      LookupStructureFactory *f, size_t size, size_t nbytes_key);
+
+  //! Create a lookup structure for exact matches.
+  virtual std::unique_ptr<ExactLookupStructure>
+  create_for_exact(size_t size, size_t nbytes_key);
+
+  //! Create a lookup structure for LPM matches.
+  virtual std::unique_ptr<LPMLookupStructure>
+  create_for_LPM(size_t size, size_t nbytes_key);
+
+  //! Create a lookup structure for ternary matches.
+  virtual std::unique_ptr<TernaryLookupStructure>
+  create_for_ternary(size_t size, size_t nbytes_key);
+};
+
+
+}  // namespace bm
+
+
+#endif  // BM_SIM_INCLUDE_BM_SIM_LOOKUP_STRUCTURES_H_

--- a/modules/bm_sim/include/bm_sim/match_key_types.h
+++ b/modules/bm_sim/include/bm_sim/match_key_types.h
@@ -1,0 +1,81 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Gordon Bailey (gb@gordonbailey.net)
+ *
+ */
+
+#ifndef BM_SIM_INCLUDE_BM_SIM_MATCH_KEY_TYPES_H_
+#define BM_SIM_INCLUDE_BM_SIM_MATCH_KEY_TYPES_H_
+
+#include <limits>
+
+#include "bytecontainer.h"
+
+namespace bm {
+
+typedef uintptr_t internal_handle_t;
+typedef uint64_t entry_handle_t;
+
+enum class MatchUnitType {
+  EXACT, LPM, TERNARY
+};
+
+// Entry types.
+struct MatchKey {
+  MatchKey() {}
+  MatchKey(ByteContainer data, uint32_t version)
+    : data(std::move(data)), version(version) {}
+
+  ByteContainer data{};
+  uint32_t version{0};
+};
+
+struct ExactMatchKey : public MatchKey {
+  using MatchKey::MatchKey;
+
+  static constexpr MatchUnitType mut = MatchUnitType::EXACT;
+};
+
+struct LPMMatchKey : public MatchKey {
+  LPMMatchKey() {}
+  LPMMatchKey(ByteContainer data, int prefix_length, uint32_t version)
+    : MatchKey(data, version), prefix_length(prefix_length) {}
+
+  int prefix_length{0};
+
+  static constexpr MatchUnitType mut = MatchUnitType::LPM;
+};
+
+struct TernaryMatchKey : public MatchKey {
+  TernaryMatchKey() {}
+  TernaryMatchKey(ByteContainer data, ByteContainer mask, int priority,
+      uint32_t version)
+    : MatchKey(data, version), mask(std::move(mask)),
+    priority(priority) {}
+
+  ByteContainer mask{};
+  // This is initialized to `max` because lookups search for the matching
+  // key with the minimum priority, this ensures that default constructed
+  // TernaryMatchKey's will never be matched.
+  int priority{std::numeric_limits<decltype(priority)>::max()};
+
+  static constexpr MatchUnitType mut = MatchUnitType::TERNARY;
+};
+
+}  // namespace bm
+
+#endif  // BM_SIM_INCLUDE_BM_SIM_MATCH_KEY_TYPES_H_

--- a/modules/bm_sim/include/bm_sim/match_tables.h
+++ b/modules/bm_sim/include/bm_sim/match_tables.h
@@ -31,6 +31,7 @@
 #include "ras.h"
 #include "calculations.h"
 #include "control_flow.h"
+#include "lookup_structures.h"
 
 namespace bm {
 
@@ -232,6 +233,7 @@ class MatchTable : public MatchTableAbstract {
       const std::string &name,
       p4object_id_t id,
       size_t size, const MatchKeyBuilder &match_key_builder,
+      LookupStructureFactory *lookup_factory,
       bool with_counters, bool with_ageing);
 
  private:
@@ -391,6 +393,7 @@ class MatchTableIndirect : public MatchTableAbstract {
     const std::string &match_type,
     const std::string &name, p4object_id_t id,
     size_t size, const MatchKeyBuilder &match_key_builder,
+    LookupStructureFactory *lookup_factory,
     bool with_counters, bool with_ageing);
 
  protected:
@@ -483,6 +486,7 @@ class MatchTableIndirectWS : public MatchTableIndirect {
     const std::string &match_type,
     const std::string &name, p4object_id_t id,
     size_t size, const MatchKeyBuilder &match_key_builder,
+    LookupStructureFactory *lookup_factory,
     bool with_counters, bool with_ageing);
 
  protected:

--- a/modules/bm_sim/include/bm_sim/switch.h
+++ b/modules/bm_sim/include/bm_sim/switch.h
@@ -83,6 +83,7 @@
 #include "runtime_interface.h"
 #include "dev_mgr.h"
 #include "phv_source.h"
+#include "lookup_structures.h"
 
 namespace bm {
 
@@ -568,12 +569,28 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).add_component<T>(ptr);
   }
 
+  void
+  set_lookup_factory(
+      const std::shared_ptr<LookupStructureFactory> &new_factory) {
+    lookup_factory = new_factory;
+  }
+
  private:
   size_t nb_cxts{};
   // TODO(antonin)
   // Context is not-movable, but is default-constructible, so I can put it in a
   // std::vector
   std::vector<Context> contexts{};
+
+  LookupStructureFactory *get_lookup_factory() const {
+    return lookup_factory ? lookup_factory.get() : &default_lookup_factory;
+  }
+
+  // Create an instance of the default lookup factory
+  static LookupStructureFactory default_lookup_factory;
+  // All Switches will refer to that instance unless explicitly
+  // given a factory
+  std::shared_ptr<LookupStructureFactory> lookup_factory{nullptr};
 
   bool enable_swap{false};
 

--- a/modules/bm_sim/include/bm_sim/tables.h
+++ b/modules/bm_sim/include/bm_sim/tables.h
@@ -39,6 +39,7 @@ struct HasFactoryMethod {
   typedef std::unique_ptr<T> (*Signature)(
     const std::string &, const std::string &,
     p4object_id_t, size_t, const MatchKeyBuilder &,
+    LookupStructureFactory *,
     bool, bool);
 
   template <typename U, Signature> struct SFINAE {};
@@ -76,7 +77,8 @@ class MatchActionTable : public ControlFlowNode, public NamedP4Object {
       const std::string &match_type,
       const std::string &name, p4object_id_t id,
       size_t size, const MatchKeyBuilder &match_key_builder,
-      bool with_counters, bool with_ageing) {
+      bool with_counters, bool with_ageing,
+      LookupStructureFactory *lookup_factory) {
     static_assert(
         std::is_base_of<MatchTableAbstract, MT>::value,
         "incorrect template, needs to be a subclass of MatchTableAbstract");
@@ -87,7 +89,7 @@ class MatchActionTable : public ControlFlowNode, public NamedP4Object {
 
     std::unique_ptr<MT> match_table = MT::create(
       match_type, name, id, size, match_key_builder,
-      with_counters, with_ageing);
+      lookup_factory, with_counters, with_ageing);
 
     return std::unique_ptr<MatchActionTable>(
       new MatchActionTable(name, id, std::move(match_table)));

--- a/modules/bm_sim/src/P4Objects.cpp
+++ b/modules/bm_sim/src/P4Objects.cpp
@@ -108,7 +108,9 @@ P4Objects::build_expression(const Json::Value &json_expression,
 }
 
 int
-P4Objects::init_objects(std::istream *is, int device_id, size_t cxt_id,
+P4Objects::init_objects(std::istream *is,
+                        LookupStructureFactory *lookup_factory,
+                        int device_id, size_t cxt_id,
                         std::shared_ptr<TransportIface> notifications_transport,
                         const std::set<header_field_pair> &required_fields,
                         const std::set<header_field_pair> &arith_fields) {
@@ -750,16 +752,16 @@ P4Objects::init_objects(std::istream *is, int device_id, size_t cxt_id,
       if (table_type == "simple") {
         table = MatchActionTable::create_match_action_table<MatchTable>(
           match_type, table_name, table_id, table_size, key_builder,
-          with_counters, with_ageing);
+          with_counters, with_ageing, lookup_factory);
       } else if (table_type == "indirect") {
         table = MatchActionTable::create_match_action_table<MatchTableIndirect>(
           match_type, table_name, table_id, table_size, key_builder,
-          with_counters, with_ageing);
+          with_counters, with_ageing, lookup_factory);
       } else if (table_type == "indirect_ws") {
         table =
           MatchActionTable::create_match_action_table<MatchTableIndirectWS>(
             match_type, table_name, table_id, table_size, key_builder,
-            with_counters, with_ageing);
+            with_counters, with_ageing, lookup_factory);
 
         if (!cfg_table.isMember("selector")) {
           assert(0 && "indirect_ws tables need to specify a selector");

--- a/modules/bm_sim/src/context.cpp
+++ b/modules/bm_sim/src/context.cpp
@@ -503,10 +503,11 @@ Context::set_force_arith(bool v) {
 
 int
 Context::init_objects(std::istream *is,
+                      LookupStructureFactory *lookup_factory,
                       const std::set<header_field_pair> &required_fields,
                       const std::set<header_field_pair> &arith_fields) {
   // initally p4objects_rt == p4objects, so this works
-  int status = p4objects_rt->init_objects(is, device_id, cxt_id,
+  int status = p4objects_rt->init_objects(is, lookup_factory, device_id, cxt_id,
                                           notifications_transport,
                                           required_fields, arith_fields);
   if (status) return status;
@@ -518,13 +519,14 @@ Context::init_objects(std::istream *is,
 Context::ErrorCode
 Context::load_new_config(
     std::istream *is,
+    LookupStructureFactory *lookup_factory,
     const std::set<header_field_pair> &required_fields,
     const std::set<header_field_pair> &arith_fields) {
   boost::unique_lock<boost::shared_mutex> lock(request_mutex);
   // check that there is no ongoing config swap
   if (p4objects != p4objects_rt) return ErrorCode::ONGOING_SWAP;
   p4objects_rt = std::make_shared<P4Objects>();
-  init_objects(is, required_fields, arith_fields);
+  init_objects(is, lookup_factory, required_fields, arith_fields);
   return ErrorCode::SUCCESS;
 }
 

--- a/modules/bm_sim/src/lookup_structures.cpp
+++ b/modules/bm_sim/src/lookup_structures.cpp
@@ -1,0 +1,260 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Gordon Bailey (gb@gordonbailey.net)
+ *
+ */
+
+#include <bf_lpm_trie/bf_lpm_trie.h>
+
+#include <algorithm>  // for std::swap
+#include <unordered_map>
+#include <vector>
+#include <tuple>
+#include <limits>
+
+#include "bm_sim/lookup_structures.h"
+#include "bm_sim/match_key_types.h"
+#include "bm_sim/lpm_trie.h"
+
+
+namespace bm {
+namespace {  // anonymous
+
+static_assert(sizeof(uintptr_t) == sizeof(internal_handle_t),
+              "Invalid type sizes");
+
+// We don't need or want to export these classes outside of this
+// compilation unit.
+
+class LPMTrieStructure : public LPMLookupStructure {
+ public:
+  explicit LPMTrieStructure(size_t key_width_bytes)
+    : trie(key_width_bytes) {
+    }
+
+  /* Copy constructor */
+  LPMTrieStructure(const LPMTrieStructure &other) = delete;
+
+  /* Move constructor */
+  LPMTrieStructure(LPMTrieStructure &&other) noexcept = default;
+
+  ~LPMTrieStructure() = default;
+
+  /* Copy assignment operator */
+  LPMTrieStructure &operator=(const LPMTrieStructure &other) = delete;
+
+  /* Move assignment operator */
+  LPMTrieStructure &operator=(LPMTrieStructure &&other) noexcept = default;
+
+  bool lookup(const ByteContainer &key_data,
+              internal_handle_t *handle) const override {
+    return trie.lookup(key_data,
+                       reinterpret_cast<uintptr_t *>(handle));
+  }
+
+  bool entry_exists(const LPMMatchKey &key) const override {
+    return trie.has_prefix(key.data, key.prefix_length);
+  }
+
+  void add_entry(const LPMMatchKey &key,
+                 internal_handle_t handle) override {
+    trie.insert_prefix(key.data, key.prefix_length,
+                       reinterpret_cast<uintptr_t>(handle));
+  }
+
+  void delete_entry(const LPMMatchKey &key) override {
+    trie.delete_prefix(key.data, key.prefix_length);
+  }
+
+  void clear() override {
+    trie.clear();
+  }
+
+ private:
+  LPMTrie trie;
+};
+
+class ExactMap : public ExactLookupStructure {
+ public:
+  explicit ExactMap(size_t size) {
+    entries_map.reserve(size);
+  }
+
+  bool lookup(const ByteContainer &key,
+              internal_handle_t *handle) const override {
+    const auto entry_it = entries_map.find(key);
+    if (entry_it == entries_map.end()) {
+      return false;  // Nothing found
+    } else {
+      *handle = entry_it->second;
+      return true;
+    }
+  }
+
+  bool entry_exists(const ExactMatchKey &key) const override {
+    (void) key;
+    return entries_map.find(key.data) != entries_map.end();
+  }
+
+  void add_entry(const ExactMatchKey &key,
+                 internal_handle_t handle) override {
+    entries_map[key.data] = handle;  // key is copied, which is not great
+  }
+
+  void delete_entry(const ExactMatchKey &key) override {
+    entries_map.erase(key.data);
+  }
+
+  void clear() override {
+    entries_map.clear();
+  }
+
+ private:
+  std::unordered_map<ByteContainer, internal_handle_t, ByteContainerKeyHash>
+    entries_map{};
+};
+
+class TernaryMap : public TernaryLookupStructure {
+ public:
+  explicit TernaryMap(size_t size, size_t nbytes_key)
+    : keys(size), nbytes_key(nbytes_key) {}
+
+  bool lookup(const ByteContainer &key_data,
+              internal_handle_t *handle) const override {
+    auto min_priority = std::numeric_limits<
+                          decltype(TernaryMatchKey::priority)>::max();
+    bool match;
+
+    const TernaryMatchKey *min_key = nullptr;
+    internal_handle_t min_handle = 0;
+
+    for (auto it = keys.begin(); it != keys.end(); ++it) {
+      if (it->priority >= min_priority) continue;
+
+      match = true;
+      for (size_t byte_index = 0; byte_index < nbytes_key; byte_index++) {
+        if (it->data[byte_index] !=
+            (key_data[byte_index] & it->mask[byte_index])) {
+          match = false;
+          break;
+        }
+      }
+
+      if (match) {
+        min_priority = it->priority;
+        min_key      = &*it;
+        min_handle   = std::distance(keys.begin(), it);
+      }
+    }
+
+    if (min_key) {
+      *handle = min_handle;
+      return true;
+    }
+
+    return false;
+  }
+
+  bool entry_exists(const TernaryMatchKey &key) const override {
+    auto handle = find_handle(key);
+
+    return handle != keys.size();
+  }
+
+  void add_entry(const TernaryMatchKey &key,
+                 internal_handle_t handle) override {
+    keys.at(handle) = key;
+  }
+
+  void delete_entry(const TernaryMatchKey &key) override {
+    auto handle = find_handle(key);
+
+    // Mark this entry as empty by setting its priority to the maximum
+    // possible value.
+    keys.at(handle).priority = std::numeric_limits<
+                              decltype(keys[handle].priority)>::max();
+  }
+
+  void clear() override {
+    // Quickly mark every entry as empty. This should be faster than doing
+    // `clear()` followed by `resize()`, as clear is already O(n)
+    for (auto &k : keys) {
+      k.priority = std::numeric_limits<decltype(k.priority)>::max();
+    }
+  }
+
+ private:
+  std::vector<TernaryMatchKey> keys;
+  size_t nbytes_key;
+
+  internal_handle_t find_handle(const TernaryMatchKey &key) const {
+    auto it  = keys.begin();
+    auto end = keys.end();
+    for (; it != end; ++it) {
+      if (it->priority == key.priority &&
+          it->data == key.data &&
+          it->mask == key.mask) {
+        break;
+      }
+    }
+    return std::distance(keys.begin(), it);
+  }
+};
+
+}  // anonymous namespace
+
+template <>
+std::unique_ptr<LookupStructure<ExactMatchKey> >
+LookupStructureFactory::create<ExactMatchKey>(
+    LookupStructureFactory *f, size_t size, size_t nbytes_key) {
+  return f->create_for_exact(size, nbytes_key);
+}
+
+template <>
+std::unique_ptr<LookupStructure<LPMMatchKey> >
+LookupStructureFactory::create<LPMMatchKey>(
+    LookupStructureFactory *f, size_t size, size_t nbytes_key) {
+  return f->create_for_LPM(size, nbytes_key);
+}
+
+template <>
+std::unique_ptr<LookupStructure<TernaryMatchKey> >
+LookupStructureFactory::create<TernaryMatchKey>(
+    LookupStructureFactory *f, size_t size, size_t nbytes_key) {
+  return f->create_for_ternary(size, nbytes_key);
+}
+
+
+std::unique_ptr<ExactLookupStructure>
+LookupStructureFactory::create_for_exact(size_t size, size_t nbytes_key) {
+  (void) nbytes_key;
+  return std::unique_ptr<ExactLookupStructure>(new ExactMap(size));
+}
+
+std::unique_ptr<LPMLookupStructure>
+LookupStructureFactory::create_for_LPM(size_t size, size_t nbytes_key) {
+  (void) size;
+  return std::unique_ptr<LPMLookupStructure>(new LPMTrieStructure(nbytes_key));
+}
+
+std::unique_ptr<TernaryLookupStructure>
+LookupStructureFactory::create_for_ternary(size_t size, size_t nbytes_key) {
+  return std::unique_ptr<TernaryLookupStructure>(new TernaryMap(size,
+                                                                nbytes_key));
+}
+
+}  // namespace bm

--- a/modules/bm_sim/src/match_tables.cpp
+++ b/modules/bm_sim/src/match_tables.cpp
@@ -25,6 +25,7 @@
 #include "bm_sim/match_tables.h"
 #include "bm_sim/logger.h"
 #include "bm_sim/event_logger.h"
+#include "bm_sim/lookup_structures.h"
 
 namespace bm {
 
@@ -33,19 +34,22 @@ namespace {
 template <typename V>
 std::unique_ptr<MatchUnitAbstract<V> >
 create_match_unit(const std::string match_type, const size_t size,
-                  const MatchKeyBuilder &match_key_builder) {
+                  const MatchKeyBuilder &match_key_builder,
+                  LookupStructureFactory *lookup_factory) {
   typedef MatchUnitExact<V> MUExact;
   typedef MatchUnitLPM<V> MULPM;
   typedef MatchUnitTernary<V> MUTernary;
 
   std::unique_ptr<MatchUnitAbstract<V> > match_unit;
   if (match_type == "exact")
-    match_unit = std::unique_ptr<MUExact>(new MUExact(size, match_key_builder));
+    match_unit = std::unique_ptr<MUExact>(
+        new MUExact(size, match_key_builder, lookup_factory));
   else if (match_type == "lpm")
-    match_unit = std::unique_ptr<MULPM>(new MULPM(size, match_key_builder));
+    match_unit = std::unique_ptr<MULPM>(
+        new MULPM(size, match_key_builder, lookup_factory));
   else if (match_type == "ternary")
     match_unit = std::unique_ptr<MUTernary>(
-      new MUTernary(size, match_key_builder));
+        new MUTernary(size, match_key_builder, lookup_factory));
   else
     assert(0 && "invalid match type");
   return match_unit;
@@ -393,9 +397,11 @@ std::unique_ptr<MatchTable>
 MatchTable::create(const std::string &match_type,
                    const std::string &name, p4object_id_t id,
                    size_t size, const MatchKeyBuilder &match_key_builder,
+                   LookupStructureFactory *lookup_factory,
                    bool with_counters, bool with_ageing) {
   std::unique_ptr<MatchUnitAbstract<ActionEntry> > match_unit =
-    create_match_unit<ActionEntry>(match_type, size, match_key_builder);
+    create_match_unit<ActionEntry>(match_type, size, match_key_builder,
+                                   lookup_factory);
 
   return std::unique_ptr<MatchTable>(
     new MatchTable(name, id, std::move(match_unit),
@@ -416,9 +422,11 @@ MatchTableIndirect::create(const std::string &match_type,
                            const std::string &name, p4object_id_t id,
                            size_t size,
                            const MatchKeyBuilder &match_key_builder,
+                           LookupStructureFactory *lookup_factory,
                            bool with_counters, bool with_ageing) {
   std::unique_ptr<MatchUnitAbstract<IndirectIndex> > match_unit =
-    create_match_unit<IndirectIndex>(match_type, size, match_key_builder);
+    create_match_unit<IndirectIndex>(match_type, size, match_key_builder,
+                                     lookup_factory);
 
   return std::unique_ptr<MatchTableIndirect>(
     new MatchTableIndirect(name, id, std::move(match_unit),
@@ -786,9 +794,11 @@ MatchTableIndirectWS::create(const std::string &match_type,
                              const std::string &name, p4object_id_t id,
                              size_t size,
                              const MatchKeyBuilder &match_key_builder,
+                             LookupStructureFactory *lookup_factory,
                              bool with_counters, bool with_ageing) {
   std::unique_ptr<MatchUnitAbstract<IndirectIndex> > match_unit =
-    create_match_unit<IndirectIndex>(match_type, size, match_key_builder);
+    create_match_unit<IndirectIndex>(match_type, size, match_key_builder,
+                                     lookup_factory);
 
   return std::unique_ptr<MatchTableIndirectWS>(
     new MatchTableIndirectWS(name, id, std::move(match_unit),

--- a/modules/bm_sim/src/switch.cpp
+++ b/modules/bm_sim/src/switch.cpp
@@ -51,6 +51,8 @@ SwitchWContexts::SwitchWContexts(size_t nb_cxts, bool enable_swap)
   }
 }
 
+LookupStructureFactory SwitchWContexts::default_lookup_factory {};
+
 void
 SwitchWContexts::add_required_field(const std::string &header_name,
                                   const std::string &field_name) {
@@ -85,7 +87,8 @@ SwitchWContexts::init_objects(const std::string &json_path, int dev_id,
     auto &cxt = contexts.at(cxt_id);
     cxt.set_device_id(device_id);
     cxt.set_notifications_transport(notifications_transport);
-    int status = cxt.init_objects(&fs, required_fields, arith_fields);
+    int status = cxt.init_objects(&fs, get_lookup_factory(),
+                                  required_fields, arith_fields);
     fs.clear();
     fs.seekg(0, std::ios::beg);
     if (status != 0) return status;
@@ -188,7 +191,8 @@ SwitchWContexts::load_new_config(const std::string &new_config) {
   if (!enable_swap) return ErrorCode::CONFIG_SWAP_DISABLED;
   std::istringstream ss(new_config);
   for (auto &cxt : contexts) {
-    ErrorCode rc = cxt.load_new_config(&ss, required_fields, arith_fields);
+    ErrorCode rc = cxt.load_new_config(&ss, get_lookup_factory(),
+                                       required_fields, arith_fields);
     if (rc != ErrorCode::SUCCESS) return rc;
     ss.clear();
     ss.seekg(0, std::ios::beg);

--- a/tests/test_ageing.cpp
+++ b/tests/test_ageing.cpp
@@ -81,7 +81,9 @@ protected:
     typedef MatchTableAbstract::ActionEntry ActionEntry;
     typedef MatchUnitExact<ActionEntry> MUExact;
 
-    std::unique_ptr<MUExact> match_unit(new MUExact(1, key_builder));
+    LookupStructureFactory factory;
+
+    std::unique_ptr<MUExact> match_unit(new MUExact(1, key_builder, &factory));
 
     // counters disabled, ageing enabled
     table = std::unique_ptr<MatchTable>(
@@ -151,7 +153,7 @@ TEST_F(AgeingTest, OneNotification) {
   ASSERT_NE(MemoryAccessor::Status::CAN_READ, ageing_writer->check_status());
   sleep_for(milliseconds(150));
   ASSERT_NE(MemoryAccessor::Status::CAN_READ, ageing_writer->check_status());
-  
+
   auto tp1 = clock::now();
   ASSERT_TRUE(send_pkt(key, &lookup_handle));
   ageing_writer->read(buffer, sizeof(buffer));


### PR DESCRIPTION
Overview
-----------------
The purpose of this pull request is to generalize the match units so that the user can provide an implementation for the actual data structures that are used. My particular use case is using the behavioral model within a SystemC project. In order to obtain timing information we need to provide our own data structures which interact with our memory model. Another example use case would be changing to a different Trie implementation which may perform better for particular patterns of lookups.

Additionally, this change reduces the duplication in `match_units.{cpp,h}`, factoring out the common logic into a templated class, and the actual lookup logic into the separate `lookup_structure.{cpp,h}` classes.

Details
----------
Users can provide their own data structure implementations by subclassing `LookupStructure<KeyType>`, and then by subclassing `LookupStructureFactory` and overriding the appropriate `create()` methods.

This factory can then be passed to a Switch instance before calling `init_objects()` or `init_from_command_line()` using the `set_lookup_factory()` method. If this is not done, then a default factory is used which creates lookup structures that use the same logic that was previously used in `match_units.{cpp,h}`.

Performance
--------------------------
The main negative performance impact is that for Ternary match units, match keys are unfortunately being copied when stored (similarly to the Exact match units). This increases the memory usage, but should not have a significant impact on speed.

Another much smaller impact is the additional virtual function calls required. This is an unavoidable consequence of allowing the user to specify the data structure used in lookups, and the performance impact should be minimal.

Coverage
--------------
   - No additional test cases were added, since this was
   essentially a refactoring, all new code was covered by existing cases.
   - Coverage either improved or stayed the same in all cases with one exception: `modules/bm_sim/include/bm_sim/handle_mgr.h`
      - Line 114 is no longer being hit. I do not have a complete understand of this module, but my guess is this is because previously Ternary matches were using the `HandleMgr` to iterate over all handles, and now this is being done by in the corresponding lookup structure.
      - Would it be possible to suggest a test-case which would restore coverage for this line?