### PR TITLE
updating packet length at the beginning of egress (simple_switch)

### DIFF
--- a/src/bm_sim/packet.cpp
+++ b/src/bm_sim/packet.cpp
@@ -214,7 +214,7 @@ Packet::Packet(Packet &&other) noexcept
       copy_id(other.copy_id), ingress_length(other.ingress_length),
       signature(other.signature), payload_size(other.payload_size),
       ingress_ts(other.ingress_ts), ingress_ts_ms(other.ingress_ts_ms),
-      phv_source(other.phv_source) {
+  phv_source(other.phv_source), registers(other.registers) {
   buffer = std::move(other.buffer);
   phv = std::move(other.phv);
 }
@@ -232,6 +232,7 @@ Packet::operator=(Packet &&other) noexcept {
   ingress_ts = other.ingress_ts;
   ingress_ts_ms = other.ingress_ts_ms;
   phv_source = other.phv_source;
+  registers = other.registers;
 
   std::swap(buffer, other.buffer);
   std::swap(phv, other.phv);

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -167,6 +167,9 @@ class add_header : public ActionPrimitive<Header &> {
     if (!hdr.is_valid()) {
       hdr.reset();
       hdr.mark_valid();
+      // updated the length packet register (register 0)
+      auto &packet = get_packet();
+      packet.set_register(0, packet.get_register(0) + hdr.get_nbytes_packet());
     }
   }
 };
@@ -183,7 +186,12 @@ REGISTER_PRIMITIVE(add_header_fast);
 
 class remove_header : public ActionPrimitive<Header &> {
   void operator ()(Header &hdr) {
-    hdr.mark_invalid();
+    if (hdr.is_valid()) {
+      // updated the length packet register (register 0)
+      auto &packet = get_packet();
+      packet.set_register(0, packet.get_register(0) - hdr.get_nbytes_packet());
+      hdr.mark_invalid();
+    }
   }
 };
 

--- a/targets/simple_switch/tests/testdata/packet_redirect.json
+++ b/targets/simple_switch/tests/testdata/packet_redirect.json
@@ -123,14 +123,20 @@
             "metadata": false
         },
         {
-            "name": "metaA",
+            "name": "hdrA2",
             "id": 2,
+            "header_type": "hdrA_t",
+            "metadata": false
+        },
+        {
+            "name": "metaA",
+            "id": 3,
             "header_type": "metaA_t",
             "metadata": true
         },
         {
             "name": "intrinsic_metadata",
-            "id": 3,
+            "id": 4,
             "header_type": "intrinsic_metadata_t",
             "metadata": true
         }
@@ -154,6 +160,15 @@
                                     "value": "hdrA"
                                 }
                             ]
+                        },
+                        {
+                            "op": "extract",
+                            "parameters": [
+                                {
+                                    "type": "regular",
+                                    "value": "hdrA2"
+                                }
+                            ]
                         }
                     ],
                     "transition_key": [],
