### PR TITLE
automatically masking first byte of each match key param

### DIFF
--- a/tests/test_tables.cpp
+++ b/tests/test_tables.cpp
@@ -109,17 +109,18 @@ class TableSizeTwo : public ::testing::Test {
     std::unique_ptr<MUType> match_unit;
 
     // true enables counters
-    match_unit = std::unique_ptr<MUType>(new MUType(t_size, key_builder, &lookup_factory));
+    match_unit = std::unique_ptr<MUType>(
+        new MUType(t_size, key_builder, &lookup_factory));
     table = std::unique_ptr<MatchTable>(
       new MatchTable("test_table", 0, std::move(match_unit), true)
     );
     table->set_next_node(0, nullptr);
     table->set_next_node_miss_default(&node_miss_default);
 
-    match_unit = std::unique_ptr<MUType>(new MUType(t_size, key_builder_w_valid, &lookup_factory));
+    match_unit = std::unique_ptr<MUType>(
+        new MUType(t_size, key_builder_w_valid, &lookup_factory));
     table_w_valid = std::unique_ptr<MatchTable>(
-      new MatchTable("test_table", 0, std::move(match_unit))
-    );
+        new MatchTable("test_table", 0, std::move(match_unit)));
     table_w_valid->set_next_node(0, nullptr);
     table_w_valid->set_next_node_miss_default(&node_miss_default);
   }
@@ -1258,10 +1259,10 @@ class TableBigMask : public ::testing::Test {
     std::unique_ptr<MUType> match_unit;
 
     // false: no counters
-    match_unit = std::unique_ptr<MUType>(new MUType(2, key_builder, &lookup_factory));
+    match_unit = std::unique_ptr<MUType>(
+        new MUType(2, key_builder, &lookup_factory));
     table = std::unique_ptr<MatchTable>(
-      new MatchTable("test_table", 0, std::move(match_unit), false)
-    );
+        new MatchTable("test_table", 0, std::move(match_unit), false));
     table->set_next_node(0, nullptr);
   }
 
@@ -1545,10 +1546,10 @@ class AdvancedLPMTest : public AdvancedTest {
     key_builder.push_back_valid_header(testHeader3);
 
     std::unique_ptr<MULPM> match_unit;
-    match_unit = std::unique_ptr<MULPM>(new MULPM(t_size, key_builder, &lookup_factory));
+    match_unit = std::unique_ptr<MULPM>(
+        new MULPM(t_size, key_builder, &lookup_factory));
     table = std::unique_ptr<MatchTable>(
-      new MatchTable("test_table", 0, std::move(match_unit), false)
-    );
+        new MatchTable("test_table", 0, std::move(match_unit), false));
     table->set_next_node(0, nullptr);
   }
 
@@ -1629,10 +1630,10 @@ class AdvancedTernaryTest : public AdvancedTest {
     key_builder.push_back_valid_header(testHeader3);
 
     std::unique_ptr<MUTernary> match_unit;
-    match_unit = std::unique_ptr<MUTernary>(new MUTernary(t_size, key_builder, &lookup_factory));
+    match_unit = std::unique_ptr<MUTernary>(
+        new MUTernary(t_size, key_builder, &lookup_factory));
     table = std::unique_ptr<MatchTable>(
-      new MatchTable("test_table", 0, std::move(match_unit), false)
-    );
+        new MatchTable("test_table", 0, std::move(match_unit), false));
     table->set_next_node(0, nullptr);
   }
 
@@ -1709,10 +1710,10 @@ class TableEntryDebug : public ::testing::Test {
     set_key_builder();
 
     // true enables counters
-    match_unit = std::unique_ptr<MUType>(new MUType(t_size, key_builder, &lookup_factory));
+    match_unit = std::unique_ptr<MUType>(
+        new MUType(t_size, key_builder, &lookup_factory));
     table = std::unique_ptr<MatchTable>(
-      new MatchTable("test_table", 0, std::move(match_unit), false)
-    );
+        new MatchTable("test_table", 0, std::move(match_unit), false));
     table->set_next_node(0, nullptr);
   }
 
