### PR TITLE
Add enable_debugger parameter for P4Switch

### DIFF
--- a/mininet/p4_mininet.py
+++ b/mininet/p4_mininet.py
@@ -53,6 +53,7 @@ class P4Switch(Switch):
                   pcap_dump = False,
                   verbose = False,
                   device_id = None,
+                  enable_debugger = False,
                   **kwargs ):
         Switch.__init__( self, name, **kwargs )
         assert(sw_path)
@@ -64,6 +65,7 @@ class P4Switch(Switch):
         self.output = open(logfile, 'w')
         self.thrift_port = thrift_port
         self.pcap_dump = pcap_dump
+        self.enable_debugger = enable_debugger
         if device_id is not None:
             self.device_id = device_id
             P4Switch.device_id = max(P4Switch.device_id, device_id)
@@ -95,9 +97,9 @@ class P4Switch(Switch):
         args.extend( ['--device-id', str(self.device_id)] )
         P4Switch.device_id += 1
         args.append(self.json_path)
-
+        if self.enable_debugger:
+            args.append("--debugger")
         logfile = '/tmp/p4s.%s.log' % self.name
-
         print ' '.join(args)
 
         self.cmd( ' '.join(args) + ' >' + logfile + ' 2>&1 &' )


### PR DESCRIPTION
Developers can use enable_debugger in mininet script to enable debugging mode

for example:

```python
s1 = net.addSwitch('s1', cls = P4Switch, sw_path=SW_PATH, json_path=JSON_PATH, enable_debugger=False)
```