### PR TITLE
Signed fields

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -11,8 +11,10 @@ per [this specification] (http://json-schema.org/).
 
 ## General information
 
-Signed fields are not supported in bmv2, although signed constants (in
-expressions, or as primitive arguments) are.
+Tentative support for signed fields (with a 2 complement representation) has
+been added to bmv2, although they are not supported in P4 1.0 or by the [p4c-bm
+compiler] (https://github.com/p4lang/p4c-bm). However, signed constants (in
+expressions, or as primitive arguments) are always supported.
 Arithmetic is done with infinite precision, but when a value is copied into a
 field, it is truncated based on the field's bitwidth.
 
@@ -44,6 +46,25 @@ For an expression, `left` and `right` will themselves be JSON objects, where the
 `value` attribute can be one of `field`, `hexstr`, `header`, `expression`,
 `bool`.
 
+bmv2 also supports these recently-added operations:
+  - data-to-bool conversion (`op` is `d2b`): unary operation which can be used
+to explicitly convert a data value (i.e. a value that can be read from /
+written to a field, or a value obtained from runtime action data, or a value
+obtained from a JSON `hexstr`) to a boolean value. Note that implicit
+conversions are not supported.
+  - bool-to-data conversion (`op` is `b2d`): unary operation which can be used
+to explicitly convert a boolean value to a data value. Note that implicit
+conversions are not supported.
+  - 2-complement modulo (`op` is `two_comp_mod`): given a source data value and
+a width data value, produces a third data value which is the signed value of the
+source given a 2-complement representation with that width. For example,
+`two_comp_mod(257, 8) == 1` and `two_comp_mod(-129, 8) == 127`.
+  - ternary operator (`op` is `?`): in addition to `left` and `right`, the JSON
+object has a fourth attribute, `cond` (condition), which is itself an
+expression. For example, in `(hA.f1 == 9) ? 3 : 4`, `cond` would be the JSON
+representation of `(hA.f1 == 9)`, `left` would be the JSON representation of `3`
+and `right` would be the JSON representation of `4`.
+
 
 The attributes of the root JSON dictionary are:
 
@@ -54,7 +75,10 @@ item has the following attributes:
 - `name`: fully qualified P4 name of the header type
 - `id`: a unique integer (unique with respect to other header types)
 - `fields`: a JSON array of JSON 2-tuples (field member name, field width in
-bits)
+bits). Note that the JSON 2-tuples can optionally be JSON 3-tuples if you want
+to experiment with signed fields support. In this case, the third element of the
+tuples is a boolean value, which is `true` iff the field is signed. A signed
+field needs to have a bitwidth of at least 2!
 
 ### `headers`
 

--- a/modules/bm_sim/include/bm_sim/bignum.h
+++ b/modules/bm_sim/include/bm_sim/bignum.h
@@ -45,6 +45,14 @@ namespace bignum {
     mpz_import(dst->backend().data(), 1, 1, size, 1, 0, src);
   }
 
+  inline int test_bit(const Bignum &v, size_t index) {
+    return mpz_tstbit(v.backend().data(), index);
+  }
+
+  inline void clear_bit(Bignum *v, size_t index) {
+    return mpz_clrbit(v->backend().data(), index);
+  }
+
 }  // namespace bignum
 
 }  // namespace bm

--- a/modules/bm_sim/include/bm_sim/data.h
+++ b/modules/bm_sim/include/bm_sim/data.h
@@ -294,6 +294,29 @@ class Data {
   }
 
   //! NC
