### PR TITLE
explicit python2 shebang in scripts

### DIFF
--- a/mininet/1sw_demo.py
+++ b/mininet/1sw_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/mininet/stress_test_ipv4.py.in
+++ b/mininet/stress_test_ipv4.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/targets/simple_switch/simple_switch_CLI.in
+++ b/targets/simple_switch/simple_switch_CLI.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
+++ b/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tests/stress_tests/gen_udp_tcp_traffic.py
+++ b/tests/stress_tests/gen_udp_tcp_traffic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/bm_CLI.in
+++ b/tools/bm_CLI.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/bm_nanomsg_events.in
+++ b/tools/bm_nanomsg_events.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/bm_p4dbg.in
+++ b/tools/bm_p4dbg.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -9,7 +9,7 @@ return_status=0
 function run_cpplint() {
     # $1 is directory
     # $2 is root
-    $THIS_DIR/cpplint.py --root=$2 $( find $1 -name \*.h -or -name \*.cpp )
+    python2 $THIS_DIR/cpplint.py --root=$2 $( find $1 -name \*.h -or -name \*.cpp )
     return_status=$(($return_status || $?))
 }
 

--- a/tools/nanomsg_client.py
+++ b/tools/nanomsg_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/p4dbg.py
+++ b/tools/p4dbg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2013-present Barefoot Networks, Inc.
 #


### PR DESCRIPTION
Explicitly calling python2 does not cause any harm to systems where python2 is default, and it makes the scripts work out of the box on systems where python3 is default (e.g. Arch Linux)