### PR TITLE
added ability to provide a target-specific command-line options parser

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -64,4 +64,5 @@ bm/bm_sim/switch.h \
 bm/bm_sim/simple_pre.h \
 bm/bm_sim/simple_pre_lag.h \
 bm/bm_sim/tables.h \
+bm/bm_sim/target_parser.h \
 bm/bm_sim/transport.h

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -27,6 +27,7 @@
 #include <map>
 
 #include "logger.h"
+#include "target_parser.h"
 
 namespace bm {
 
@@ -55,7 +56,7 @@ class OptionsParser {
   friend class SwitchWContexts;
 
  public:
-  void parse(int argc, char *argv[]);
+  void parse(int argc, char *argv[], TargetParserIface *tp);
 
  private:
   std::string config_file_path{};

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -84,6 +84,7 @@
 #include "dev_mgr.h"
 #include "phv_source.h"
 #include "lookup_structures.h"
+#include "target_parser.h"
 
 namespace bm {
 
@@ -175,7 +176,17 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   //! int status = simple_switch->init_from_command_line_options(argc, argv);
   //! if (status != 0) std::exit(status);
   //! @endcode
-  int init_from_command_line_options(int argc, char *argv[]);
+  //! If your target has custom CLI options, you can provide a pointer \p tp to
+  //! a secondary parser which implements the TargetParserIface interface. The
+  //! bm::TargetParserIface::parse method will be called with the unrecognized
+  //! options. Target specific options need to appear after bmv2 general
+  //! options on the command line, and be separated from them by `--`. For
+  //! example:
+  //! @code
+  //! <my_target_exe> prog.json -i 0@eth0 -- --my-option v
+  //! @endcode
+  int init_from_command_line_options(int argc, char *argv[],
+                                     TargetParserIface *tp = nullptr);
 
   //! Retrieve the shared pointer to an object of type `T` previously added to
   //! the switch using add_component().

--- a/include/bm/bm_sim/target_parser.h
+++ b/include/bm/bm_sim/target_parser.h
@@ -1,0 +1,121 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+//! @file target_parser.h
+//! This file defines the bm::TargetParserIface interface and the
+//! bm::TargetParserBasic class, which implements this interface. Target
+//! developpers can write their own parser class, implementing
+//! bm::TargetParserIface, and pass an instance of it to
+//! bm::SwitchWContexts::init_from_command_line_options, which will be used to
+//! parse target-specific options. bm::TargetParserBasic is a simple example of
+//! a parser class, which should be enough for many targets.
+
+#ifndef BM_BM_SIM_TARGET_PARSER_H_
+#define BM_BM_SIM_TARGET_PARSER_H_
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <ostream>
+
+namespace bm {
+
+//! Interface for target-specific command-line options parsers.
+class TargetParserIface {
+ public:
+  virtual ~TargetParserIface() { }
+
+  //! Called by the bmv2 command-line options parser, when it is done with
+  //! general options. All options appearing after `--` will be passed to this
+  //! function. \p errstream should be used to log error messages.
+  virtual int parse(const std::vector<std::string> &more_options,
+                    std::ostream *errstream) = 0;
+
+  //! Called by the bmv2 command-line parser, when the user requests the help
+  //! description (with `-h`, `--help`).
+  virtual void help_msg(std::ostream *outstream) const = 0;
+};
+
+class TargetParserBasicStore;
+
+//! A basic target-specific command-line options parser, which should be enough
+//! for many targets.
+class TargetParserBasic final : public TargetParserIface {
+ public:
+  //! Return codes for this class
+  enum class ReturnCode {
+    //! successful operation
+    SUCCESS = 0,
+    //! option was already added to the parser
+    DUPLICATE_OPTION,
+    //! option name not recognized (did not call add)
+    INVALID_OPTION_NAME,
+    //! the option was not provided by the user
+    OPTION_NOT_PROVIDED,
+    //! type mismatch, you used the wrong get method
+    INVALID_OPTION_TYPE
+  };
+
+  //! Constructor
+  TargetParserBasic();
+  ~TargetParserBasic();
+
+  //! See bm::TargetParserIface::parse. Make sure all possible options have been
+  //! registered using add_string_option(), add_int_option() or
+  //! add_flag_option().
+  int parse(const std::vector<std::string> &more_options,
+            std::ostream *errstream) override;
+
+  //! See bm::TargetParserIface::help_msg
+  void help_msg(std::ostream *outstream) const override;
+
+  //! Add a command-line option `--<name>` with a value of type string, along
+  //! with a help string that will be displayed by help_msg(). You will need to
+  //! call get_string_option() to retrieve the value.
+  ReturnCode add_string_option(const std::string &name,
+                               const std::string &help_str);
+  //! Add a command-line option `--<name>` with a value of type int, along with
+  //! a help string that will be displayed by help_msg(). You will need to call
+  //! get_int_option() to retrieve the value.
+  ReturnCode add_int_option(const std::string &name,
+                            const std::string &help_str);
+  //! Add a command-line flag `--<name>`, along with a help string that will be
+  //! displayed by help_msg().You will need to call get_flag_option() to
+  //! determine presence / absence of the flag.
+  ReturnCode add_flag_option(const std::string &name,
+                             const std::string &help_str);
+
+  //! Retrieve the value of command-line option `--<name>`. The option needs to
+  //! have been previously registered with add_string_option().
+  ReturnCode get_string_option(const std::string &name, std::string *v) const;
+  //! Retrieve the value of command-line option `--<name>`. The option needs to
+  //! have been previously registered with add_int_option().
+  ReturnCode get_int_option(const std::string &name, int *v) const;
+  //! Determine whether the command-line flag `--<name>` was present / absent on
+  //! the command line.
+  ReturnCode get_flag_option(const std::string &name, bool *v) const;
+
+ private:
+  std::unique_ptr<TargetParserBasicStore> var_store;
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_TARGET_PARSER_H_

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -56,6 +56,7 @@ stateful.cpp \
 switch.cpp \
 simple_pre.cpp \
 simple_pre_lag.cpp \
+target_parser.cpp \
 transport.cpp \
 utils.h \
 xxhash.c \

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -106,9 +106,10 @@ SwitchWContexts::init_objects(const std::string &json_path, int dev_id,
 }
 
 int
-SwitchWContexts::init_from_command_line_options(int argc, char *argv[]) {
+SwitchWContexts::init_from_command_line_options(int argc, char *argv[],
+                                                TargetParserIface *tp) {
   OptionsParser parser;
-  parser.parse(argc, argv);
+  parser.parse(argc, argv, tp);
 
   notifications_addr = parser.notifications_addr;
   auto transport = std::shared_ptr<TransportIface>(

--- a/src/bm_sim/target_parser.cpp
+++ b/src/bm_sim/target_parser.cpp
@@ -1,0 +1,165 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/target_parser.h>
+
+#include <boost/program_options.hpp>
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <unordered_set>
+#include <ostream>
+
+namespace po = boost::program_options;
+
+namespace bm {
+
+class TargetParserBasicStore {
+  typedef TargetParserBasic::ReturnCode ReturnCode;
+
+ public:
+  template <typename T>
+  ReturnCode add_option(const std::string &name, const std::string &help_str) {
+    if (has_option(name)) return ReturnCode::DUPLICATE_OPTION;
+    description.add_options()(name.c_str(), po::value<T>(), help_str.c_str());
+    option_added(name);
+    return ReturnCode::SUCCESS;
+  }
+
+  int parse(const std::vector<std::string> &more_options,
+            std::ostream *errstream) {
+    po::command_line_parser parser(more_options);
+    try {
+      po::store(parser.options(description).run(), vm);
+      po::notify(vm);
+    }
+    catch (const std::exception &e) {
+      if (errstream) (*errstream) << e.what() << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
+  template <typename T>
+  ReturnCode get_option(const std::string &name, T *v) const {
+    if (!has_option(name)) return ReturnCode::INVALID_OPTION_NAME;
+    if (!vm.count(name)) return ReturnCode::OPTION_NOT_PROVIDED;
+    try {
+      *v = vm.at(name).as<T>();
+      return ReturnCode::SUCCESS;
+    }
+    catch (...) {
+      return ReturnCode::INVALID_OPTION_TYPE;
+    }
+  }
+
+  void get_description(std::ostream *outstream) const {
+    (*outstream) << description;
+  }
+
+ private:
+  bool has_option(const std::string &name) const {
+    return option_names.find(name) != option_names.end();
+  }
+
+  void option_added(const std::string &name) {
+    option_names.insert(name);
+  }
+
+  // could not get boost to throw a duplicate_option_error in case of duplicate
+  // option names, so I'm using a set to keep track
+  std::unordered_set<std::string> option_names;
+  po::options_description description{"Target options"};
+  po::variables_map vm;
+};
+
+template <>
+TargetParserBasic::ReturnCode
+TargetParserBasicStore::add_option<bool>(const std::string &name,
+                                         const std::string &help_str) {
+  if (has_option(name)) return ReturnCode::DUPLICATE_OPTION;
+  description.add_options()(name.c_str(), help_str.c_str());
+  option_added(name);
+  return ReturnCode::SUCCESS;
+}
+
+template <>
+TargetParserBasic::ReturnCode
+TargetParserBasicStore::get_option<bool>(const std::string &name,
+                                         bool *v) const {
+  if (!has_option(name)) return ReturnCode::INVALID_OPTION_NAME;
+  *v = static_cast<bool>(vm.count(name));
+  return ReturnCode::SUCCESS;
+}
+
+
+TargetParserBasic::TargetParserBasic()
+    : var_store(new TargetParserBasicStore()) { }
+
+
+TargetParserBasic::~TargetParserBasic() { }
+
+int
+TargetParserBasic::parse(const std::vector<std::string> &more_options,
+                         std::ostream *errstream) {
+  return var_store->parse(more_options, errstream);
+}
+
+void
+TargetParserBasic::help_msg(std::ostream *outstream) const {
+  var_store->get_description(outstream);
+}
+
+TargetParserBasic::ReturnCode
+TargetParserBasic::add_string_option(const std::string &name,
+                                     const std::string &help_str) {
+  return var_store->add_option<std::string>(name, help_str);
+}
+
+TargetParserBasic::ReturnCode
+TargetParserBasic::add_int_option(const std::string &name,
+                                  const std::string &help_str) {
+  return var_store->add_option<int>(name, help_str);
+}
+
+TargetParserBasic::ReturnCode
+TargetParserBasic::add_flag_option(const std::string &name,
+                                   const std::string &help_str) {
+  return var_store->add_option<bool>(name, help_str);
+}
+
+TargetParserBasic::ReturnCode
+TargetParserBasic::get_string_option(const std::string &name,
+                                     std::string *v) const {
+  return var_store->get_option<std::string>(name, v);
+}
+
+TargetParserBasic::ReturnCode
+TargetParserBasic::get_int_option(const std::string &name, int *v) const {
+  return var_store->get_option<int>(name, v);
+}
+
+TargetParserBasic::ReturnCode
+TargetParserBasic::get_flag_option(const std::string &name, bool *v) const {
+  return var_store->get_option<bool>(name, v);
+}
+
+}  // namespace bm

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -50,7 +50,8 @@ test_fields \
 test_devmgr \
 test_packet \
 test_extern \
-test_switch
+test_switch \
+test_target_parser
 
 check_PROGRAMS = $(TESTS) test_all
 
@@ -79,6 +80,7 @@ test_devmgr_SOURCES        = $(common_source) test_devmgr.cpp
 test_packet_SOURCES        = $(common_source) test_packet.cpp
 test_extern_SOURCES        = $(common_source) test_extern.cpp
 test_switch_SOURCES        = $(common_source) test_switch.cpp
+test_target_parser_SOURCES = $(common_source) test_target_parser.cpp
 test_all_SOURCES = $(common_source) \
 test_actions.cpp \
 test_checksums.cpp \
@@ -103,7 +105,8 @@ test_fields.cpp \
 test_devmgr.cpp \
 test_packet.cpp \
 test_extern.cpp \
-test_switch.cpp
+test_switch.cpp \
+test_target_parser.cpp
 
 EXTRA_DIST = \
 testdata/en0.pcap \

--- a/tests/test_target_parser.cpp
+++ b/tests/test_target_parser.cpp
@@ -1,0 +1,277 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <string>
+
+#include <boost/filesystem.hpp>
+
+#include <bm/bm_sim/options_parse.h>
+#include <bm/bm_sim/target_parser.h>
+
+using namespace bm;
+
+namespace fs = boost::filesystem;
+
+namespace {
+
+struct TargetParserDummy : public TargetParserIface {
+  int parse(const std::vector<std::string> &more_options,
+            std::ostream *errstream) override {
+    (void) errstream;
+    input = more_options;
+    return 0;
+  }
+
+  void help_msg(std::ostream *outstream) const override {
+    (void) outstream;
+  }
+
+  std::vector<std::string> input;
+};
+
+struct Argv {
+  Argv &push_back(std::string arg) {
+    args.push_back(std::move(arg));
+    return *this;
+  }
+
+  char **get() {
+    argv.clear();
+    for (const auto &s : args)
+      argv.push_back(const_cast<char *>(s.c_str()));
+    argv.push_back(nullptr);
+    return argv.data();
+  }
+
+  const std::vector<std::string> &get_vec() const {
+    return args;
+  }
+
+  size_t size() const {
+    return args.size();
+  }
+
+  std::vector<char *> argv;
+  std::vector<std::string> args;
+};
+
+}  // namespace
+
+
+class TargetParserIfaceTest : public ::testing::Test {
+ protected:
+  TargetParserDummy dummy_parser;
+  fs::path json_path;
+
+  TargetParserIfaceTest() {
+    json_path = fs::path(TESTDATADIR) / fs::path("empty_config.json");
+  }
+};
+
+TEST_F(TargetParserIfaceTest, NoDispatch) {
+  OptionsParser main_parser;
+  Argv argv;
+  argv.push_back("name")
+      .push_back(json_path.string());
+  main_parser.parse(argv.size(), argv.get(), nullptr);
+  SUCCEED();
+}
+
+TEST_F(TargetParserIfaceTest, DispatchEmpty) {
+  OptionsParser main_parser;
+  Argv argv;
+  argv.push_back("name")
+      .push_back(json_path.string());
+  main_parser.parse(argv.size(), argv.get(), &dummy_parser);
+  ASSERT_EQ(0u, dummy_parser.input.size());
+}
+
+TEST_F(TargetParserIfaceTest, DispatchOne) {
+  OptionsParser main_parser;
+  Argv argv;
+  argv.push_back("name")
+      .push_back(json_path.string())
+      .push_back("--")
+      .push_back("--unknown").push_back("9");
+  main_parser.parse(argv.size(), argv.get(), &dummy_parser);
+  ASSERT_EQ(2u, dummy_parser.input.size());
+  ASSERT_EQ("--unknown", dummy_parser.input.at(0));
+  ASSERT_EQ("9", dummy_parser.input.at(1));
+}
+
+TEST_F(TargetParserIfaceTest, DispatchPositional) {
+  OptionsParser main_parser;
+  Argv argv;
+  argv.push_back("name")
+      .push_back(json_path.string())
+      .push_back("--")
+      .push_back("unknown");
+  main_parser.parse(argv.size(), argv.get(), &dummy_parser);
+  ASSERT_EQ(1u, dummy_parser.input.size());
+  ASSERT_EQ("unknown", dummy_parser.input.at(0));
+}
+
+TEST_F(TargetParserIfaceTest, DispatchMany) {
+  OptionsParser main_parser;
+  Argv argv;
+  argv.push_back("name")
+      .push_back(json_path.string())
+      .push_back("--");
+  size_t iters = 16;
+  for (size_t i = 0; i < iters; i++) {
+    argv.push_back("--unknown" + std::to_string(i))
+        .push_back(std::to_string(i));
+  }
+  main_parser.parse(argv.size(), argv.get(), &dummy_parser);
+  ASSERT_EQ(2 * iters, dummy_parser.input.size());  
+}
+
+class TargetParserBasicTest : public ::testing::Test {
+ protected:
+  typedef TargetParserBasic::ReturnCode ReturnCode;
+
+  TargetParserBasic target_parser;
+  fs::path json_path;
+
+  TargetParserBasicTest() {
+    json_path = fs::path(TESTDATADIR) / fs::path("empty_config.json");
+  }
+};
+
+TEST_F(TargetParserBasicTest, TargetOptionString) {
+  const std::string option_name = "option1";
+  const std::string strv = "strv";
+  std::string v;
+  target_parser.add_string_option(option_name, "hs1");
+  Argv argv;
+  argv.push_back("--" + option_name).push_back(strv);
+  target_parser.parse(argv.get_vec(), nullptr);
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.get_string_option(option_name, &v));
+  ASSERT_EQ(strv, v);
+}
+
+TEST_F(TargetParserBasicTest, TargetOptionInt) {
+  const std::string option_name = "option1";
+  const int intv = 9;
+  int v;
+  target_parser.add_int_option(option_name, "hs1");
+  Argv argv;
+  argv.push_back("--" + option_name).push_back(std::to_string(intv));
+  target_parser.parse(argv.get_vec(), nullptr);
+  ASSERT_EQ(ReturnCode::SUCCESS, target_parser.get_int_option(option_name, &v));
+  ASSERT_EQ(intv, v);
+}
+
+TEST_F(TargetParserBasicTest, TargetOptionFlag) {
+  const std::string option_name_1 = "option1";
+  const std::string option_name_2 = "option2";
+  bool v1, v2;
+  target_parser.add_flag_option(option_name_1, "hs1");
+  target_parser.add_flag_option(option_name_2, "hs2");
+  Argv argv;
+  argv.push_back("--" + option_name_1);
+  target_parser.parse(argv.get_vec(), nullptr);
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.get_flag_option(option_name_1, &v1));
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.get_flag_option(option_name_2, &v2));
+  ASSERT_TRUE(v1);
+  ASSERT_FALSE(v2);
+}
+
+TEST_F(TargetParserBasicTest, TargetOptionMix) {
+  target_parser.add_string_option("option1", "hs1");
+  target_parser.add_flag_option("option2", "hs2");
+  target_parser.add_int_option("option3", "hs3");
+  std::string strv;
+  int intv;
+  bool boolv;
+  Argv argv;
+  argv.push_back("--option1").push_back("1")
+      .push_back("--option2")
+      .push_back("--option3").push_back("1");
+  target_parser.parse(argv.get_vec(), nullptr);
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.get_string_option("option1", &strv));
+  ASSERT_EQ("1", strv);
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.get_flag_option("option2", &boolv));
+  ASSERT_TRUE(boolv);
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.get_int_option("option3", &intv));
+  ASSERT_EQ(1, intv);
+}
+
+TEST_F(TargetParserBasicTest, HelpMsg) {
+  // TODO(antonin): worth it to have a better test?
+  std::stringstream os;
+  ASSERT_EQ("", os.str());
+  target_parser.add_string_option("option1", "hs1");
+  target_parser.help_msg(&os);
+  ASSERT_NE("", os.str());
+}
+
+TEST_F(TargetParserBasicTest, DuplicateOption) {
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.add_string_option("option1", "hs1"));
+  ASSERT_EQ(ReturnCode::DUPLICATE_OPTION,
+            target_parser.add_string_option("option1", "hs1"));
+  ASSERT_EQ(ReturnCode::DUPLICATE_OPTION,
+            target_parser.add_int_option("option1", "hs1"));
+}
+
+TEST_F(TargetParserBasicTest, InvalidOptionName) {
+  int v;
+  ASSERT_EQ(ReturnCode::INVALID_OPTION_NAME,
+            target_parser.get_int_option("unknown", &v));
+}
+
+TEST_F(TargetParserBasicTest, InvalidOptionType) {
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.add_string_option("option1", "hs1"));
+  Argv argv;
+  argv.push_back("--option1").push_back("1");
+  target_parser.parse(argv.get_vec(), nullptr);
+  int v;
+  ASSERT_EQ(ReturnCode::INVALID_OPTION_TYPE,
+            target_parser.get_int_option("option1", &v));
+}
+
+TEST_F(TargetParserBasicTest, OptionNotProvided) {
+  ASSERT_EQ(ReturnCode::SUCCESS,
+            target_parser.add_string_option("option1", "hs1"));
+  Argv argv;
+  target_parser.parse(argv.get_vec(), nullptr);
+  std::string v;
+  ASSERT_EQ(ReturnCode::OPTION_NOT_PROVIDED,
+            target_parser.get_string_option("option1", &v));
+}
+
+TEST_F(TargetParserBasicTest, ParsingError) {
+  Argv argv;
+  argv.push_back("--option1").push_back("1");
+  std::stringstream os;
+  ASSERT_NE(0, target_parser.parse(argv.get_vec(), &os));
+  ASSERT_EQ("unrecognised option '--option1'\n", os.str());
+}


### PR DESCRIPTION
- target implementers can now subclass `bm::TargetParserIface` and pass an instance of their class to `bm::Switch::init_from_command_line_options`
- target specific options need to come after general bmv2 options, and be separated from these by `--`. I had originally considered using boost program_options' `allow_unregistered` for this, but it wasn't working too well and I believe the new scheme is cleaner.