### PR TITLE
reset_target_state, pre improvements

### DIFF
--- a/include/bm/bm_sim/simple_pre.h
+++ b/include/bm/bm_sim/simple_pre.h
@@ -92,6 +92,7 @@ class McSimplePre {
   McReturnCode mc_node_destroy(const l1_hdl_t);
   McReturnCode mc_node_update(const l1_hdl_t l1_hdl,
                               const PortMap &port_map);
+  void reset_state();
 
   //! This is the only "dataplane" method for this class. It takes as input a
   //! multicast group id (set during pipeline processing) and returns a vector
@@ -131,7 +132,6 @@ class McSimplePre {
   static constexpr int MGID_TABLE_SIZE = 4096;
   static constexpr int L1_MAX_ENTRIES = 4096;
   static constexpr int L2_MAX_ENTRIES = 8192;
-  bool pre_debug{0};
 
   struct MgidEntry {
     mgrp_t mgid{};
@@ -169,14 +169,15 @@ class McSimplePre {
             lag_map(lag_map) {}
   };
 
+  // internal version, which does not acquire the lock
+  void reset_state_();
+
   std::unordered_map<mgrp_hdl_t, MgidEntry> mgid_entries{};
   std::unordered_map<l1_hdl_t, L1Entry> l1_entries{};
   std::unordered_map<l2_hdl_t, L2Entry> l2_entries{};
   HandleMgr l1_handles{};
   HandleMgr l2_handles{};
-  mutable boost::shared_mutex mgid_lock{};
-  mutable boost::shared_mutex l1_lock{};
-  mutable boost::shared_mutex l2_lock{};
+  mutable boost::shared_mutex mutex{};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/simple_pre_lag.h
+++ b/include/bm/bm_sim/simple_pre_lag.h
@@ -48,6 +48,8 @@ class McSimplePreLAG : public McSimplePre {
   McReturnCode mc_set_lag_membership(const lag_id_t lag_index,
                                      const PortMap &port_map);
 
+  void reset_state();
+
   //! TODO(unknown)
   std::vector<McOut> replicate(const McIn) const;
 
@@ -64,7 +66,6 @@ class McSimplePreLAG : public McSimplePre {
   };
 
   std::unordered_map<lag_id_t, LagEntry> lag_entries{};
-  mutable boost::shared_mutex lag_lock{};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -118,6 +118,11 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   //! threads) and call this function when you are ready to process packets.
   virtual void start_and_return() = 0;
 
+  //! You can override this method in your target. It will be called whenever
+  //! reset_state() is invoked by the control plane. For example, the
+  //! simple_switch target uses this to reset PRE state.
+  virtual void reset_target_state() { }
+
   //! Returns the Thrift port used for the runtime RPC server.
   int get_runtime_port() { return thrift_port; }
 

--- a/src/bm_sim/simple_pre.cpp
+++ b/src/bm_sim/simple_pre.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <bm/bm_sim/simple_pre.h>
+#include <bm/bm_sim/logger.h>
 
 #include <string>
 #include <vector>
@@ -32,28 +33,24 @@ namespace bm {
 
 McSimplePre::McReturnCode
 McSimplePre::mc_mgrp_create(const mgrp_t mgid, mgrp_hdl_t *mgrp_hdl) {
-  boost::unique_lock<boost::shared_mutex> lock(mgid_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   size_t num_entries = mgid_entries.size();
   if (num_entries >= MGID_TABLE_SIZE) {
-    std::cout << "mgrp create failed. mgid table full!\n";
+    Logger::get()->error("mgrp create failed, mgid table full");
     return TABLE_FULL;
   }
   *mgrp_hdl = mgid;
   MgidEntry mgid_entry(mgid);
   mgid_entries.insert(std::make_pair(*mgrp_hdl, std::move(mgid_entry)));
-  if (pre_debug) {
-    std::cout << "mgrp node created for mgid : " << mgid << "\n";
-  }
+  Logger::get()->debug("mgrp node created for mgid {}", mgid);
   return SUCCESS;
 }
 
 McSimplePre::McReturnCode
 McSimplePre::mc_mgrp_destroy(mgrp_hdl_t mgrp_hdl) {
-  boost::unique_lock<boost::shared_mutex> lock(mgid_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   mgid_entries.erase(mgrp_hdl);
-  if (pre_debug) {
-    std::cout << "mgrp node deleted for mgid : " << mgrp_hdl << "\n";
-  }
+  Logger::get()->debug("mgrp node deleted for mgid {}", mgrp_hdl);
   return SUCCESS;
 }
 
@@ -61,63 +58,56 @@ McSimplePre::McReturnCode
 McSimplePre::mc_node_create(const rid_t rid,
                             const PortMap &portmap,
                             l1_hdl_t *l1_hdl) {
-  boost::unique_lock<boost::shared_mutex> lock1(l1_lock);
-  boost::unique_lock<boost::shared_mutex> lock2(l2_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   l2_hdl_t l2_hdl;
   size_t num_l1_entries = l1_entries.size();
   size_t num_l2_entries = l2_entries.size();
   if (num_l1_entries >= L1_MAX_ENTRIES) {
-    std::cout << "node create failed. l1 table full!\n";
+    Logger::get()->error("node create failed, l1 table full");
     return TABLE_FULL;
   }
   if (num_l2_entries >= L2_MAX_ENTRIES) {
-    std::cout << "node create failed. l2 table full!\n";
+    Logger::get()->error("node create failed, l2 table full");
     return TABLE_FULL;
   }
   if (l1_handles.get_handle(l1_hdl)) {
-    std::cout << "node create failed. l1 handle failed!\n";
+    Logger::get()->error("node create failed, failed to obtain l1 handle");
     return ERROR;
   }
   if (l2_handles.get_handle(&l2_hdl)) {
-    std::cout << "node create failed. l2 handle failed!\n";
+    Logger::get()->error("node create failed, failed to obtain l2 handle");
     return ERROR;
   }
   l1_entries.insert(std::make_pair(*l1_hdl, L1Entry(rid)));
   L1Entry &l1_entry = l1_entries[*l1_hdl];
   l1_entry.l2_hdl = l2_hdl;
   l2_entries.insert(std::make_pair(l2_hdl, L2Entry(*l1_hdl, portmap)));
-  if (pre_debug) {
-    std::cout << "node created for rid : " << rid << "\n";
-  }
+  Logger::get()->debug("node created for rid {}", rid);
   return SUCCESS;
 }
 
 McSimplePre::McReturnCode
 McSimplePre::mc_node_associate(const mgrp_hdl_t mgrp_hdl,
                                const l1_hdl_t l1_hdl) {
-  boost::unique_lock<boost::shared_mutex> lock1(mgid_lock);
-  boost::unique_lock<boost::shared_mutex> lock2(l1_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   if (!l1_handles.valid_handle(l1_hdl)) {
-    std::cout << "node associate failed. invalid l1 handle\n";
+    Logger::get()->error("node associate failed, invalid l1 handle");
     return INVALID_L1_HANDLE;
   }
   MgidEntry &mgid_entry = mgid_entries[mgrp_hdl];
   L1Entry &l1_entry = l1_entries[l1_hdl];
   mgid_entry.l1_list.push_back(l1_hdl);
   l1_entry.mgrp_hdl = mgrp_hdl;
-  if (pre_debug) {
-    std::cout << "node associated with mgid : " << mgrp_hdl << "\n";
-  }
+  Logger::get()->debug("node associated with mgid {}", mgrp_hdl);
   return SUCCESS;
 }
 
 McSimplePre::McReturnCode
 McSimplePre::mc_node_dissociate(const mgrp_hdl_t mgrp_hdl,
                                 const l1_hdl_t l1_hdl) {
-  boost::unique_lock<boost::shared_mutex> lock1(mgid_lock);
-  boost::unique_lock<boost::shared_mutex> lock2(l1_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   if (!l1_handles.valid_handle(l1_hdl)) {
-    std::cout << "node dissociate failed. invalid l1 handle\n";
+    Logger::get()->error("node dissociate failed, invalid l1 handle");
     return INVALID_L1_HANDLE;
   }
   MgidEntry &mgid_entry = mgid_entries[mgrp_hdl];
@@ -127,56 +117,61 @@ McSimplePre::mc_node_dissociate(const mgrp_hdl_t mgrp_hdl,
                                        l1_hdl),
                            mgid_entry.l1_list.end());
   l1_entry.mgrp_hdl = 0;
-  if (pre_debug) {
-    std::cout << "node dissociated with mgid : " << mgrp_hdl << "\n";
-  }
+  Logger::get()->debug("node dissociated with mgid {}", mgrp_hdl);
   return SUCCESS;
 }
 
 McSimplePre::McReturnCode
 McSimplePre::mc_node_destroy(const l1_hdl_t l1_hdl) {
-  boost::unique_lock<boost::shared_mutex> lock1(l1_lock);
-  boost::unique_lock<boost::shared_mutex> lock2(l2_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   rid_t rid;
   if (!l1_handles.valid_handle(l1_hdl)) {
-    std::cout << "node destroy failed. invalid l1 handle!\n";
+    Logger::get()->error("node destroy failed, invalid l1 handle");
     return INVALID_L1_HANDLE;
   }
   L1Entry &l1_entry = l1_entries[l1_hdl];
   rid = l1_entry.rid;
   l2_entries.erase(l1_entry.l2_hdl);
   if (l2_handles.release_handle(l1_entry.l2_hdl)) {
-    std::cout << "node destroy failed. invalid l2 handle!\n";
+    Logger::get()->error("node destroy failed, invalid l2 handle");
     return INVALID_L2_HANDLE;
   }
   l1_entries.erase(l1_hdl);
-  if (l1_handles.release_handle(l1_hdl)) {
-    std::cout << "node destroy failed. invalid l2 handle!\n";
-    return INVALID_L1_HANDLE;
-  }
-  if (pre_debug) {
-    std::cout << "node destroyed for rid : " << rid << "\n";
-  }
+  assert(!l1_handles.release_handle(l1_hdl));
+  Logger::get()->debug("node destroyed for rid {}", rid);
   return SUCCESS;
 }
 
 McSimplePre::McReturnCode
 McSimplePre::mc_node_update(const l1_hdl_t l1_hdl,
                             const PortMap &port_map) {
-  boost::unique_lock<boost::shared_mutex> lock1(l1_lock);
-  boost::unique_lock<boost::shared_mutex> lock2(l2_lock);
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
   if (!l1_handles.valid_handle(l1_hdl)) {
-    std::cout << "node update failed. invalid l1 handle!\n";
+    Logger::get()->error("node update failed, invalid l1 handle");
     return INVALID_L1_HANDLE;
   }
   L1Entry &l1_entry = l1_entries[l1_hdl];
   l2_hdl_t l2_hdl = l1_entry.l2_hdl;
   L2Entry &l2_entry = l2_entries[l2_hdl];
   l2_entry.port_map = port_map;
-  if (pre_debug) {
-    std::cout << "node updated for rid : " << l1_entry.rid << "\n";
-  }
+  Logger::get()->debug("node updated for rid {}", l1_entry.rid);
   return SUCCESS;
+}
+
+void
+McSimplePre::reset_state_() {
+  mgid_entries.clear();
+  l1_entries.clear();
+  l2_entries.clear();
+  l1_handles.clear();
+  l2_handles.clear();
+}
+
+void
+McSimplePre::reset_state() {
+  Logger::get()->debug("resetting PRE state");
+  boost::unique_lock<boost::shared_mutex> lock(mutex);
+  reset_state_();
 }
 
 std::vector<McSimplePre::McOut>
@@ -184,14 +179,18 @@ McSimplePre::replicate(const McSimplePre::McIn ingress_info) const {
   std::vector<McSimplePre::McOut> egress_info_list;
   egress_port_t port_id;
   McSimplePre::McOut egress_info;
-  boost::shared_lock<boost::shared_mutex> lock1(mgid_lock);
-  boost::shared_lock<boost::shared_mutex> lock2(l1_lock);
-  boost::shared_lock<boost::shared_mutex> lock3(l2_lock);
-  const MgidEntry mgid_entry = mgid_entries.at(ingress_info.mgid);
-  for (l1_hdl_t l1_hdl : mgid_entry.l1_list) {
-    const L1Entry l1_entry = l1_entries.at(l1_hdl);
+  boost::shared_lock<boost::shared_mutex> lock(mutex);
+  auto mgid_it = mgid_entries.find(ingress_info.mgid);
+  if (mgid_it == mgid_entries.end()) {
+    Logger::get()->warn("Replication requested for mgid {}, which is not known "
+                        "to the PRE", ingress_info.mgid);
+    return {};
+  }
+  const MgidEntry &mgid_entry = mgid_it->second;
+  for (const l1_hdl_t l1_hdl : mgid_entry.l1_list) {
+    const L1Entry &l1_entry = l1_entries.at(l1_hdl);
     egress_info.rid = l1_entry.rid;
-    const L2Entry l2_entry = l2_entries.at(l1_entry.l2_hdl);
+    const L2Entry &l2_entry = l2_entries.at(l1_entry.l2_hdl);
     // Port replication
     for (port_id = 0; port_id < l2_entry.port_map.size(); port_id++) {
       if (l2_entry.port_map[port_id]) {
@@ -200,10 +199,7 @@ McSimplePre::replicate(const McSimplePre::McIn ingress_info) const {
       }
     }
   }
-  if (pre_debug) {
-    std::cout << "number of packets replicated : "
-              << egress_info_list.size() << "\n";
-  }
+  BMLOG_DEBUG("number of packets replicated : {}", egress_info_list.size());
   return egress_info_list;
 }
 

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -226,6 +226,7 @@ SwitchWContexts::reset_state() {
     ErrorCode rc = cxt.reset_state();
     if (rc != ErrorCode::SUCCESS) return rc;
   }
+  reset_target_state();
   return ErrorCode::SUCCESS;
 }
 

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -160,6 +160,12 @@ SimpleSwitch::start_and_return() {
   t3.detach();
 }
 
+void
+SimpleSwitch::reset_target_state() {
+  bm::Logger::get()->debug("Resetting simple_switch target-specific state");
+  get_component<McSimplePreLAG>()->reset_state();
+}
+
 int
 SimpleSwitch::set_egress_queue_depth(int port, const size_t depth_pkts) {
   egress_buffers.set_capacity(port, depth_pkts);

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -75,9 +75,11 @@ class SimpleSwitch : public Switch {
   // by default, swapping is off
   explicit SimpleSwitch(int max_port = 256, bool enable_swap = false);
 
-  int receive(int port_num, const char *buffer, int len);
+  int receive(int port_num, const char *buffer, int len) override;
 
-  void start_and_return();
+  void start_and_return() override;
+
+  void reset_target_state() override;
 
   int mirroring_mapping_add(mirror_id_t mirror_id, int egress_port) {
     mirroring_map[mirror_id] = egress_port;

--- a/tests/test_pre.cpp
+++ b/tests/test_pre.cpp
@@ -25,8 +25,7 @@
 
 using namespace bm;
 
-TEST(McSimplePre, Replicate)
-{
+TEST(McSimplePre, Replicate) {
   McSimplePre pre;
   McSimplePre::mgrp_t mgid = 0x400;
   McSimplePre::mgrp_hdl_t mgrp_hdl;
@@ -135,8 +134,7 @@ TEST(McSimplePre, Replicate)
 }
 
 
-TEST(McSimplePreLAG, Replicate)
-{
+TEST(McSimplePreLAG, Replicate) {
   McSimplePreLAG pre;
   McSimplePre::mgrp_t mgid = 0x400;
   McSimplePre::mgrp_hdl_t mgrp_hdl;
@@ -333,4 +331,32 @@ TEST(McSimplePreLAG, Replicate)
   }
   rc = pre.mc_mgrp_destroy(mgrp_hdl);
   ASSERT_EQ(rc, McSimplePre::SUCCESS);
+}
+
+TEST(McSimplePreLAG, ResetState) {
+  McSimplePreLAG pre;
+  McSimplePreLAG::mgrp_hdl_t mgrp;
+  McSimplePreLAG::l1_hdl_t l1h;
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_mgrp_create(1, &mgrp));
+  McSimplePreLAG::PortMap port_map;
+  port_map[1] = 1;
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_node_create(0, port_map, {}, &l1h));
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_node_associate(mgrp, l1h));
+  McSimplePreLAG::LagMap lag_map;
+  lag_map[2] = 1;
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_node_create(0, {}, lag_map, &l1h));
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_node_associate(mgrp, l1h));
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_set_lag_membership(2, port_map));
+
+  auto mc_out_1 = pre.replicate({1});
+  ASSERT_EQ(2u, mc_out_1.size());
+
+  // probably not the best test for reset
+  pre.reset_state();
+  auto mc_out_2 = pre.replicate({1});
+  ASSERT_EQ(0u, mc_out_2.size());
+
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_mgrp_create(1, &mgrp));
+  auto mc_out_3 = pre.replicate({1});
+  ASSERT_EQ(0u, mc_out_3.size());
 }


### PR DESCRIPTION
- targets can now override `SwitchWContexts::reset_target_state()` and reset their own specific state when the reset_state control plane function is called (`bm_reset_state` in the Thrift RPC service)
- the simple_switch target overrides this function to reset the PRE state
- consequently I added a `reset_state` method to the 2 PRE implementations which are part of the bmv2 core library
- the following improvements were also made to the PRE implementations:
  * a single mutex instead one per data structure to simplify the code (the benefits of having several mutexes was dubious)
  * replace `std::cout` logs with `bm::Logger` logs
  * remove crash when PRE is invoked with an unknown mgid (replaced by warning)
  * ...