@@ -173,15 +188,49 @@
             "name": "deparser",
             "id": 0,
             "order": [
-                "hdrA"
+                "hdrA",
+                "hdrA2"
             ]
         }
     ],
     "meter_arrays": [],
     "actions": [
         {
-            "name": "_recirculate",
+            "name": "_nop",
             "id": 0,
+            "runtime_data": [],
+            "primitives": []
+        },
+        {
+            "name": "_exit",
+            "id": 1,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "exit",
+                    "parameters": []
+                }
+            ]
+        },
+        {
+            "name": "_resubmit",
+            "id": 2,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "resubmit",
+                    "parameters": [
+                        {
+                            "type": "hexstr",
+                            "value": "0x1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "_recirculate",
+            "id": 3,
             "runtime_data": [],
             "primitives": [
                 {
@@ -197,7 +246,7 @@
         },
         {
             "name": "_multicast",
-            "id": 1,
+            "id": 4,
             "runtime_data": [
                 {
                     "name": "mgrp",
@@ -220,12 +269,21 @@
                             "value": 0
                         }
                     ]
+                },
+                {
+                    "op": "remove_header",
+                    "parameters": [
+                        {
+                            "type": "header",
+                            "value": "hdrA2"
+                        }
+                    ]
                 }
             ]
         },
         {
             "name": "_clone_i2e",
-            "id": 2,
+            "id": 5,
             "runtime_data": [
                 {
                     "name": "mirror_id",
@@ -250,7 +308,7 @@
         },
         {
             "name": "_clone_e2e",
-            "id": 3,
+            "id": 6,
             "runtime_data": [
                 {
                     "name": "mirror_id",
@@ -274,8 +332,34 @@
             ]
         },
         {
+            "name": "set_hdr",
+            "id": 7,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "hdrA",
+                                "f2"
+                            ]
+                        },
+                        {
+                            "type": "field",
+                            "value": [
+                                "standard_metadata",
+                                "packet_length"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "name": "_set_port",
-            "id": 4,
+            "id": 8,
             "runtime_data": [
                 {
                     "name": "port",
@@ -314,41 +398,17 @@
                             "value": "0x1"
                         }
                     ]
-                }
-            ]
-        },
-        {
-            "name": "_exit",
-            "id": 5,
-            "runtime_data": [],
-            "primitives": [
+                },
                 {
-                    "op": "exit",
-                    "parameters": []
-                }
-            ]
-        },
-        {
-            "name": "_resubmit",
-            "id": 6,
-            "runtime_data": [],
-            "primitives": [
-                {
-                    "op": "resubmit",
+                    "op": "remove_header",
                     "parameters": [
                         {
-                            "type": "hexstr",
-                            "value": "0x1"
+                            "type": "header",
+                            "value": "hdrA2"
                         }
                     ]
                 }
             ]
-        },
-        {
-            "name": "_nop",
-            "id": 7,
-            "runtime_data": [],
-            "primitives": []
         }
     ],
     "pipelines": [
@@ -396,7 +456,6 @@
                         "_multicast": "t_ingress_2",
                         "_exit": "t_ingress_2"
                     },
-                    "default_action": null,
                     "base_default_next": "t_ingress_2"
                 },
                 {
@@ -436,7 +495,6 @@
                         "_resubmit": null,
                         "_clone_i2e": null
                     },
-                    "default_action": null,
                     "base_default_next": null
                 }
             ],
@@ -480,11 +538,28 @@
                         "_clone_e2e"
                     ],
                     "next_tables": {
-                        "_nop": null,
-                        "_recirculate": null,
-                        "_clone_e2e": null
+                        "_nop": "t_exit",
+                        "_recirculate": "t_exit",
+                        "_clone_e2e": "t_exit"
                     },
-                    "default_action": null,
+                    "base_default_next": "t_exit"
+                },
+                {
+                    "name": "t_exit",
+                    "id": 3,
+                    "match_type": "exact",
+                    "type": "simple",
+                    "max_size": 1,
+                    "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
+                    "key": [],
+                    "actions": [
+                        "set_hdr"
+                    ],
+                    "next_tables": {
+                        "set_hdr": null
+                    },
                     "base_default_next": null
                 }
             ],

--- a/targets/simple_switch/tests/testdata/packet_redirect.p4
+++ b/targets/simple_switch/tests/testdata/packet_redirect.p4
@@ -21,6 +21,7 @@ header_type hdrA_t {
 }
 
 header hdrA_t hdrA;
+header hdrA_t hdrA2;
 
 header_type metaA_t {
     fields {
@@ -55,6 +56,7 @@ metadata intrinsic_metadata_t intrinsic_metadata;
 
 parser start {
     extract(hdrA);
+    extract(hdrA2);
     return ingress;
 }
 
@@ -76,6 +78,7 @@ action _recirculate() {
 
 action _multicast(mgrp) {
     modify_field(intrinsic_metadata.mcast_grp, mgrp);
+    remove_header(hdrA2);
 }
 
 action _clone_i2e(mirror_id) {
@@ -89,6 +92,7 @@ action _clone_e2e(mirror_id) {
 action _set_port(port) {
     modify_field(standard_metadata.egress_spec, port);
     modify_field(metaA.f1, 1);
+    remove_header(hdrA2);
 }
 
 action _exit() {
@@ -128,6 +132,17 @@ table t_egress {
     size : 128;
 }
 
+action set_hdr() {
+    modify_field(hdrA.f2, standard_metadata.packet_length);
+}
+
+table t_exit {
+    actions {
+        set_hdr;
+    }
+    size : 1;
+}
+
 control ingress {
     apply(t_ingress_1);
     apply(t_ingress_2);
@@ -135,4 +150,5 @@ control ingress {
 
 control egress {
     apply(t_egress);
+    apply(t_exit);
 }


### PR DESCRIPTION
- using one of the packet registers to NOT update `standard_metadata.packet_length` on the fly
- testing it in `test_packet_redirect`