### PR TITLE
trying to fix coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,5 @@ script:
 
 # code coverage
 after_success:
-  - if [ "$GCOV" != "" ]; then (cd src/bm_sim; $GCOV -r -o .libs/ *.cpp); fi
+  - if [ "$GCOV" != "" ]; then (cd src/bm_sim; $GCOV -p -r -o .libs/ *.cpp; rm *third_party*); fi
   - if [ "$GCOV" != "" ]; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
recently coverage reports started including code under `third_party`, despite the use of `--relative-only` with `gcov`; so I'm trying to fix that by manually deleting the reports for these files before sending them to codecov