+  void two_comp_mod(const Data &src, const Data &width) {
+    static Bignum one(1);
+    unsigned int uwidth = width.get_uint();
+    Bignum mask = (one << uwidth) - 1;
+    Bignum max = (one << (uwidth - 1)) - 1;
+    Bignum min = -(one << (uwidth - 1));
+    if (src.value < min || src.value > max) {
+      value = src.value & mask;
+      if (value > max)
+        value -= (one << uwidth);
+    } else {
+      value = src.value;
+    }
+  }
+
+  //! NC
+  template<typename T,
+           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  bool test_eq(T i) const {
+    return (value == i);
+  }
+
+  //! NC
   friend bool operator==(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
     return lhs.value == rhs.value;

--- a/modules/bm_sim/include/bm_sim/expressions.h
+++ b/modules/bm_sim/include/bm_sim/expressions.h
@@ -39,7 +39,9 @@ enum class ExprOpcode {
   AND, OR, NOT,
   BIT_AND, BIT_OR, BIT_XOR, BIT_NEG,
   VALID_HEADER,
-  TERNARY_OP, SKIP
+  TERNARY_OP, SKIP,
+  TWO_COMP_MOD,
+  DATA_TO_BOOL, BOOL_TO_DATA
 };
 
 class ExprOpcodesMap {

--- a/modules/bm_sim/src/P4Objects.cpp
+++ b/modules/bm_sim/src/P4Objects.cpp
@@ -134,6 +134,9 @@ P4Objects::init_objects(std::istream *is,
     const Json::Value &cfg_fields = cfg_header_type["fields"];
     for (const auto cfg_field : cfg_fields) {
       const string field_name = cfg_field[0].asString();
+      bool is_signed = false;
+      if (cfg_field.size() > 2)
+        is_signed = cfg_field[2].asBool();
       if (cfg_field[1].asString() == "*") {  // VL field
         ArithExpression raw_expr;
         assert(cfg_header_type.isMember("length_exp"));
@@ -143,10 +146,11 @@ P4Objects::init_objects(std::istream *is,
         raw_expr.build();
         std::unique_ptr<VLHeaderExpression> VL_expr(
           new VLHeaderExpression(raw_expr));
-        header_type->push_back_VL_field(field_name, std::move(VL_expr));
+        header_type->push_back_VL_field(field_name, std::move(VL_expr),
+                                        is_signed);
       } else {
         int field_bit_width = cfg_field[1].asInt();
-        header_type->push_back_field(field_name, field_bit_width);
+        header_type->push_back_field(field_name, field_bit_width, is_signed);
       }
     }
 

--- a/modules/bm_sim/src/headers.cpp
+++ b/modules/bm_sim/src/headers.cpp
@@ -39,7 +39,8 @@ Header::Header(const std::string &name, p4object_id_t id,
     if (arith_offsets.find(i) == arith_offsets.end()) {
       arith_flag = false;
     }
-    fields.push_back(Field(header_type.get_bit_width(i), arith_flag));
+    fields.push_back(Field(header_type.get_bit_width(i), arith_flag,
+                           header_type.is_field_signed(i)));
     uint64_t field_unique_id = id;
     field_unique_id <<= 32;
     field_unique_id |= i;

--- a/tests/test_conditionals.cpp
+++ b/tests/test_conditionals.cpp
@@ -288,6 +288,22 @@ TEST_F(ConditionalsTest, BitXor) {
   ASSERT_TRUE(c.eval(*phv));
 }
 
+TEST_F(ConditionalsTest, TwoCompMod) {
+  int v1 = -129;
+  int v2 = 8;
+  int res = 127;
+
+  Conditional c("ctest", 0);
+  c.push_back_load_const(Data(v1));
+  c.push_back_load_const(Data(v2));
+  c.push_back_op(ExprOpcode::TWO_COMP_MOD);
+  c.push_back_load_const(Data(res));
+  c.push_back_op(ExprOpcode::EQ_DATA);
+  c.build();
+
+  ASSERT_TRUE(c.eval(*phv));
+}
+
 TEST_F(ConditionalsTest, BitNeg) {
   int v = 0xababa;
 
@@ -437,6 +453,84 @@ TEST_F(ConditionalsTest, TernaryOp) {
   testHeader1_f16.set(value_ternary_2);
 
   ASSERT_TRUE(c.eval(*phv));
+}
+
+TEST_F(ConditionalsTest, TernaryOp2) {
+  // 1 == (((testHeader1.f16 < testHeader2.f16) ? 1 : 0) & 0x1) & 0xff
+  Conditional c("ctest", 0);
+
+  Expression ternary_e1;
+  ternary_e1.push_back_load_const(Data(1));
+
+  Expression ternary_e2;
+  ternary_e2.push_back_load_const(Data(0));
+
+  c.push_back_load_field(testHeader1, 3); // f16
+  c.push_back_load_field(testHeader2, 3); // f16
+  c.push_back_op(ExprOpcode::LT_DATA);
+  c.push_back_ternary_op(ternary_e1, ternary_e2);
+  c.push_back_load_const(Data(0x1));
+  c.push_back_op(ExprOpcode::BIT_AND);
+  c.push_back_load_const(Data(0xff));
+  c.push_back_op(ExprOpcode::BIT_AND);
+  c.push_back_load_const(Data(1));
+  c.push_back_op(ExprOpcode::EQ_DATA);
+  c.build();
+
+  Field &testHeader1_f16 = phv->get_field(testHeader1, 3); // f16
+  Field &testHeader2_f16 = phv->get_field(testHeader2, 3); // f16
+  testHeader1_f16.set(3);
+  testHeader2_f16.set(3);
+
+  ASSERT_FALSE(c.eval(*phv));
+
+  testHeader1_f16.set(1);
+
+  ASSERT_TRUE(c.eval(*phv));
+}
+
+TEST_F(ConditionalsTest, D2B) {
+  Conditional c("ctest", 0);
+  c.push_back_load_field(testHeader1, 3);  // f16
+  c.push_back_op(ExprOpcode::DATA_TO_BOOL);
+  c.build();
+
+  Field &testHeader1_f16 = phv->get_field(testHeader1, 3);
+
+  testHeader1_f16.set(0);
+  ASSERT_FALSE(c.eval(*phv));
+
+  testHeader1_f16.set(1);
+  ASSERT_TRUE(c.eval(*phv));
+
+  testHeader1_f16.set(7);
+  ASSERT_TRUE(c.eval(*phv));
+}
+
+TEST_F(ConditionalsTest, B2D) {
+  auto build_condition = [](const std::string &name, int id, bool bool_v,
+                            int data_v) {
+    Conditional c(name, id);
+    c.push_back_load_bool(bool_v);
+    c.push_back_op(ExprOpcode::BOOL_TO_DATA);
+    c.push_back_load_const(Data(data_v));
+    c.push_back_op(ExprOpcode::EQ_DATA);
+    c.build();
+    return c;
+  };
+
+  Conditional c1 = build_condition("c1", 0, true, 0);
+  ASSERT_FALSE(c1.eval(*phv));
+  Conditional c2 = build_condition("c2", 1, true, 1);
+  ASSERT_TRUE(c2.eval(*phv));
+  Conditional c3 = build_condition("c3", 2, true, 7);
+  ASSERT_FALSE(c3.eval(*phv));
+  Conditional c4 = build_condition("c4", 3, false, 0);
+  ASSERT_TRUE(c4.eval(*phv));
+  Conditional c5 = build_condition("c5", 4, false, 1);
+  ASSERT_FALSE(c5.eval(*phv));
+  Conditional c6 = build_condition("c6", 5, false, 7);
+  ASSERT_FALSE(c6.eval(*phv));
 }
 
 TEST_F(ConditionalsTest, Stress) {

--- a/tests/test_data.cpp
+++ b/tests/test_data.cpp
@@ -28,21 +28,21 @@ using bm::Data;
 
 TEST(Data, ConstructorFromUInt) {
   const Data d(0xaba);
-  EXPECT_EQ((unsigned) 0xaba, d.get_uint());
+  ASSERT_EQ((unsigned) 0xaba, d.get_uint());
 }
 
 TEST(Data, ConstructorFromBytes) {
   unsigned char bytes[2] = {0x0a, 0xba};
   const Data d((char *) bytes, sizeof(bytes));
-  EXPECT_EQ((unsigned) 0xaba, d.get_uint());
+  ASSERT_EQ((unsigned) 0xaba, d.get_uint());
 }
 
 TEST(Data, ConstructorFromHexStr) {
   const Data d1(std::string("0xaba"));
-  EXPECT_EQ((unsigned) 0xaba, d1.get_uint());
+  ASSERT_EQ((unsigned) 0xaba, d1.get_uint());
 
   const Data d2("-0xaba");
-  EXPECT_EQ(-0xaba, d2.get_int());
+  ASSERT_EQ(-0xaba, d2.get_int());
 }
 
 TEST(Data, EqualityOp) {
@@ -61,16 +61,16 @@ TEST(Data, CopyOp) {
   const Data d1(0xaba);
   Data d2;
   d2 = d1;
-  EXPECT_EQ(d1, d2);
+  ASSERT_EQ(d1, d2);
   d2.set(0);
-  EXPECT_EQ((unsigned) 0xaba, d1.get_uint());
+  ASSERT_EQ((unsigned) 0xaba, d1.get_uint());
 }
 
 TEST(Data, AddDestIsSrc) {
   Data d1(11);
   Data d2(22);
   d1.add(d1, d2);
-  EXPECT_EQ((unsigned) 33, d1.get_uint());
+  ASSERT_EQ((unsigned) 33, d1.get_uint());
 }
 
 TEST(Data, Add) {
@@ -78,7 +78,7 @@ TEST(Data, Add) {
   Data d2(22);
   Data d3;
   d3.add(d1, d2);
-  EXPECT_EQ((unsigned) 33, d3.get_uint());
+  ASSERT_EQ((unsigned) 33, d3.get_uint());
 }
 
 TEST(Data, Sub) {
@@ -86,14 +86,14 @@ TEST(Data, Sub) {
   Data d2(10);
   Data d3;
   d3.sub(d1, d2);
-  EXPECT_EQ((unsigned) 12, d3.get_uint());
+  ASSERT_EQ((unsigned) 12, d3.get_uint());
 }
 
 TEST(Data, BitNeg) {
   Data d1(0xaba);
   Data d2;
   d2.bit_neg(d1);
-  EXPECT_EQ(~0xaba, d2.get_int());
+  ASSERT_EQ(~0xaba, d2.get_int());
 }
 
 TEST(Data, ShiftLeft) {
@@ -101,7 +101,7 @@ TEST(Data, ShiftLeft) {
   Data d2(3);
   Data d3;
   d3.shift_left(d1, d2);
-  EXPECT_EQ((0xaba) << 3, d3.get_int());
+  ASSERT_EQ((0xaba) << 3, d3.get_int());
 }
 
 TEST(Data, ShiftRight) {
@@ -109,5 +109,44 @@ TEST(Data, ShiftRight) {
   Data d2(3);
   Data d3;
   d3.shift_right(d1, d2);
-  EXPECT_EQ((0xabababa) >> 3, d3.get_int());
+  ASSERT_EQ((0xabababa) >> 3, d3.get_int());
+}
+
+namespace {
+
+void test_two_comp_mod(int src, unsigned int width, int expected) {
+  Data dst;
+  dst.two_comp_mod(Data(src), Data(width));
+  ASSERT_EQ(expected, dst.get_int());
+}
+
+}  // namespace
+
+TEST(Data, TwoCompMod) {
+  test_two_comp_mod(3, 2, -1);
+  test_two_comp_mod(10, 8, 10);
+  test_two_comp_mod(-10, 8, -10);
+  test_two_comp_mod(256, 8, 0);
+  test_two_comp_mod(257, 8, 1);
+  test_two_comp_mod(128, 8, -128);
+  test_two_comp_mod(129, 8, -127);
+  test_two_comp_mod(127, 8, 127);
+  test_two_comp_mod(126, 8, 126);
+  test_two_comp_mod(-129, 8, 127);
+}
+
+TEST(Data, TwoCompModStress) {
+  Data dst;
+  Data src(129);
+  Data width(8);
+  for (size_t iter = 0; iter < 100000; iter++) {
+    dst.two_comp_mod(src, width);
+    ASSERT_EQ(-127, dst.get_int());
+  }
+}
+
+TEST(Data, TestEq) {
+  int v = 99;
+  Data d(v);
+  ASSERT_TRUE(d.test_eq(v));
 }


### PR DESCRIPTION
- tentative support for signed fields (with a 2-complement representation)
- added support for 3 new operators: 2-complement modulo (`two_comp_mod`), bool-to-data conversion (`b2d`) and data-to-bool conversion (`d2b`)
- updated JSON format doc to reflect these changes
- added an extra unit test for ternary operator