### PR TITLE
added the ability to set the queue rate for each individual port

### DIFF
--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -99,9 +99,14 @@ class SimpleSwitch : public Switch {
     return 0;
   }
 
-  int set_egress_queue_rate(const uint64_t rate_pps) {
+  int set_egress_queue_rate(int port, const uint64_t rate_pps) {
+    egress_buffers.set_rate(port, rate_pps);
+    return 0;
+  }
+
+  int set_all_egress_queue_rates(const uint64_t rate_pps) {
     for (int i = 0; i < max_port; i++) {
-      egress_buffers.set_rate(i, rate_pps);
+      set_egress_queue_rate(i, rate_pps);
     }
     return 0;
   }

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -43,9 +43,14 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
         self.sswitch_client.set_egress_queue_depth(depth)
 
     def do_set_queue_rate(self, line):
-        "Set rate of egress queue: set_queue_rate <rate_pps>"
-        rate = int(line)
-        self.sswitch_client.set_egress_queue_rate(rate)
+        "Set rate of one / all egress queue(s): set_queue_rate <rate_pps> [<egress_port>]"
+        args = line.split()
+        rate = int(args[0])
+        if len(args) > 1:
+            port = int(args[1])
+            self.sswitch_client.set_egress_queue_rate(port, rate)
+        else:
+            self.sswitch_client.set_all_egress_queue_rates(rate)
 
     def do_mirroring_add(self, line):
         "Add mirroring mapping: mirroring_add <mirror_id> <egress_port>"

--- a/targets/simple_switch/tests/test_queueing.cpp
+++ b/targets/simple_switch/tests/test_queueing.cpp
@@ -196,7 +196,7 @@ TEST_F(SimpleSwitch_QueueingP4, QueueingAdvanced) {
   int recv_port = -1;
 
   // setting egress queue rate to 1 pps
-  test_switch->set_egress_queue_rate(1u);
+  test_switch->set_all_egress_queue_rates(1u);
 
   const size_t nb_packets = 16u;
   for (size_t i = 0; i < nb_packets; i++) {

--- a/targets/simple_switch/thrift/simple_switch.thrift
+++ b/targets/simple_switch/thrift/simple_switch.thrift
@@ -28,6 +28,7 @@ service SimpleSwitch {
   i32 mirroring_mapping_get_egress_port(1:i32 mirror_id);
 
   i32 set_egress_queue_depth(1:i32 depth_pkts);
-  i32 set_egress_queue_rate(1:i64 rate_pps);
+  i32 set_egress_queue_rate(1:i32 port_num, 2:i64 rate_pps);
+  i32 set_all_egress_queue_rates(1:i64 rate_pps);
 
 }

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.ipp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.ipp
@@ -55,9 +55,15 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     return switch_->set_egress_queue_depth(static_cast<size_t>(depth_pkts));
   }
 
-  int32_t set_egress_queue_rate(const int64_t rate_pps) {
+  int32_t set_egress_queue_rate(const int32_t port_num, const int64_t rate_pps) {
     bm::Logger::get()->trace("set_egress_queue_rate");
-    return switch_->set_egress_queue_rate(static_cast<uint64_t>(rate_pps));
+    return switch_->set_egress_queue_rate(port_num,
+                                          static_cast<uint64_t>(rate_pps));
+  }
+
+  int32_t set_all_egress_queue_rates(const int64_t rate_pps) {
+    bm::Logger::get()->trace("set_all_egress_queue_rates");
+    return switch_->set_all_egress_queue_rates(static_cast<uint64_t>(rate_pps));
   }
 
 private:


### PR DESCRIPTION
- for the simple_switch target
- the CLI command `set_queue_rate` can now take an optional second argument (port number). If this second argument is missing, it will apply to all ports