### PR TITLE
small fixes for compiling with clang

### DIFF
--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -46,7 +46,7 @@ packet_handler(int port_num, const char *buffer, int len, void *cookie) {
 SwitchWContexts::SwitchWContexts(size_t nb_cxts, bool enable_swap)
   : DevMgr(),
     nb_cxts(nb_cxts), contexts(nb_cxts), enable_swap(enable_swap),
-    phv_source(std::move(PHVSourceIface::make_phv_source(nb_cxts))) {
+    phv_source(PHVSourceIface::make_phv_source(nb_cxts)) {
   for (size_t i = 0; i < nb_cxts; i++) {
     contexts.at(i).set_cxt_id(i);
   }

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -20,6 +20,8 @@
 
 #include <bm/bm_sim/actions.h>
 
+#include <random>
+
 template <typename... Args>
 using ActionPrimitive = bm::ActionPrimitive<Args...>;
 

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -254,7 +254,7 @@ SimpleSwitch::copy_ingress_pkt(
         .set(phv->get_field(p.header, p.offset));
   }
   phv_copy->get_field("standard_metadata.instance_type").set(copy_type);
-  return std::move(packet_copy);
+  return packet_copy;
 }
 
 void

--- a/tests/test_tables.cpp
+++ b/tests/test_tables.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <random>
 #include <thread>
 #include <future>
 #include <bm/bm_sim/tables.h>


### PR DESCRIPTION
I tried to compile with clang 3.8, and it spotted some small problems:

* some unnecessary `std::move`
* missing headers

