### PR TITLE
updating 'standard_metadata.packet_length' when recirculating packet

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -490,6 +490,8 @@ SimpleSwitch::egress_thread(size_t worker_id) {
         }
         phv_copy->get_field("standard_metadata.instance_type")
             .set(PKT_INSTANCE_TYPE_RECIRC);
+        phv_copy->get_field("standard_metadata.packet_length")
+            .set(packet_copy->get_data_size());
         input_buffer.push_front(std::move(packet_copy));
         continue;
       }


### PR DESCRIPTION
Issue reported by Jeferson Santiago da Silva on p4-dev (http://lists.p4.org/pipermail/p4-dev_lists.p4.org/2016-July/000421.html)