### PR TITLE
fixed bug in arith enabling for header stack fields

### DIFF
--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -203,6 +203,9 @@ class P4Objects {
 
   bool header_exists(const std::string &header_name) const;
 
+  // public to be accessed by test class
+  std::ostream &outstream;
+
  private:
   void add_header_type(const std::string &name,
                          std::unique_ptr<HeaderType> header_type) {
@@ -390,9 +393,8 @@ class P4Objects {
 
   std::unordered_map<std::string, header_field_pair> field_aliases{};
 
- public:
-  // public to be accessed by test class
-  std::ostream &outstream;
+  // used for initialization only
+  std::unordered_map<p4object_id_t, p4object_id_t> header_id_to_stack_id{};
 
  private:
   int get_field_offset(header_id_t header_id, const std::string &field_name);
@@ -406,6 +408,8 @@ class P4Objects {
 
   std::unique_ptr<CalculationsMap::MyC> check_hash(
       const std::string &name) const;
+
+  void enable_arith(header_id_t header_id, int field_offset);
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/header_stacks.h
+++ b/include/bm/bm_sim/header_stacks.h
@@ -174,6 +174,14 @@ class HeaderStack : public NamedP4Object {
     next = 0;
   }
 
+  Header &at(size_t idx) {
+    return headers.at(idx);
+  }
+
+  const Header &at(size_t idx) const {
+    return headers.at(idx);
+  }
+
  private:
   // To be called by PHV class
   // This is a special case, as I want to store a reference

--- a/include/bm/bm_sim/phv.h
+++ b/include/bm/bm_sim/phv.h
@@ -351,6 +351,9 @@ class PHVFactory {
 
   void disable_all_field_arith(header_id_t header_id);
 
+  void enable_stack_field_arith(header_stack_id_t header_stack_id,
+                                int field_offset);
+
   void enable_all_arith();
 
   std::unique_ptr<PHV> create() const;

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -86,7 +86,7 @@ P4Objects::build_expression(const Json::Value &json_expression,
     int field_offset = get_field_offset(header_id, field_name);
     expr->push_back_load_field(header_id, field_offset);
 
-    phv_factory.enable_field_arith(header_id, field_offset);
+    enable_arith(header_id, field_offset);
   } else if (type == "bool") {
     expr->push_back_load_bool(json_value.asBool());
   } else if (type == "hexstr") {
@@ -204,8 +204,10 @@ P4Objects::init_objects(std::istream *is,
     header_stack_to_type_map[header_stack_name] = header_stack_type;
 
     std::vector<header_id_t> header_ids;
-    for (const auto &cfg_header_id : cfg_header_stack["header_ids"])
+    for (const auto &cfg_header_id : cfg_header_stack["header_ids"]) {
       header_ids.push_back(cfg_header_id.asInt());
+      header_id_to_stack_id[cfg_header_id.asInt()] = header_stack_id;
+    }
 
     phv_factory.push_back_header_stack(header_stack_name, header_stack_id,
                                        *header_stack_type, header_ids);
@@ -338,7 +340,7 @@ P4Objects::init_objects(std::istream *is,
           assert(dest_type == "field");
           const auto dest = field_info(cfg_dest["value"][0].asString(),
                                        cfg_dest["value"][1].asString());
-          phv_factory.enable_field_arith(std::get<0>(dest), std::get<1>(dest));
+          enable_arith(std::get<0>(dest), std::get<1>(dest));
 
           const string &src_type = cfg_src["type"].asString();
           if (src_type == "field") {
@@ -347,7 +349,7 @@ P4Objects::init_objects(std::istream *is,
             parse_state->add_set_from_field(
               std::get<0>(dest), std::get<1>(dest),
               std::get<0>(src), std::get<1>(src));
-            phv_factory.enable_field_arith(std::get<0>(src), std::get<1>(src));
+            enable_arith(std::get<0>(src), std::get<1>(src));
           } else if (src_type == "hexstr") {
             parse_state->add_set_from_data(
               std::get<0>(dest), std::get<1>(dest),
@@ -651,7 +653,7 @@ P4Objects::init_objects(std::istream *is,
           int field_offset = get_field_offset(header_id, field_name);
           action_fn->parameter_push_back_field(header_id, field_offset);
 
-          phv_factory.enable_field_arith(header_id, field_offset);
+          enable_arith(header_id, field_offset);
         } else if (type == "calculation") {
           const string name = cfg_parameter["value"].asString();
           NamedCalculation *calculation = get_named_calculation(name);
@@ -1119,7 +1121,7 @@ P4Objects::init_objects(std::istream *is,
     for (const auto &cfg_field : cfg_force_arith) {
       const auto field = field_info(cfg_field[0].asString(),
                                     cfg_field[1].asString());
-      phv_factory.enable_field_arith(std::get<0>(field), std::get<1>(field));
+      enable_arith(std::get<0>(field), std::get<1>(field));
     }
   }
 
@@ -1132,7 +1134,7 @@ P4Objects::init_objects(std::istream *is,
       //           << " does not exist but required for arith, ignoring\n";
     } else {
       const auto field = field_info(p.first, p.second);
-      phv_factory.enable_field_arith(std::get<0>(field), std::get<1>(field));
+      enable_arith(std::get<0>(field), std::get<1>(field));
     }
   }
 
@@ -1257,6 +1259,16 @@ P4Objects::check_hash(const std::string &name) const {
   auto h = CalculationsMap::get_instance()->get_copy(name);
   if (!h) outstream << "Unknown hash algorithm: " << name  << std::endl;
   return h;
+}
+
+void
+P4Objects::enable_arith(header_id_t header_id, int field_offset) {
+  auto it = header_id_to_stack_id.find(header_id);
+  if (it == header_id_to_stack_id.end()) {
+    phv_factory.enable_field_arith(header_id, field_offset);
+  } else {
+    phv_factory.enable_stack_field_arith(it->second, field_offset);
+  }
 }
 
 MeterArray *

--- a/src/bm_sim/phv.cpp
+++ b/src/bm_sim/phv.cpp
@@ -171,6 +171,14 @@ PHVFactory::disable_all_field_arith(header_id_t header_id) {
 }
 
 void
+PHVFactory::enable_stack_field_arith(header_stack_id_t header_stack_id,
+                                     int field_offset) {
+  HeaderStackDesc &desc = header_stack_descs.at(header_stack_id);
+  for (header_id_t header_id : desc.headers)
+    enable_field_arith(header_id, field_offset);
+}
+
+void
 PHVFactory::enable_all_arith() {
   for (auto it : header_descs)
     enable_all_field_arith(it.first);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -123,4 +123,6 @@ testdata/runtime_iface.p4 \
 testdata/runtime_iface.json \
 testdata/one_header.json \
 testdata/parse_vset.p4 \
-testdata/parse_vset.json
+testdata/parse_vset.json \
+testdata/header_stack.p4 \
+testdata/header_stack.json

--- a/tests/primitives.cpp
+++ b/tests/primitives.cpp
@@ -79,3 +79,11 @@ class register_write
 };
 
 REGISTER_PRIMITIVE(register_write);
+
+class pop : public ActionPrimitive<HeaderStack &, const Data &> {
+  void operator ()(HeaderStack &stack, const Data &num) {
+    stack.pop_front(num.get_uint());
+  }
+};
+
+REGISTER_PRIMITIVE(pop);

--- a/tests/testdata/header_stack.json
+++ b/tests/testdata/header_stack.json
@@ -1,0 +1,271 @@
+{
+    "header_types": [
+        {
+            "name": "standard_metadata_t",
+            "id": 0,
+            "fields": [
+                [
+                    "ingress_port",
+                    9
+                ],
+                [
+                    "packet_length",
+                    32
+                ],
+                [
+                    "egress_spec",
+                    9
+                ],
+                [
+                    "egress_port",
+                    9
+                ],
+                [
+                    "egress_instance",
+                    32
+                ],
+                [
+                    "instance_type",
+                    32
+                ],
+                [
+                    "clone_spec",
+                    32
+                ],
+                [
+                    "_padding",
+                    5
+                ]
+            ],
+            "length_exp": null,
+            "max_length": null
+        },
+        {
+            "name": "hdr_t",
+            "id": 1,
+            "fields": [
+                [
+                    "f1",
+                    16
+                ],
+                [
+                    "f2",
+                    16
+                ]
+            ],
+            "length_exp": null,
+            "max_length": null
+        }
+    ],
+    "headers": [
+        {
+            "name": "standard_metadata",
+            "id": 0,
+            "header_type": "standard_metadata_t",
+            "metadata": true
+        },
+        {
+            "name": "hdr[0]",
+            "id": 1,
+            "header_type": "hdr_t",
+            "metadata": false
+        },
+        {
+            "name": "hdr[1]",
+            "id": 2,
+            "header_type": "hdr_t",
+            "metadata": false
+        },
+        {
+            "name": "hdr[2]",
+            "id": 3,
+            "header_type": "hdr_t",
+            "metadata": false
+        }
+    ],
+    "header_stacks": [
+        {
+            "name": "hdr",
+            "id": 0,
+            "size": 3,
+            "header_type": "hdr_t",
+            "header_ids": [
+                1,
+                2,
+                3
+            ]
+        }
+    ],
+    "parsers": [
+        {
+            "name": "parser",
+            "id": 0,
+            "init_state": "start",
+            "parse_states": [
+                {
+                    "name": "start",
+                    "id": 0,
+                    "parser_ops": [
+                        {
+                            "op": "extract",
+                            "parameters": [
+                                {
+                                    "type": "regular",
+                                    "value": "hdr[0]"
+                                }
+                            ]
+                        },
+                        {
+                            "op": "extract",
+                            "parameters": [
+                                {
+                                    "type": "regular",
+                                    "value": "hdr[1]"
+                                }
+                            ]
+                        }
+                    ],
+                    "transition_key": [],
+                    "transitions": [
+                        {
+                            "type": "default",
+                            "value": null,
+                            "mask": null,
+                            "next_state": null
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "parse_vsets": [],
+    "deparsers": [
+        {
+            "name": "deparser",
+            "id": 0,
+            "order": [
+                "hdr[0]",
+                "hdr[1]"
+            ]
+        }
+    ],
+    "meter_arrays": [],
+    "actions": [
+        {
+            "name": "a1",
+            "id": 0,
+            "runtime_data": [
+                {
+                    "name": "v1",
+                    "bitwidth": 16
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "hdr[1]",
+                                "f1"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                },
+                {
+                    "op": "pop",
+                    "parameters": [
+                        {
+                            "type": "header_stack",
+                            "value": "hdr"
+                        },
+                        {
+                            "type": "hexstr",
+                            "value": "0x1"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "pipelines": [
+        {
+            "name": "ingress",
+            "id": 0,
+            "init_table": "t1",
+            "tables": [
+                {
+                    "name": "t1",
+                    "id": 0,
+                    "match_type": "exact",
+                    "type": "simple",
+                    "max_size": 16384,
+                    "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
+                    "key": [],
+                    "actions": [
+                        "a1"
+                    ],
+                    "next_tables": {
+                        "a1": null
+                    },
+                    "base_default_next": null
+                }
+            ],
+            "conditionals": []
+        },
+        {
+            "name": "egress",
+            "id": 1,
+            "init_table": null,
+            "tables": [],
+            "conditionals": []
+        }
+    ],
+    "calculations": [],
+    "checksums": [],
+    "learn_lists": [],
+    "field_lists": [],
+    "counter_arrays": [],
+    "register_arrays": [],
+    "force_arith": [
+        [
+            "standard_metadata",
+            "ingress_port"
+        ],
+        [
+            "standard_metadata",
+            "packet_length"
+        ],
+        [
+            "standard_metadata",
+            "egress_spec"
+        ],
+        [
+            "standard_metadata",
+            "egress_port"
+        ],
+        [
+            "standard_metadata",
+            "egress_instance"
+        ],
+        [
+            "standard_metadata",
+            "instance_type"
+        ],
+        [
+            "standard_metadata",
+            "clone_spec"
+        ],
+        [
+            "standard_metadata",
+            "_padding"
+        ]
+    ]
+}

--- a/tests/testdata/header_stack.p4
+++ b/tests/testdata/header_stack.p4
@@ -1,0 +1,29 @@
+header_type hdr_t {
+    fields {
+        f1 : 16;
+        f2 : 16;
+    }
+}
+
+header hdr_t hdr[3];
+
+parser start {
+    extract(hdr[0]);
+    extract(hdr[1]);
+    return ingress;
+}
+
+action a1(v1) {
+    modify_field(hdr[1].f1, v1);
+    pop(hdr, 1);
+}
+
+table t1 {
+    actions { a1; }
+}
+
+control ingress {
+    apply(t1);
+}
+
+control egress { }


### PR DESCRIPTION
The following code was handled incorrectly:
```
extract(hdr[next]);
extract(hdr[next]);
pop(hdr, 1);
modify_field(meta.f1, hdr[0].f1);
```
bmv2 wasn't enabling arithmetic ops on `hdr[1].f1` so when pop() would copy `hdr[1].f1` to `hdr[0].f1`, it would copy 0 instead of the actual value.

The solution was to enable arith on `hdr[x].f1` after seeing `hdr[0].f1` used in a primitive.