### PR TITLE
added ability to retrieve meter rates

### DIFF
--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -291,6 +291,10 @@ class Context final {
   mt_set_meter_rates(const std::string &table_name, entry_handle_t handle,
                      const std::vector<Meter::rate_config_t> &configs);
 
+  MatchErrorCode
+  mt_get_meter_rates(const std::string &table_name, entry_handle_t handle,
+                     std::vector<Meter::rate_config_t> *configs);
+
   Counter::CounterErrorCode
   read_counters(const std::string &counter_name,
                 size_t index,
@@ -314,6 +318,10 @@ class Context final {
   MeterErrorCode
   meter_set_rates(const std::string &meter_name, size_t idx,
                   const std::vector<Meter::rate_config_t> &configs);
+
+  MeterErrorCode
+  meter_get_rates(const std::string &meter_name, size_t idx,
+                  std::vector<Meter::rate_config_t> *configs);
 
   RegisterErrorCode
   register_read(const std::string &register_name,

--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -181,6 +181,9 @@ class MatchTableAbstract : public NamedP4Object {
       entry_handle_t handle,
       const std::vector<Meter::rate_config_t> &configs) const;
 
+  MatchErrorCode get_meter_rates(
+      entry_handle_t handle, std::vector<Meter::rate_config_t> *configs) const;
+
   MatchErrorCode set_entry_ttl(entry_handle_t handle, unsigned int ttl_ms);
 
   void sweep_entries(std::vector<entry_handle_t> *entries) const;

--- a/include/bm/bm_sim/meters.h
+++ b/include/bm/bm_sim/meters.h
@@ -138,6 +138,9 @@ class Meter {
     return set_rates(configs.begin(), configs.end());
   }
 
+  // returns an empty vector if meter not configured
+  std::vector<rate_config_t> get_rates() const;
+
   MeterErrorCode reset_rates();
 
   //! Executes the meter on the given packet. Returns an integral value in the

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -192,6 +192,12 @@ class RuntimeInterface {
                      entry_handle_t handle,
                      const std::vector<Meter::rate_config_t> &configs) = 0;
 
+  virtual MatchErrorCode
+  mt_get_meter_rates(size_t cxt_id,
+                     const std::string &table_name,
+                     entry_handle_t handle,
+                     std::vector<Meter::rate_config_t> *configs) = 0;
+
   virtual MatchTableType
   mt_get_type(size_t cxt_id, const std::string &table_name) const = 0;
 
@@ -279,6 +285,11 @@ class RuntimeInterface {
   meter_set_rates(size_t cxt_id,
                   const std::string &meter_name, size_t idx,
                   const std::vector<Meter::rate_config_t> &configs) = 0;
+
+  virtual MeterErrorCode
+  meter_get_rates(size_t cxt_id,
+                  const std::string &meter_name, size_t idx,
+                  std::vector<Meter::rate_config_t> *configs) = 0;
 
   virtual RegisterErrorCode
   register_read(size_t cxt_id,

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -572,6 +572,13 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).mt_set_meter_rates(table_name, handle, configs);
   }
 
+  MatchErrorCode
+  mt_get_meter_rates(
+      size_t cxt_id, const std::string &table_name, entry_handle_t handle,
+      std::vector<Meter::rate_config_t> *configs) override {
+    return contexts.at(cxt_id).mt_get_meter_rates(table_name, handle, configs);
+  }
+
   Counter::CounterErrorCode
   read_counters(size_t cxt_id,
                 const std::string &counter_name,
@@ -610,6 +617,13 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
                   const std::string &meter_name, size_t idx,
                   const std::vector<Meter::rate_config_t> &configs) override {
     return contexts.at(cxt_id).meter_set_rates(meter_name, idx, configs);
+  }
+
+  MeterErrorCode
+  meter_get_rates(size_t cxt_id,
+                  const std::string &meter_name, size_t idx,
+                  std::vector<Meter::rate_config_t> *configs) override {
+    return contexts.at(cxt_id).meter_get_rates(meter_name, idx, configs);
   }
 
   RegisterErrorCode

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -501,6 +501,23 @@ public:
     }
   }
 
+  void bm_mt_get_meter_rates(std::vector<BmMeterRateConfig> & _return, const int32_t cxt_id, const std::string& table_name, const BmEntryHandle entry_handle) {
+    Logger::get()->trace("bm_mt_get_meter_rates");
+    std::vector<Meter::rate_config_t> rates;
+    MatchErrorCode error_code = switch_->mt_get_meter_rates(
+        cxt_id, table_name, entry_handle, &rates);
+    if(error_code != MatchErrorCode::SUCCESS) {
+      InvalidTableOperation ito;
+      ito.code = get_exception_code(error_code);
+      throw ito;
+    }
+    _return.resize(rates.size());
+    for (size_t i = 0; i < rates.size(); i++) {
+      _return[i].units_per_micros = rates[i].info_rate;
+      _return[i].burst_size = rates[i].burst_size;
+    }
+  }
+
   template <typename E>
   void copy_match_part_entry(BmMtEntry *e, const E &entry) {
     retrieve_match_key(e->match_key, entry.match_key);
@@ -823,6 +840,23 @@ public:
       InvalidMeterOperation imo;
       imo.code = (MeterOperationErrorCode::type) error_code;
       throw imo;
+    }
+  }
+
+  void bm_meter_get_rates(std::vector<BmMeterRateConfig> & _return, const int32_t cxt_id, const std::string& meter_array_name, const int32_t index) {
+    Logger::get()->trace("bm_meter_get_rates");
+    std::vector<Meter::rate_config_t> rates;
+    Meter::MeterErrorCode error_code = switch_->meter_get_rates(
+        cxt_id, meter_array_name, index, &rates);
+    if(error_code != Meter::MeterErrorCode::SUCCESS) {
+      InvalidMeterOperation imo;
+      imo.code = (MeterOperationErrorCode::type) error_code;
+      throw imo;
+    }
+    _return.resize(rates.size());
+    for (size_t i = 0; i < rates.size(); i++) {
+      _return[i].units_per_micros = rates[i].info_rate;
+      _return[i].burst_size = rates[i].burst_size;
     }
   }
 

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -247,6 +247,17 @@ MatchTableAbstract::set_meter_rates(
 }
 
 MatchErrorCode
+MatchTableAbstract::get_meter_rates(
+    entry_handle_t handle, std::vector<Meter::rate_config_t> *configs) const {
+  if (!with_meters) return MatchErrorCode::METERS_DISABLED;
+  WriteLock lock = lock_write();
+  if (!is_valid_handle(handle)) return MatchErrorCode::INVALID_HANDLE;
+  const Meter &meter = match_unit_->get_meter(handle);
+  *configs = meter.get_rates();
+  return MatchErrorCode::SUCCESS;
+}
+
+MatchErrorCode
 MatchTableAbstract::set_entry_ttl(entry_handle_t handle, unsigned int ttl_ms) {
   if (!with_ageing) return MatchErrorCode::AGEING_DISABLED;
   WriteLock lock = lock_write();

--- a/src/bm_sim/meters.cpp
+++ b/src/bm_sim/meters.cpp
@@ -21,6 +21,7 @@
 #include <bm/bm_sim/meters.h>
 
 #include <algorithm>
+#include <vector>
 
 namespace bm {
 
@@ -127,6 +128,18 @@ Meter::deserialize(std::istream *in) {
 void
 Meter::reset_global_clock() {
   time_init = Meter::clock::now();
+}
+
+std::vector<Meter::rate_config_t>
+Meter::get_rates() const {
+  std::vector<rate_config_t> configs;
+  auto lock = unique_lock();
+  if (!configured) return configs;
+  // elegant but probably not the most efficient
+  for (const MeterRate &rate : rates)
+    configs.push_back(rate_config_t::make(rate.info_rate, rate.burst_size));
+  std::reverse(configs.begin(), configs.end());
+  return configs;
 }
 
 

--- a/targets/simple_switch/tests/CLI_tests/testdata/indirect_res.in
+++ b/targets/simple_switch/tests/CLI_tests/testdata/indirect_res.in
@@ -3,6 +3,7 @@ counter_read my_indirect_counter 16
 meter_set_rates my_indirect_meter 0 1:1 2:1
 meter_set_rates my_indirect_meter 16 1:1 2:1
 meter_set_rates my_indirect_meter 0 2:1 1:1
+meter_get_rates my_indirect_meter 0
 register_read my_register 0
 register_read my_register 16
 register_write my_register 0 1

--- a/targets/simple_switch/tests/CLI_tests/testdata/indirect_res.out
+++ b/targets/simple_switch/tests/CLI_tests/testdata/indirect_res.out
@@ -8,6 +8,9 @@ Invalid meter operation (INVALID_INDEX)
 ????
 Invalid meter operation (INVALID_INFO_RATE_VALUE)
 ????
+0: info rate = 1.0, burst size = 1
+1: info rate = 2.0, burst size = 1
+????
 my_register[0]=  0
 ????
 Invalid register operation (INVALID_INDEX)

--- a/tests/test_meters.cpp
+++ b/tests/test_meters.cpp
@@ -154,3 +154,20 @@ TEST_F(MetersTest, trTCM) {
 
   ASSERT_EQ(expected, output);
 }
+
+TEST_F(MetersTest, GetRates) {
+  Meter meter(MeterType::PACKETS, 2);
+  // committed : 2 packets per second, burst size of 3
+  Meter::rate_config_t committed_rate = {0.000002, 3};
+  // peak : 10 packets per second, burst size of 1
+  Meter::rate_config_t peak_rate = {0.00001, 1};
+  const std::vector<Meter::rate_config_t> rates = {committed_rate, peak_rate};
+  meter.set_rates(rates);
+
+  const auto retrieved_rates = meter.get_rates();
+  ASSERT_EQ(rates.size(), retrieved_rates.size());
+  for (size_t i = 0; i < rates.size(); i++) {
+    ASSERT_EQ(rates[i].info_rate, retrieved_rates[i].info_rate);
+    ASSERT_EQ(rates[i].burst_size, retrieved_rates[i].burst_size);
+  }
+}

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -427,6 +427,12 @@ service Standard {
     4:list<BmMeterRateConfig> rates
   ) throws (1:InvalidTableOperation ouch),
 
+  list<BmMeterRateConfig> bm_mt_get_meter_rates(
+    1:i32 cxt_id,
+    2:string table_name,
+    3:BmEntryHandle entry_handle
+  ) throws (1:InvalidTableOperation ouch),
+
   list<BmMtEntry> bm_mt_get_entries(
     1:i32 cxt_id,
     2:string table_name
@@ -533,6 +539,12 @@ service Standard {
     2:string meter_array_name,
     3:i32 index,
     4:list<BmMeterRateConfig> rates
+  ) throws (1:InvalidMeterOperation ouch)
+
+  list<BmMeterRateConfig> bm_meter_get_rates(
+    1:i32 cxt_id,
+    2:string meter_array_name,
+    3:i32 index
   ) throws (1:InvalidMeterOperation ouch)
 
 

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1528,6 +1528,33 @@ class RuntimeAPI(cmd.Cmd):
     def complete_meter_set_rates(self, text, line, start_index, end_index):
         return self._complete_meters(text)
 
+    @handle_bad_input
+    def do_meter_get_rates(self, line):
+        "Retrieve rates for a meter: meter_get_rates <name> <index>"
+        args = line.split()
+        self.exactly_n_args(args, 2)
+        meter_name = args[0]
+        meter = self.get_res("meter", meter_name, METER_ARRAYS)
+        try:
+            index = int(args[1])
+        except:
+            raise UIn_Error("Bad format for index")
+        # meter.rate_count
+        if meter.is_direct:
+            table_name = meter.binding
+            rates = self.client.bm_mt_get_meter_rates(0, table_name, index)
+        else:
+            rates = self.client.bm_meter_get_rates(0, meter_name, index)
+        if len(rates) != meter.rate_count:
+            print "WARNING: expected", meter.rate_count, "rates",
+            print "but only received", len(rates)
+        for idx, rate in enumerate(rates):
+            print "{}: info rate = {}, burst size = {}".format(
+                idx, rate.units_per_micros, rate.burst_size)
+
+    def complete_meter_get_rates(self, text, line, start_index, end_index):
+        return self._complete_meters(text)
+
     def _complete_meters(self, text):
         return self._complete_res(METER_ARRAYS, text)
 


### PR DESCRIPTION
- added 2 methods to Thrift RPC IDL (direct meters & indirect)
- corresponding CLI command is `meter_get_rates`