### PR TITLE
added customizable crc16 and crc32

### DIFF
--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -303,6 +303,12 @@ class Context final {
   dump_table(const std::string& table_name,
              std::ostream *stream) const;
 
+  template <typename T>
+  CustomCrcErrorCode
+  set_crc_custom_parameters(
+      const std::string &calc_name,
+      const typename CustomCrcMgr<T>::crc_config_t &crc_config);
+
   // ---------- End runtime interfaces ----------
 
   using ReadLock = std::unique_lock<std::mutex>;

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -252,6 +252,16 @@ class RuntimeInterface {
   virtual std::string
   get_config_md5() const = 0;
 
+  virtual CustomCrcErrorCode
+  set_crc16_custom_parameters(
+      size_t cxt_id, const std::string &calc_name,
+      const CustomCrcMgr<uint16_t>::crc_config_t &crc16_config) = 0;
+
+  virtual CustomCrcErrorCode
+  set_crc32_custom_parameters(
+      size_t cxt_id, const std::string &calc_name,
+      const CustomCrcMgr<uint32_t>::crc_config_t &crc32_config) = 0;
+
   virtual ErrorCode
   reset_state() = 0;
 

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -539,6 +539,17 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   std::string get_config() const override;
   std::string get_config_md5() const override;
 
+  // conscious choice not to use templates here (or could not use virtual)
+  CustomCrcErrorCode
+  set_crc16_custom_parameters(
+      size_t cxt_id, const std::string &calc_name,
+      const CustomCrcMgr<uint16_t>::crc_config_t &crc16_config) override;
+
+  CustomCrcErrorCode
+  set_crc32_custom_parameters(
+      size_t cxt_id, const std::string &calc_name,
+      const CustomCrcMgr<uint32_t>::crc_config_t &crc32_config) override;
+
   // ---------- End RuntimeInterface ----------
 
  protected:

--- a/src/bm_runtime/Standard_server.ipp
+++ b/src/bm_runtime/Standard_server.ipp
@@ -666,6 +666,38 @@ public:
     _return.append(stream.str());
   }
 
+  void bm_set_crc16_custom_parameters(const int32_t cxt_id, const std::string& calc_name, const BmCrc16Config& crc16_config) {
+    Logger::get()->trace("bm_set_crc16_custom_parameters");
+    CustomCrcMgr<uint16_t>::crc_config_t c;
+    c.polynomial = static_cast<uint16_t>(crc16_config.polynomial);
+    c.initial_remainder = static_cast<uint16_t>(crc16_config.initial_remainder);
+    c.final_xor_value = static_cast<uint16_t>(crc16_config.final_xor_value);
+    c.data_reflected = crc16_config.data_reflected;
+    c.remainder_reflected = crc16_config.remainder_reflected;
+    auto rc = switch_->set_crc16_custom_parameters(cxt_id, calc_name, c);
+    if(rc != CustomCrcErrorCode::SUCCESS) {
+      InvalidCrcOperation ico;
+      ico.code = static_cast<CrcErrorCode::type>(rc); // TODO
+      throw ico;
+    }
+  }
+
+  void bm_set_crc32_custom_parameters(const int32_t cxt_id, const std::string& calc_name, const BmCrc32Config& crc32_config) {
+    Logger::get()->trace("bm_set_crc32_custom_parameters");
+    CustomCrcMgr<uint32_t>::crc_config_t c;
+    c.polynomial = static_cast<uint32_t>(crc32_config.polynomial);
+    c.initial_remainder = static_cast<uint32_t>(crc32_config.initial_remainder);
+    c.final_xor_value = static_cast<uint32_t>(crc32_config.final_xor_value);
+    c.data_reflected = crc32_config.data_reflected;
+    c.remainder_reflected = crc32_config.remainder_reflected;
+    auto rc = switch_->set_crc32_custom_parameters(cxt_id, calc_name, c);
+    if(rc != CustomCrcErrorCode::SUCCESS) {
+      InvalidCrcOperation ico;
+      ico.code = static_cast<CrcErrorCode::type>(rc); // TODO
+      throw ico;
+    }
+  }
+
   void bm_reset_state() {
     Logger::get()->trace("bm_reset_state");
     switch_->reset_state();

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -453,7 +453,7 @@ Context::register_reset(const std::string &register_name) {
 }
 
 MatchErrorCode
-Context::dump_table(const std::string& table_name,
+Context::dump_table(const std::string &table_name,
                     std::ostream *stream) const {
   boost::shared_lock<boost::shared_mutex> lock(request_mutex);
   MatchTableAbstract *abstract_table =
@@ -462,6 +462,24 @@ Context::dump_table(const std::string& table_name,
   abstract_table->dump(stream);
   return MatchErrorCode::SUCCESS;
 }
+
+template <typename T>
+CustomCrcErrorCode
+Context::set_crc_custom_parameters(
+    const std::string &calc_name,
+    const typename CustomCrcMgr<T>::crc_config_t &crc_config) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  auto *named_calculation = p4objects_rt->get_named_calculation(calc_name);
+  if (!named_calculation) return CustomCrcErrorCode::INVALID_CALCULATION_NAME;
+  return CustomCrcMgr<T>::update_config(named_calculation, crc_config);
+}
+
+template CustomCrcErrorCode Context::set_crc_custom_parameters<uint16_t>(
+    const std::string &calc_name,
+    const CustomCrcMgr<uint16_t>::crc_config_t &crc_config);
+template CustomCrcErrorCode Context::set_crc_custom_parameters<uint32_t>(
+    const std::string &calc_name,
+    const CustomCrcMgr<uint32_t>::crc_config_t &crc_config);
 
 // ---------- End runtime interfaces ----------
 

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -333,6 +333,22 @@ SwitchWContexts::get_config_md5() const {
   return get_config_md5_();
 }
 
+CustomCrcErrorCode
+SwitchWContexts::set_crc16_custom_parameters(
+    size_t cxt_id, const std::string &calc_name,
+    const CustomCrcMgr<uint16_t>::crc_config_t &crc16_config) {
+  return contexts.at(cxt_id).set_crc_custom_parameters<uint16_t>(
+      calc_name, crc16_config);
+}
+
+CustomCrcErrorCode
+SwitchWContexts::set_crc32_custom_parameters(
+    size_t cxt_id, const std::string &calc_name,
+    const CustomCrcMgr<uint32_t>::crc_config_t &crc32_config) {
+  return contexts.at(cxt_id).set_crc_custom_parameters<uint32_t>(
+      calc_name, crc32_config);
+}
+
 // Switch convenience class
 
 Switch::Switch(bool enable_swap)

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -178,6 +178,32 @@ struct DevMgrPortInfo {
   4:map<string, string> extra;
 }
 
+struct BmCrc16Config {
+  1:i16 polynomial;
+  2:i16 initial_remainder;
+  3:i16 final_xor_value;
+  4:bool data_reflected;
+  5:bool remainder_reflected;
+}
+
+struct BmCrc32Config {
+  1:i32 polynomial;
+  2:i32 initial_remainder;
+  3:i32 final_xor_value;
+  4:bool data_reflected;
+  5:bool remainder_reflected;
+}
+
+enum CrcErrorCode {
+  INVALID_CALCULATION_NAME = 1,
+  WRONG_TYPE_CALCULATION = 2,
+  INVALID_CONFIG = 3
+}
+
+exception InvalidCrcOperation {
+ 1:CrcErrorCode code
+}
+
 service Standard {
 	
   // table operations
@@ -470,6 +496,18 @@ service Standard {
     1:i32 cxt_id,
     2:string table_name
   )
+
+  void bm_set_crc16_custom_parameters(
+    1:i32 cxt_id,
+    2:string calc_name,
+    3:BmCrc16Config crc16_config
+  ) throws (1:InvalidCrcOperation ouch)
+
+  void bm_set_crc32_custom_parameters(
+    1:i32 cxt_id,
+    2:string calc_name,
+    3:BmCrc32Config crc32_config
+  ) throws (1:InvalidCrcOperation ouch)
 
   void bm_reset_state()
 


### PR DESCRIPTION
- added customizable crc16 and crc32
- added support for setting custom crc parameters in the Thrift RPC service and in the runtime_CLI
- added info log message when crc is updated
- in the P4 program, use `crc16_custom` (resp. `crc32_custom`) instead of `crc16` (resp `crc32`) as the hash algorithm type
- for each field list calculation, you can choose the crc polynomial (and more) at runtime by using the CLI commands `set_crc16_parameters` (resp. `set_crc32_parameters`)