### PR TITLE
fixed race condition in parse vset shadow copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,9 @@ directory. You can also browse this documentation [online]
 
 ### Are all features supported yet ?
 
-At this time, the only missing feature that we are aware of is *parse value
-sets*. This P4 feature was scarcely used in bmv1 and is not present in bmv2.
+At this time, we believe that all P4 features have been implemented. The last
+feature to have been implemented is *parse value sets*, which was scarcely used
+in bmv1.
 
 If you find more missing features or if you would like to request that a
 specific feature be added, please send us an email (p4-dev@p4.org) or submit an

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -230,6 +230,8 @@ class ParseVSetIface {
 // future.
 class ParseVSet : public NamedP4Object, public ParseVSetIface {
   template <typename P> friend class ParseSwitchCaseVSet;
+  typedef std::unique_lock<std::mutex> Lock;
+
  public:
   typedef ParseVSetIface::ErrorCode ErrorCode;
 
@@ -252,6 +254,10 @@ class ParseVSet : public NamedP4Object, public ParseVSetIface {
   void add_shadow(ParseVSetIface *shadow);
 
   size_t compressed_bitwidth;
+  // if no mutex we can have inconsistent results accross shadow copies (some
+  // have a value, others don't. This mutex is never requested by the dataplane
+  // (each shadow has its own).
+  mutable std::mutex shadows_mutex{};
   std::vector<ParseVSetIface *> shadows{};
   std::unique_ptr<ParseVSetIface> base{nullptr};
 };

--- a/src/bm_sim/parser.cpp
+++ b/src/bm_sim/parser.cpp
@@ -215,6 +215,7 @@ class ParseVSetCommon : public ParseVSetIface {
 
   size_t compressed_bitwidth{};
   size_t width{};
+  // TODO(antonin): used shared mutex?
   mutable std::mutex set_mutex{};
   std::unordered_set<ByteContainer, ByteContainerKeyHash> set{};
   std::vector<int> bitwidths{};
@@ -266,11 +267,13 @@ ParseVSet::add_shadow(ParseVSetIface *shadow) {
 
 void
 ParseVSet::add(const ByteContainer &v) {
+  Lock lock(shadows_mutex);
   for (auto shadow : shadows) shadow->add(v);
 }
 
 void
 ParseVSet::remove(const ByteContainer &v) {
+  Lock lock(shadows_mutex);
   for (auto shadow : shadows) shadow->remove(v);
 }
 
@@ -281,6 +284,7 @@ ParseVSet::contains(const ByteContainer &v) const {
 
 void
 ParseVSet::clear() {
+  Lock lock(shadows_mutex);
   for (auto shadow : shadows) shadow->clear();
 }
 


### PR DESCRIPTION
updated README to indicate that parse value sets are no longer missing