@@ -1725,23 +1726,23 @@ class TableEntryDebug : public ::testing::Test {
   MatchErrorCode add_entries() {
     entry_handle_t handle;
     MatchErrorCode rc1 =
-    table->add_entry(gen_match_key("\x12\x34","\xab\xcd"), &action_fn, action_data, &handle,
-                     priority);
+    table->add_entry(gen_match_key("\x12\x34","\xab\xcd"), &action_fn,
+                     action_data, &handle, priority);
     if (rc1 != MatchErrorCode::SUCCESS) return rc1;
 
     MatchErrorCode rc2 =
-    table->add_entry(gen_match_key("\x34\x56","\xcd\xef"), &action_fn, action_data, &handle,
-                     priority);
+    table->add_entry(gen_match_key("\x34\x56","\xcd\xef"), &action_fn,
+                     action_data, &handle, priority);
     if (rc2 != MatchErrorCode::SUCCESS) return rc2;
 
     MatchErrorCode rc3 =
-    table->add_entry(gen_match_key("\x56\x78","\xfe\xdc"), &action_fn, action_data, &handle,
-                     priority);
+    table->add_entry(gen_match_key("\x56\x78","\xfe\xdc"), &action_fn,
+                     action_data, &handle, priority);
     if (rc3 != MatchErrorCode::SUCCESS) return rc3;
 
     MatchErrorCode rc4 =
-    table->add_entry(gen_match_key("\x78\x90","\xdc\xba"), &action_fn, action_data, &handle,
-                     priority);
+    table->add_entry(gen_match_key("\x78\x90","\xdc\xba"), &action_fn,
+                     action_data, &handle, priority);
     return rc4;
 
   }
@@ -1886,10 +1887,6 @@ std::string TableEntryDebug<MUTernary>::gen_entries_string() const {
       "3: 7890 0cb0 01 &&& fffff00ff0 => actionA - aba,\n"
       "default: NULL\n");
 }
-
-typedef Types<MUExact,
-	      MULPM,
-	      MUTernary> TableTypes;
 
 TYPED_TEST_CASE(TableEntryDebug, TableTypes);
 
@@ -2071,4 +2068,155 @@ TEST_F(TableDeadlock, DumpEntryString) {
   } else {
     t1.join();
   }
