### PR TITLE
added ability to retrieve a single entry / member / group

### DIFF
--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -250,14 +250,27 @@ class Context final {
 
   template <typename T>
   MatchErrorCode
+  mt_get_entry(const std::string &table_name, entry_handle_t handle,
+               typename T::Entry *entry) const;
+
+  template <typename T>
+  MatchErrorCode
   mt_get_default_entry(const std::string &table_name,
                        typename T::Entry *default_entry) const;
 
   std::vector<MatchTableIndirect::Member>
   mt_indirect_get_members(const std::string &table_name) const;
 
+  MatchErrorCode
+  mt_indirect_get_member(const std::string &table_name, grp_hdl_t grp,
+                         MatchTableIndirect::Member *member) const;
+
   std::vector<MatchTableIndirectWS::Group>
   mt_indirect_ws_get_groups(const std::string &table_name) const;
+
+  MatchErrorCode
+  mt_indirect_ws_get_group(const std::string &table_name, grp_hdl_t grp,
+                           MatchTableIndirectWS::Group *group) const;
 
   MatchErrorCode
   mt_read_counters(const std::string &table_name,

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -207,6 +207,20 @@ class RuntimeInterface {
                              const std::string &table_name) const = 0;
 
   virtual MatchErrorCode
+  mt_get_entry(size_t cxt_id, const std::string &table_name,
+               entry_handle_t handle, MatchTable::Entry *entry) const = 0;
+
+  virtual MatchErrorCode
+  mt_indirect_get_entry(size_t cxt_id, const std::string &table_name,
+                        entry_handle_t handle,
+                        MatchTableIndirect::Entry *entry) const = 0;
+
+  virtual MatchErrorCode
+  mt_indirect_ws_get_entry(size_t cxt_id, const std::string &table_name,
+                           entry_handle_t handle,
+                           MatchTableIndirectWS::Entry *entry) const = 0;
+
+  virtual MatchErrorCode
   mt_get_default_entry(size_t cxt_id, const std::string &table_name,
                        MatchTable::Entry *entry) const = 0;
 
@@ -223,9 +237,19 @@ class RuntimeInterface {
   mt_indirect_get_members(size_t cxt_id,
                           const std::string &table_name) const = 0;
 
+  virtual MatchErrorCode
+  mt_indirect_get_member(size_t cxt_id, const std::string &table_name,
+                         mbr_hdl_t mbr,
+                         MatchTableIndirect::Member *member) const = 0;
+
   virtual std::vector<MatchTableIndirectWS::Group>
   mt_indirect_ws_get_groups(size_t cxt_id,
                             const std::string &table_name) const = 0;
+
+  virtual MatchErrorCode
+  mt_indirect_ws_get_group(size_t cxt_id, const std::string &table_name,
+                           grp_hdl_t grp,
+                           MatchTableIndirectWS::Group *group) const = 0;
 
   virtual Counter::CounterErrorCode
   read_counters(size_t cxt_id,

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -467,6 +467,29 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   }
 
   MatchErrorCode
+  mt_get_entry(size_t cxt_id, const std::string &table_name,
+               entry_handle_t handle, MatchTable::Entry *entry) const override {
+    return contexts.at(cxt_id).mt_get_entry<MatchTable>(
+        table_name, handle, entry);
+  }
+
+  MatchErrorCode
+  mt_indirect_get_entry(size_t cxt_id, const std::string &table_name,
+                        entry_handle_t handle,
+                        MatchTableIndirect::Entry *entry) const override {
+    return contexts.at(cxt_id).mt_get_entry<MatchTableIndirect>(
+        table_name, handle, entry);
+  }
+
+  MatchErrorCode
+  mt_indirect_ws_get_entry(size_t cxt_id, const std::string &table_name,
+                           entry_handle_t handle,
+                           MatchTableIndirectWS::Entry *entry) const override {
+    return contexts.at(cxt_id).mt_get_entry<MatchTableIndirectWS>(
+        table_name, handle, entry);
+  }
+
+  MatchErrorCode
   mt_get_default_entry(size_t cxt_id, const std::string &table_name,
                        MatchTable::Entry *entry) const override {
     return contexts.at(cxt_id).mt_get_default_entry<MatchTable>(
@@ -495,10 +518,25 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).mt_indirect_get_members(table_name);
   }
 
+  MatchErrorCode
+  mt_indirect_get_member(size_t cxt_id, const std::string &table_name,
+                         mbr_hdl_t mbr,
+                         MatchTableIndirect::Member *member) const override {
+    return contexts.at(cxt_id).mt_indirect_get_member(table_name, mbr, member);
+  }
+
   std::vector<MatchTableIndirectWS::Group>
   mt_indirect_ws_get_groups(size_t cxt_id,
                             const std::string &table_name) const override {
     return contexts.at(cxt_id).mt_indirect_ws_get_groups(table_name);
+  }
+
+  MatchErrorCode
+  mt_indirect_ws_get_group(size_t cxt_id, const std::string &table_name,
+                           grp_hdl_t grp,
+                           MatchTableIndirectWS::Group *group) const override {
+    return contexts.at(cxt_id).mt_indirect_ws_get_group(
+        table_name, grp, group);
   }
 
   MatchErrorCode

--- a/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
+++ b/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
@@ -68,6 +68,8 @@ def main():
         sys.exit(2)
     thrift_port = str(9090 + rand)
     device_id = str(rand)
+    # TODO(antonin): fragile if the name changes in the bmv2 code
+    rpc_path = "/tmp/bmv2-{}-notifications.ipc".format(device_id)
 
     # makes sure that the switch will start right away
     simple_switch_p = subprocess.Popen(
@@ -87,6 +89,13 @@ def main():
 
     time.sleep(1)
 
+    def cleanup():
+        simple_switch_p.kill()
+        try:
+            os.remove(rpc_path)
+        except:
+            pass
+
     cmd = ["@abs_top_srcdir@/tools/runtime_CLI.py",
            "--thrift-port", thrift_port]
     out = None
@@ -102,7 +111,7 @@ def main():
         rc = p.returncode
 
         if rc:
-            simple_switch_p.kill()
+            cleanup()
             sys.exit(3)
 
     assert(out)
@@ -126,7 +135,7 @@ def main():
                 success = False
 
         if success:
-            simple_switch_p.kill()
+            cleanup()
             sys.exit(0)
         else:
             print "Expected"
@@ -134,7 +143,7 @@ def main():
             print "But got"
             print "\n".join(out_parsed)
 
-    simple_switch_p.kill()
+    cleanup()
     sys.exit(4)
 
 if __name__ == '__main__':

--- a/targets/simple_switch/tests/CLI_tests/testdata/table_dump.in
+++ b/targets/simple_switch/tests/CLI_tests/testdata/table_dump.in
@@ -4,3 +4,6 @@ table_indirect_add ecmp_group 10.0.0.1/12 => 0
 table_indirect_add_member_to_group ecmp_group 0 0
 table_indirect_add_with_group ecmp_group 10.0.1.1/32 => 0
 table_dump ecmp_group
+table_dump_entry ecmp_group 0
+table_dump_member ecmp_group 0
+table_dump_group ecmp_group 0

--- a/targets/simple_switch/tests/CLI_tests/testdata/table_dump.out
+++ b/targets/simple_switch/tests/CLI_tests/testdata/table_dump.out
@@ -37,3 +37,14 @@ Dumping default entry
 EMPTY
 ==========
 ????
+Dumping entry 0x0
+Match key:
+* ipv4.dstAddr        : LPM       0a000001/12
+Index: member(0)
+????
+Dumping member 0
+Action entry: set_nhop - 0a000001, 01
+????
+Dumping group 0
+Members: [0]
+????

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -432,6 +432,12 @@ service Standard {
     2:string table_name
   ) throws (1:InvalidTableOperation ouch),
 
+  BmMtEntry bm_mt_get_entry(
+    1:i32 cxt_id,
+    2:string table_name,
+    3:BmEntryHandle entry_handle
+  ) throws (1:InvalidTableOperation ouch),
+
   BmActionEntry bm_mt_get_default_entry(
     1:i32 cxt_id,
     2:string table_name
@@ -442,9 +448,21 @@ service Standard {
     2:string table_name
   ) throws (1:InvalidTableOperation ouch),
 
+  BmMtIndirectMember bm_mt_indirect_get_member(
+    1:i32 cxt_id,
+    2:string table_name,
+    3:BmMemberHandle mbr_handle
+  ) throws (1:InvalidTableOperation ouch),
+
   list<BmMtIndirectWsGroup> bm_mt_indirect_ws_get_groups(
     1:i32 cxt_id,
     2:string table_name
+  ) throws (1:InvalidTableOperation ouch),
+
+  BmMtIndirectWsGroup bm_mt_indirect_ws_get_group(
+    1:i32 cxt_id,
+    2:string table_name,
+    3:BmGroupHandle grp_handle
   ) throws (1:InvalidTableOperation ouch),
 
   // indirect counters


### PR DESCRIPTION
- Thrift RPC service updated
- added matching commands to CLI: `table_dump_entry`, `table_dump_member`, `table_dump_group`
- using these CLI commands to test added functionality (in `CLI_tests`)