### PR TITLE
Added a Valgrind suppression file for unit tests

### DIFF
--- a/tests/valgrind.test.supp
+++ b/tests/valgrind.test.supp
@@ -1,0 +1,47 @@
+{
+   debugger1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:__cxx_global_var_init70
+   fun:_GLOBAL__sub_I_debugger.cpp
+}
+{
+   event_logger1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:__cxx_global_var_init47
+   fun:_GLOBAL__sub_I_event_logger.cpp
+}
+{
+   event_logger2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN2bm14TransportIface10make_dummyEv
+   fun:__cxx_global_var_init47
+   fun:_GLOBAL__sub_I_event_logger.cpp
+}
+{
+   packet1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:__cxx_global_var_init7
+   fun:_GLOBAL__sub_I_packet.cpp
+}
+{
+   unknown
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.19.so
+   obj:*
+   obj:*
+   obj:*
+}

--- a/tools/run_valgrind.sh
+++ b/tools/run_valgrind.sh
@@ -6,7 +6,9 @@ TEST_DIR=$THIS_DIR/../tests
 
 cd $TEST_DIR
 
-libtool --mode=execute valgrind --leak-check=full --show-reachable=yes ./test_all --valgrind
+libtool --mode=execute valgrind \
+    --suppressions=valgrind.test.supp --leak-check=full --show-reachable=yes \
+    ./test_all --valgrind
 return_status=$?
 
 cd -


### PR DESCRIPTION
This prevents Valgrind from complaining about the global variable
pointers which we do not wrap in smart pointers (as per coding
guidelines) and are never de-allocated.