### PR TITLE
added the ability to set the queue depth for each individual port

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -160,6 +160,34 @@ SimpleSwitch::start_and_return() {
   t3.detach();
 }
 
+int
+SimpleSwitch::set_egress_queue_depth(int port, const size_t depth_pkts) {
+  egress_buffers.set_capacity(port, depth_pkts);
+  return 0;
+}
+
+int
+SimpleSwitch::set_all_egress_queue_depths(const size_t depth_pkts) {
+  for (int i = 0; i < max_port; i++) {
+    set_egress_queue_depth(i, depth_pkts);
+  }
+  return 0;
+}
+
+int
+SimpleSwitch::set_egress_queue_rate(int port, const uint64_t rate_pps) {
+  egress_buffers.set_rate(port, rate_pps);
+  return 0;
+}
+
+int
+SimpleSwitch::set_all_egress_queue_rates(const uint64_t rate_pps) {
+  for (int i = 0; i < max_port; i++) {
+    set_egress_queue_rate(i, rate_pps);
+  }
+  return 0;
+}
+
 void
 SimpleSwitch::transmit_thread() {
   while (1) {

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -92,24 +92,11 @@ class SimpleSwitch : public Switch {
     return get_mirroring_mapping(mirror_id);
   }
 
-  int set_egress_queue_depth(const size_t depth_pkts) {
-    for (int i = 0; i < max_port; i++) {
-      egress_buffers.set_capacity(i, depth_pkts);
-    }
-    return 0;
-  }
+  int set_egress_queue_depth(int port, const size_t depth_pkts);
+  int set_all_egress_queue_depths(const size_t depth_pkts);
 
-  int set_egress_queue_rate(int port, const uint64_t rate_pps) {
-    egress_buffers.set_rate(port, rate_pps);
-    return 0;
-  }
-
-  int set_all_egress_queue_rates(const uint64_t rate_pps) {
-    for (int i = 0; i < max_port; i++) {
-      set_egress_queue_rate(i, rate_pps);
-    }
-    return 0;
-  }
+  int set_egress_queue_rate(int port, const uint64_t rate_pps);
+  int set_all_egress_queue_rates(const uint64_t rate_pps);
 
  private:
   static constexpr size_t nb_egress_threads = 4u;

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -38,9 +38,14 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
         self.sswitch_client = sswitch_client
 
     def do_set_queue_depth(self, line):
-        "Set depth of egress queue: set_queue_depth <nb_pkts>"
-        depth = int(line)
-        self.sswitch_client.set_egress_queue_depth(depth)
+        "Set depth of one / all egress queue(s): set_queue_depth <nb_pkts> [<egress_port>]"
+        args = line.split()
+        depth = int(args[0])
+        if len(args) > 1:
+            port = int(args[1])
+            self.sswitch_client.set_egress_queue_depth(port, depth)
+        else:
+            self.sswitch_client.set_all_egress_queue_depths(depth)
 
     def do_set_queue_rate(self, line):
         "Set rate of one / all egress queue(s): set_queue_rate <rate_pps> [<egress_port>]"

--- a/targets/simple_switch/thrift/simple_switch.thrift
+++ b/targets/simple_switch/thrift/simple_switch.thrift
@@ -27,7 +27,8 @@ service SimpleSwitch {
   i32 mirroring_mapping_delete(1:i32 mirror_id);
   i32 mirroring_mapping_get_egress_port(1:i32 mirror_id);
 
-  i32 set_egress_queue_depth(1:i32 depth_pkts);
+  i32 set_egress_queue_depth(1:i32 port_num, 2:i32 depth_pkts);
+  i32 set_all_egress_queue_depths(1:i32 depth_pkts);
   i32 set_egress_queue_rate(1:i32 port_num, 2:i64 rate_pps);
   i32 set_all_egress_queue_rates(1:i64 rate_pps);
 

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.ipp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.ipp
@@ -50,9 +50,16 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     return switch_->mirroring_mapping_get(mirror_id);
   }
 
-  int32_t set_egress_queue_depth(const int32_t depth_pkts) {
+  int32_t set_egress_queue_depth(const int32_t port_num, const int32_t depth_pkts) {
     bm::Logger::get()->trace("set_egress_queue_depth");
-    return switch_->set_egress_queue_depth(static_cast<size_t>(depth_pkts));
+    return switch_->set_egress_queue_depth(port_num,
+                                           static_cast<uint32_t>(depth_pkts));
+  }
+
+  int32_t set_all_egress_queue_depths(const int32_t depth_pkts) {
+    bm::Logger::get()->trace("set_all_egress_queue_depths");
+    return switch_->set_all_egress_queue_depths(
+        static_cast<uint32_t>(depth_pkts));
   }
 
   int32_t set_egress_queue_rate(const int32_t port_num, const int64_t rate_pps) {


### PR DESCRIPTION
- for the simple switch target
- did the same thing already for queue rate
- seized the opportunity to move the functions to set queue rate and depth from simple_switch.h to simple_switch.cpp