### PR TITLE
got rid of '.ipp' files for Thrift server implementations

### DIFF
--- a/include/bm/bm_runtime/bm_runtime.h
+++ b/include/bm/bm_runtime/bm_runtime.h
@@ -19,15 +19,11 @@ using namespace thrift_provider::protocol;
 
 namespace bm_runtime {
 
-using boost::shared_ptr;
-
 extern TMultiplexedProcessor *processor_;
-extern bm::SwitchWContexts *switch_;
 
-template <typename Handler, typename Processor, typename S>
-int add_service(const std::string &service_name) {
-  // TODO(antonin): static_cast too error prone here?
-  shared_ptr<Handler> handler(new Handler(static_cast<S *>(switch_)));
+template <typename Iface, typename Processor>
+int add_service(const std::string &service_name,
+                boost::shared_ptr<Iface> handler) {
   processor_->registerProcessor(service_name,
 				shared_ptr<TProcessor>(new Processor(handler)));
   return 0;

--- a/src/bm_runtime/Makefile.am
+++ b/src/bm_runtime/Makefile.am
@@ -7,6 +7,6 @@ noinst_LTLIBRARIES = libbmruntime.la
 
 libbmruntime_la_SOURCES = \
 server.cpp \
-Standard_server.ipp \
-SimplePre_server.ipp \
-SimplePreLAG_server.ipp
+Standard_server.cpp \
+SimplePre_server.cpp \
+SimplePreLAG_server.cpp

--- a/src/bm_runtime/SimplePreLAG_server.cpp
+++ b/src/bm_runtime/SimplePreLAG_server.cpp
@@ -20,6 +20,7 @@
 
 #include <bm/SimplePreLAG.h>
 
+#include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/simple_pre_lag.h>
 #include <bm/bm_sim/logger.h>
 
@@ -136,4 +137,9 @@ private:
   std::vector<std::shared_ptr<McSimplePreLAG> > pres{};
 };
 
-} }
+boost::shared_ptr<SimplePreLAGIf> get_handler(SwitchWContexts *switch_) {
+  return boost::shared_ptr<SimplePreLAGHandler>(new SimplePreLAGHandler(switch_));
+}
+
+}  // namespace simple_pre_lag
+}  // namespace bm_runtime

--- a/src/bm_runtime/SimplePre_server.cpp
+++ b/src/bm_runtime/SimplePre_server.cpp
@@ -20,6 +20,7 @@
 
 #include <bm/SimplePre.h>
 
+#include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/simple_pre.h>
 #include <bm/bm_sim/logger.h>
 
@@ -122,4 +123,9 @@ private:
   std::vector<std::shared_ptr<McSimplePre> > pres{};
 };
 
-} }
+boost::shared_ptr<SimplePreIf> get_handler(SwitchWContexts *switch_) {
+  return boost::shared_ptr<SimplePreHandler>(new SimplePreHandler(switch_));
+}
+
+}  // namespace simple_pre
+}  // namespace bm_runtime

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -1036,4 +1036,9 @@ void StandardHandler::copy_one_group(
   for (const auto h : from.mbr_handles) g->mbr_handles.push_back(h);
 }
 
-} }
+boost::shared_ptr<StandardIf> get_handler(SwitchWContexts *switch_) {
+  return boost::shared_ptr<StandardHandler>(new StandardHandler(switch_));
+}
+
+}  // namespace standard
+}  // namespace bm_runtime

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -58,7 +58,7 @@ noinst_LTLIBRARIES = libsimpleswitch.la
 
 libsimpleswitch_la_SOURCES = \
 simple_switch.cpp simple_switch.h primitives.cpp \
-thrift/src/SimpleSwitch_server.ipp
+thrift/src/SimpleSwitch_server.cpp
 
 bin_PROGRAMS = simple_switch
 

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -1,3 +1,23 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
 #include <bm/SimpleSwitch.h>
 
 #ifdef P4THRIFT
@@ -21,21 +41,15 @@ namespace thrift_provider = apache::thrift;
 
 #include "simple_switch.h"
 
-using namespace ::thrift_provider;
-using namespace ::thrift_provider::protocol;
-using namespace ::thrift_provider::transport;
-using namespace ::thrift_provider::server;
-
-using boost::shared_ptr;
-
-using namespace  ::sswitch_runtime;
+namespace sswitch_runtime {
 
 class SimpleSwitchHandler : virtual public SimpleSwitchIf {
  public:
-  SimpleSwitchHandler(Switch *sw)
-    : switch_(dynamic_cast<SimpleSwitch *>(sw)) { }
+  explicit SimpleSwitchHandler(SimpleSwitch *sw)
+    : switch_(sw) { }
 
-  int32_t mirroring_mapping_add(const int32_t mirror_id, const int32_t egress_port) {
+  int32_t mirroring_mapping_add(const int32_t mirror_id,
+                                const int32_t egress_port) {
     bm::Logger::get()->trace("mirroring_mapping_add");
     return switch_->mirroring_mapping_add(mirror_id, egress_port);
   }
@@ -50,7 +64,8 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     return switch_->mirroring_mapping_get(mirror_id);
   }
 
-  int32_t set_egress_queue_depth(const int32_t port_num, const int32_t depth_pkts) {
+  int32_t set_egress_queue_depth(const int32_t port_num,
+                                 const int32_t depth_pkts) {
     bm::Logger::get()->trace("set_egress_queue_depth");
     return switch_->set_egress_queue_depth(port_num,
                                            static_cast<uint32_t>(depth_pkts));
@@ -62,7 +77,8 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
         static_cast<uint32_t>(depth_pkts));
   }
 
-  int32_t set_egress_queue_rate(const int32_t port_num, const int64_t rate_pps) {
+  int32_t set_egress_queue_rate(const int32_t port_num,
+                                const int64_t rate_pps) {
     bm::Logger::get()->trace("set_egress_queue_rate");
     return switch_->set_egress_queue_rate(port_num,
                                           static_cast<uint64_t>(rate_pps));
@@ -73,6 +89,12 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     return switch_->set_all_egress_queue_rates(static_cast<uint64_t>(rate_pps));
   }
 
-private:
+ private:
   SimpleSwitch *switch_;
 };
+
+boost::shared_ptr<SimpleSwitchIf> get_handler(SimpleSwitch *sw) {
+  return boost::shared_ptr<SimpleSwitchHandler>(new SimpleSwitchHandler(sw));
+}
+
+}  // namespace sswitch_runtime


### PR DESCRIPTION
- clean-up of `bm_runtime`
- was an unusual way of structuring code which could have been confusing to people
- new way is more parallel-compilation friendly