+}
+
+
+// We recently added automatic masking of the first byte of each match
+// param. For example, if a match field is 14 bit wide and we receive value
+// 0xffff from the client (instead of the correct 0x3fff), we will automatically
+// do the conversion. Before that change, we would not perform any checks and
+// simply use the user-provided value, which would cause unexpected dataplane
+// behavior. But is this silent conversion better than returning an error to the
+// client?
+template <typename MUType>
+class TableBadInputKey : public ::testing::Test {
+ protected:
+  static constexpr size_t t_size = 128u;
+
+  MatchKeyBuilder key_builder;
+  std::unique_ptr<MatchTable> table;
+
+  HeaderType testHeaderType;
+  header_id_t testHeader1{0}, testHeader2{1}, testHeader3{2};
+  ActionFn action_fn;
+  ActionData action_data;
+  int priority = 12;
+
+  PHVFactory phv_factory;
+  std::unique_ptr<PHVSourceIface> phv_source{nullptr};
+
+  TableBadInputKey()
+      : testHeaderType("test_t", 0), action_fn("actionA", 0),
+        phv_source(PHVSourceIface::make_phv_source()) {
+    // non-aligned, to expose potential issues
+    testHeaderType.push_back_field("f14", 14);
+    // for header byte alignment
+    testHeaderType.push_back_field("f2", 2);
+    phv_factory.push_back_header("test1", testHeader1, testHeaderType);
+    phv_factory.push_back_header("test2", testHeader2, testHeaderType);
+    phv_factory.push_back_header("test3", testHeader3, testHeaderType);
+
+    std::unique_ptr<MUType> match_unit;
+
+    set_key_builder();
+
+    match_unit = std::unique_ptr<MUType>(
+        new MUType(t_size, key_builder, &lookup_factory));
+    table = std::unique_ptr<MatchTable>(
+        new MatchTable("test_table", 0, std::move(match_unit), false));
+    table->set_next_node(0, nullptr);
+  }
+
+  std::vector<MatchKeyParam> gen_match_key() const;
+
+  MatchErrorCode add_entry(entry_handle_t *handle) {
+    return table->add_entry(gen_match_key(), &action_fn, action_data, handle,
+                            priority);
+  }
+
+  Packet get_pkt() const {
+    // dummy packet, won't be parsed
+    Packet packet = Packet::make_new(
+        128, PacketBuffer(256), phv_source.get());
+    packet.get_phv()->get_header(testHeader1).mark_valid();
+    packet.get_phv()->get_header(testHeader2).mark_valid();
+    packet.get_phv()->get_header(testHeader3).mark_valid();
+    return packet;
+  }
+
+  Packet gen_pkt(const std::string &h1_f14_v = "0x3fff",
+                 const std::string &h2_f14_v = "0x3fff",
+                 const std::string &h3_f14_v = "0x3fff") const {
+    Packet packet = get_pkt();
+    PHV *phv = packet.get_phv();
+    Field &h1_f14 = phv->get_field(testHeader1, 0);
+    Field &h2_f14 = phv->get_field(testHeader2, 0);
+    Field &h3_f14 = phv->get_field(testHeader3, 0);
+
+    h1_f14.set(h1_f14_v);
+    h2_f14.set(h2_f14_v);
+    h3_f14.set(h3_f14_v);
+
+    return packet;
+  }
+
+  virtual void SetUp() {
+    phv_source->set_phv_factory(0, &phv_factory);
+  }
+
+ private:
+  void set_key_builder();
+};
+
+template <>
+void TableBadInputKey<MUExact>::set_key_builder() {
+  key_builder.push_back_field(testHeader1, 0, 14,
+                              MatchKeyParam::Type::EXACT, "h1.f0");
+}
+
+template <>
+void TableBadInputKey<MULPM>::set_key_builder() {
+  key_builder.push_back_field(testHeader1, 0, 14,
+                              MatchKeyParam::Type::LPM, "h1.f0");
+  key_builder.push_back_field(testHeader2, 0, 14,
+                              MatchKeyParam::Type::EXACT, "h2.f0");
+}
+
+template <>
+void TableBadInputKey<MUTernary>::set_key_builder() {
+  key_builder.push_back_field(testHeader1, 0, 14,
+                              MatchKeyParam::Type::LPM, "h1.f0");
+  key_builder.push_back_field(testHeader2, 0, 14,
+                              MatchKeyParam::Type::TERNARY, "h2.f0");
+  key_builder.push_back_field(testHeader3, 0, 14,
+                              MatchKeyParam::Type::EXACT, "h3.f0");
+}
+
+template <>
+std::vector<MatchKeyParam>
+TableBadInputKey<MUExact>::gen_match_key() const {
+  std::vector<MatchKeyParam> match_key;
+  match_key.emplace_back(MatchKeyParam::Type::EXACT, std::string("\xff\xff"));
+  return match_key;
+}
+
+template <>
+std::vector<MatchKeyParam>
+TableBadInputKey<MULPM>::gen_match_key() const {
+  std::vector<MatchKeyParam> match_key;
+  match_key.emplace_back(MatchKeyParam::Type::LPM, std::string("\xff\xff"), 12);
+  match_key.emplace_back(MatchKeyParam::Type::EXACT, std::string("\xff\xff"));
+  return match_key;
+}
+
+template <>
+std::vector<MatchKeyParam>
+TableBadInputKey<MUTernary>::gen_match_key() const {
+  std::vector<MatchKeyParam> match_key;
+  match_key.emplace_back(MatchKeyParam::Type::LPM, std::string("\xff\xff"), 12);
+  match_key.emplace_back(MatchKeyParam::Type::TERNARY, std::string("\xff\xff"),
+                         std::string("\xff\xff"));
+  match_key.emplace_back(MatchKeyParam::Type::EXACT, std::string("\xff\xff"));
+  return match_key;
+}
+
+TYPED_TEST_CASE(TableBadInputKey, TableTypes);
+
+TYPED_TEST(TableBadInputKey, NonByteAligned) {
+  entry_handle_t handle, lookup_handle;
+  bool hit;
+  ASSERT_EQ(MatchErrorCode::SUCCESS, this->add_entry(&handle));
+  auto pkt = this->gen_pkt();
+  this->table->lookup(pkt, &hit, &lookup_handle);
+  ASSERT_TRUE(hit);
 }


### PR DESCRIPTION
- in case user input not correctly formatted
- would it be better to return an error to the client / application?