### PR TITLE
creating a branch with no clang regression to run tests while LLVM ap…

### DIFF
--- a/.travis.yml.bak
+++ b/.travis.yml.bak
@@ -14,11 +14,15 @@ matrix:
       compiler: gcc
       env: COMPILER=g++-5 GCOV=gcov-5
 
+    - os: linux
+      env: COMPILER=clang++-3.6
+
 addons:
   apt:
     sources:
       - boost-latest
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.6
     packages:
       - libjudy-dev
       - libgmp-dev
@@ -37,6 +41,7 @@ addons:
       - pkg-config
       - g++-4.8
       - g++-5
+      - clang-3.6
       - libssl-dev
       - python-pip
 


### PR DESCRIPTION
…t repo down
This is a temporary change and I will revert it when the issue is fixed (or an alternative is found). See http://llvm.org/apt/