### PR TITLE
added support for valid hidden field

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -65,6 +65,14 @@ expression. For example, in `(hA.f1 == 9) ? 3 : 4`, `cond` would be the JSON
 representation of `(hA.f1 == 9)`, `left` would be the JSON representation of `3`
 and `right` would be the JSON representation of `4`.
 
+For field references, some special values are allowed. They are called "hidden
+fields". For now, we only support one kind of hidden fields: `<header instance
+name>.$valid$`. This field is a 1-bit field which encodes the validity of the
+corresponding header. It is a read-only field. It can be used just like any
+other field; in particular as part of a match-table key or in a control-flow
+condition. In the long run, this field will completely replace the valid match
+type and the `valid()` built-in (in expressions), but we are not there yet.
+
 
 The attributes of the root JSON dictionary are:
 

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -46,9 +46,10 @@ class Field : public Data {
   // Field. Unfortunately that would require adding an extra level of
   // indirection in Header (for the field vector), so I am sticking to this for
   // now.
-  explicit Field(int nbits, bool arith_flag = true, bool is_signed = false)
+  explicit Field(int nbits, bool arith_flag = true, bool is_signed = false,
+                 bool hidden = false)
       : nbits(nbits), nbytes((nbits + 7) / 8), bytes(nbytes),
-        is_signed(is_signed) {
+        is_signed(is_signed), hidden(hidden) {
     arith = arith_flag;
     // TODO(antonin) ?
     // should I only do that for arith fields ?
@@ -74,6 +75,7 @@ class Field : public Data {
       bignum::clear_bit(&value, nbits - 1);
       value += min;
     }
+    // TODO(antonin): should notifications be disabled for hidden fields?
     DEBUGGER_NOTIFY_UPDATE(*packet_id, my_id, bytes.data(), nbits);
   }
 
@@ -100,7 +102,7 @@ class Field : public Data {
 
   bool get_arith_flag() const { return arith; }
 
-  void export_bytes() {
+  void export_bytes() override {
     std::fill(bytes.begin(), bytes.end(), 0);  // very important !
 
     if (!is_signed) {
@@ -149,11 +151,16 @@ class Field : public Data {
     bytes = src.bytes;
   }
 
+  bool is_hidden() const {
+    return hidden;
+  }
+
  private:
   int nbits;
   int nbytes;
   ByteContainer bytes;
   bool is_signed{false};
+  bool hidden{false};
   Bignum mask{1};
   Bignum max{1};
   Bignum min{1};

--- a/src/bm_sim/headers.cpp
+++ b/src/bm_sim/headers.cpp
@@ -24,8 +24,80 @@
 
 #include <string>
 #include <set>
+#include <map>
 
 namespace bm {
+
+namespace {
+
+// hidden fields in the map needs to be ordered just like the enum, which may
+// not be very robust code...
+class HiddenFMap {
+ public:
+  // TODO(antonin): find something more elegant?
+  static const std::map<HeaderType::HiddenF, HeaderType::FInfo> &map();
+  static size_t size();
+
+ private:
+  static HiddenFMap *get_instance();
+  HiddenFMap();
+
+  std::map<HeaderType::HiddenF, HeaderType::FInfo> fmap;
+};
+
+HiddenFMap::HiddenFMap() {
+  fmap = {
+    {HeaderType::HiddenF::VALID, {"$valid$", 1, false, true}},
+  };
+}
+
+HiddenFMap *
+HiddenFMap::get_instance() {
+  static HiddenFMap instance;
+  return &instance;
+}
+
+const std::map<HeaderType::HiddenF, HeaderType::FInfo> &
+HiddenFMap::map() {
+  auto instance = get_instance();
+  return instance->fmap;
+}
+
+size_t
+HiddenFMap::size() {
+  return map().size();
+}
+
+}  // namespace
+
+HeaderType::HeaderType(const std::string &name, p4object_id_t id)
+    : NamedP4Object(name, id) {
+  const auto &fmap = HiddenFMap::map();
+  for (auto p : fmap) fields_info.push_back(p.second);
+}
+
+int
+HeaderType::push_back_field(const std::string &field_name, int field_bit_width,
+                            bool is_signed) {
+  auto pos = fields_info.end() - HiddenFMap::size();
+  auto offset = std::distance(fields_info.begin(), pos);
+  fields_info.insert(pos, {field_name, field_bit_width, is_signed, false});
+  return offset;
+}
+
+int
+HeaderType::push_back_VL_field(
+    const std::string &field_name,
+    std::unique_ptr<VLHeaderExpression> field_length_expr,
+    bool is_signed) {
+  auto offset = push_back_field(field_name, 0, is_signed);
+  // TODO(antonin)
+  assert(!is_VL_header() && "header can only have one VL field");
+  VL_expr_raw = std::move(field_length_expr);
+  VL_offset = offset;
+  return offset;
+}
+
 
 Header::Header(const std::string &name, p4object_id_t id,
                const HeaderType &header_type,
@@ -34,28 +106,42 @@ Header::Header(const std::string &name, p4object_id_t id,
   : NamedP4Object(name, id), header_type(header_type), metadata(metadata) {
   // header_type_id = header_type.get_type_id();
   for (int i = 0; i < header_type.get_num_fields(); i++) {
-    // use emplace_back instead?
+    const auto &finfo = header_type.get_finfo(i);
     bool arith_flag = true;
     if (arith_offsets.find(i) == arith_offsets.end()) {
       arith_flag = false;
     }
-    fields.push_back(Field(header_type.get_bit_width(i), arith_flag,
-                           header_type.is_field_signed(i)));
+    fields.emplace_back(finfo.bitwidth, arith_flag, finfo.is_signed,
+                        finfo.is_hidden);
     uint64_t field_unique_id = id;
     field_unique_id <<= 32;
     field_unique_id |= i;
     fields.back().set_id(field_unique_id);
-    nbytes_phv += fields.back().get_nbytes();
-    nbytes_packet += fields.back().get_nbits();
+    if (!finfo.is_hidden) nbytes_packet += fields.back().get_nbits();
   }
   assert(nbytes_packet % 8 == 0);
   nbytes_packet /= 8;
+  valid_field = &fields.at(header_type.get_hidden_offset(
+      HeaderType::HiddenF::VALID));
+}
+
+void
+Header::mark_valid() {
+  valid = true;
+  valid_field->set(1);
+}
+
+void
+Header::mark_invalid() {
+  valid = false;
+  valid_field->set(0);
 }
 
 void Header::extract(const char *data, const PHV &phv) {
   if (is_VL_header()) return extract_VL(data, phv);
   int hdr_offset = 0;
   for (Field &f : fields) {
+    if (f.is_hidden()) break;  // all hidden fields are at the end
     hdr_offset += f.extract(data, hdr_offset);
     data += hdr_offset / 8;
     hdr_offset = hdr_offset % 8;
@@ -67,10 +153,10 @@ void Header::extract_VL(const char *data, const PHV &phv) {
   static thread_local Data computed_nbits;
   int VL_offset = header_type.get_VL_offset();
   int hdr_offset = 0;
-  // Should I take care of nbytes_phv? I don't think it is being used anymore
   nbytes_packet = 0;
   for (int i = 0; i < header_type.get_num_fields(); i++) {
     Field &f = fields[i];
+    if (f.is_hidden()) break;  // all hidden fields are at the end
     if (VL_offset == i) {
       VL_expr->eval(phv, &computed_nbits);
       hdr_offset += f.extract_VL(data, hdr_offset, computed_nbits.get_int());
@@ -90,6 +176,7 @@ void Header::deparse(char *data) const {
   // TODO(antonin): special case for VL header ?
   int hdr_offset = 0;
   for (const Field &f : fields) {
+    if (f.is_hidden()) break;  // all hidden fields are at the end
     hdr_offset += f.deparse(data, hdr_offset);
     data += hdr_offset / 8;
     hdr_offset = hdr_offset % 8;

--- a/src/bm_sim/match_units.cpp
+++ b/src/bm_sim/match_units.cpp
@@ -213,10 +213,10 @@ MatchKeyBuilder::operator()(const PHV &phv, ByteContainer *key) const {
       // we do not reset all fields to 0 in between packets
       // so I need this hack if the P4 programmer assumed that:
       // field not valid => field set to 0
-      // const Field &field = phv.get_field(p.first, p.second);
-      // key->append(field.get_bytes());
+      // for hidden fields, we want the actual value, even though for $valid$,
+      // it does not make a difference
       const Field &field = header[in.f_offset];
-      if (header.is_valid()) {
+      if (header.is_valid() || field.is_hidden()) {
         key->append(field.get_bytes());
       } else {
         key->append(std::string(field.get_nbytes(), '\x00'));

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -439,6 +439,7 @@ TEST_F(ActionsTest, CopyHeader) {
   testActionFnEntry(pkt.get());
   ASSERT_TRUE(hdr1.is_valid());
   for(unsigned int i = 0; i < hdr1.size(); i++) {
+    if (hdr1[i].is_hidden()) break;
     ASSERT_EQ(i + 1, hdr1[i].get_uint());
   }
 }

--- a/tests/test_phv.cpp
+++ b/tests/test_phv.cpp
@@ -90,6 +90,32 @@ TEST_F(PHVTest, CopyHeaders) {
   ASSERT_EQ(f48, f48_2);
 }
 
+// we are testing that the $valid$ hidden field is poperly added internally by
+// the HeaderType class, that it is properly accessible and that it is updated
+// properly.
+TEST_F(PHVTest, HiddenValid) {
+  ASSERT_EQ(2u, testHeaderType.get_hidden_offset(HeaderType::HiddenF::VALID));
+
+  ASSERT_EQ(2u, testHeaderType.get_field_offset("$valid$"));
+
+  const auto &finfo = testHeaderType.get_finfo(2u);
+  ASSERT_EQ("$valid$", finfo.name);
+  ASSERT_EQ(1, finfo.bitwidth);
+  ASSERT_FALSE(finfo.is_signed);
+  ASSERT_TRUE(finfo.is_hidden);
+
+  const Field &f = phv->get_field("test1.$valid$");
+  ASSERT_EQ(0, f.get_int());
+  Header &h = phv->get_header(testHeader1);
+  h.mark_valid();
+  ASSERT_EQ(1, f.get_int());
+  h.mark_invalid();
+  ASSERT_EQ(0, f.get_int());
+
+  // check that both point to the same thing
+  ASSERT_EQ(&f, &phv->get_field(testHeader1, 2u));
+}
+
 TEST_F(PHVTest, FieldAlias) {
   phv_factory.add_field_alias("best.alias.ever", "test1.f16");
   std::unique_ptr<PHV> phv_2 = phv_factory.create();


### PR DESCRIPTION
- added support for hidden fields in a header
- added a first hidden field `$valid$` which stores the validity of a header; as of today this field cannot be written to. It can be used to do a ternary match on the validity of a header in a match table.
- an alternative would be to support arbitrary expressions in the match key; however that is more work (because of field re-organization) and is probably an overkill