### PR TITLE
Add ability to retrieve a match entry from key

### DIFF
--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -261,6 +261,13 @@ class Context final {
   mt_get_default_entry(const std::string &table_name,
                        typename T::Entry *default_entry) const;
 
+  template <typename T>
+  MatchErrorCode
+  mt_get_entry_from_key(const std::string &table_name,
+                        const std::vector<MatchKeyParam> &match_key,
+                        typename T::Entry *entry,
+                        int priority = 1) const;
+
   std::vector<MatchTableIndirect::Member>
   mt_indirect_get_members(const std::string &table_name) const;
 

--- a/include/bm/bm_sim/lookup_structures.h
+++ b/include/bm/bm_sim/lookup_structures.h
@@ -131,6 +131,12 @@ class LookupStructure {
   //! Ternary structure.
   virtual bool entry_exists(const K &key) const = 0;
 
+  //! Retrieve the handle of an entry. Returns true if and only if an entry
+  //! exists. See entry_exists() for more information about the notion of entry
+  //! existence.
+  virtual bool retrieve_handle(const K &key,
+                               internal_handle_t *handle) const = 0;
+
   //! Store an entry in the lookup structure. Associates the given handle
   //! with the given entry.
   virtual void add_entry(const K &key, internal_handle_t handle) = 0;

--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -296,6 +296,9 @@ class MatchTable : public MatchTableAbstract {
 
   MatchErrorCode get_entry(entry_handle_t handle, Entry *entry) const;
 
+  MatchErrorCode get_entry_from_key(const std::vector<MatchKeyParam> &match_key,
+                                    Entry *entry, int priority = 1) const;
+
   std::vector<Entry> get_entries() const;
 
   MatchErrorCode get_default_entry(Entry *entry) const;
@@ -487,6 +490,9 @@ class MatchTableIndirect : public MatchTableAbstract {
 
   MatchErrorCode get_entry(entry_handle_t handle, Entry *entry) const;
 
+  MatchErrorCode get_entry_from_key(const std::vector<MatchKeyParam> &match_key,
+                                    Entry *entry, int priority = 1) const;
+
   std::vector<Entry> get_entries() const;
 
   MatchErrorCode get_default_entry(Entry *entry) const;
@@ -608,6 +614,9 @@ class MatchTableIndirectWS : public MatchTableIndirect {
   MatchErrorCode set_default_group(grp_hdl_t grp);
 
   MatchErrorCode get_entry(entry_handle_t handle, Entry *entry) const;
+
+  MatchErrorCode get_entry_from_key(const std::vector<MatchKeyParam> &match_key,
+                                    Entry *entry, int priority = 1) const;
 
   std::vector<Entry> get_entries() const;
 

--- a/include/bm/bm_sim/match_units.h
+++ b/include/bm/bm_sim/match_units.h
@@ -372,6 +372,10 @@ class MatchUnitAbstract : public MatchUnitAbstract_ {
                            std::vector<MatchKeyParam> *match_key,
                            const V **value, int *priority = nullptr) const;
 
+  MatchErrorCode retrieve_handle(const std::vector<MatchKeyParam> &match_key,
+                                 entry_handle_t *handle,
+                                 int priority = -1) const;
+
   // TODO(antonin): move this one level up in class hierarchy?
   // will return an empty string if the handle is not valid
   // otherwise will return a dump of the match entry in a nice format
@@ -411,6 +415,11 @@ class MatchUnitAbstract : public MatchUnitAbstract_ {
   virtual MatchErrorCode get_entry_(entry_handle_t handle,
                                     std::vector<MatchKeyParam> *match_key,
                                     const V **value, int *priority) const = 0;
+
+  virtual MatchErrorCode retrieve_handle_(
+      const std::vector<MatchKeyParam> &match_key,
+      entry_handle_t *handle,
+      int priority) const = 0;
 
   virtual MatchErrorCode dump_match_entry_(std::ostream *out,
                                            entry_handle_t handle) const = 0;
@@ -460,6 +469,10 @@ class MatchUnitGeneric : public MatchUnitAbstract<V> {
                             std::vector<MatchKeyParam> *match_key,
                             const V **value, int *priority) const override;
 
+  MatchErrorCode retrieve_handle_(const std::vector<MatchKeyParam> &match_key,
+                                  entry_handle_t *handle,
+                                  int priority) const override;
+
   MatchErrorCode dump_match_entry_(std::ostream *out,
                                    entry_handle_t handle) const override;
 
@@ -469,6 +482,10 @@ class MatchUnitGeneric : public MatchUnitAbstract<V> {
 
   void serialize_(std::ostream *out) const override;
   void deserialize_(std::istream *in, const P4Objects &objs) override;
+
+  MatchErrorCode build_entry_from_match_key(
+      const std::vector<MatchKeyParam> &match_key, int priority,
+      Entry *entry) const;
 
  private:
   std::vector<Entry> entries{};

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -239,6 +239,24 @@ class RuntimeInterface {
       size_t cxt_id, const std::string &table_name,
       MatchTableIndirectWS::Entry *entry) const = 0;
 
+  virtual MatchErrorCode
+  mt_get_entry_from_key(size_t cxt_id, const std::string &table_name,
+                        const std::vector<MatchKeyParam> &match_key,
+                        MatchTable::Entry *entry, int priority = 1) const = 0;
+
+  virtual MatchErrorCode
+  mt_indirect_get_entry_from_key(size_t cxt_id, const std::string &table_name,
+                                 const std::vector<MatchKeyParam> &match_key,
+                                 MatchTableIndirect::Entry *entry,
+                                 int priority = 1) const = 0;
+
+  virtual MatchErrorCode
+  mt_indirect_ws_get_entry_from_key(size_t cxt_id,
+                                    const std::string &table_name,
+                                    const std::vector<MatchKeyParam> &match_key,
+                                    MatchTableIndirectWS::Entry *entry,
+                                    int priority = 1) const = 0;
+
   virtual std::vector<MatchTableIndirect::Member>
   mt_indirect_get_members(size_t cxt_id,
                           const std::string &table_name) const = 0;

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -518,6 +518,34 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
         table_name, entry);
   }
 
+  MatchErrorCode
+  mt_get_entry_from_key(size_t cxt_id, const std::string &table_name,
+                        const std::vector<MatchKeyParam> &match_key,
+                        MatchTable::Entry *entry,
+                        int priority = 1) const override {
+    return contexts.at(cxt_id).mt_get_entry_from_key<MatchTable>(
+        table_name, match_key, entry, priority);
+  }
+
+  MatchErrorCode
+  mt_indirect_get_entry_from_key(size_t cxt_id, const std::string &table_name,
+                                 const std::vector<MatchKeyParam> &match_key,
+                                 MatchTableIndirect::Entry *entry,
+                                 int priority = 1) const override {
+    return contexts.at(cxt_id).mt_get_entry_from_key<MatchTableIndirect>(
+        table_name, match_key, entry, priority);
+  }
+
+  MatchErrorCode
+  mt_indirect_ws_get_entry_from_key(size_t cxt_id,
+                                    const std::string &table_name,
+                                    const std::vector<MatchKeyParam> &match_key,
+                                    MatchTableIndirectWS::Entry *entry,
+                                    int priority = 1) const override {
+    return contexts.at(cxt_id).mt_get_entry_from_key<MatchTableIndirectWS>(
+        table_name, match_key, entry, priority);
+  }
+
   std::vector<MatchTableIndirect::Member>
   mt_indirect_get_members(size_t cxt_id,
                           const std::string &table_name) const override {

--- a/src/bf_lpm_trie/bf_lpm_trie.c
+++ b/src/bf_lpm_trie/bf_lpm_trie.c
@@ -166,8 +166,9 @@ void bf_lpm_trie_insert(bf_lpm_trie_t *trie,
     current_node->pref_num++;
 }
 
-bool bf_lpm_trie_has_prefix(const bf_lpm_trie_t *trie,
-			    const char *prefix, int prefix_length) {
+bool bf_lpm_trie_retrieve_value(const bf_lpm_trie_t *trie,
+                                const char *prefix, int prefix_length,
+                                value_t *pvalue) {
   node_t *current_node = trie->root;
   byte_t byte;
   unsigned short prefix_key;
@@ -188,7 +189,20 @@ bool bf_lpm_trie_has_prefix(const bf_lpm_trie_t *trie,
   else 
     prefix_key = get_prefix_key((unsigned) prefix_length, (byte_t) *prefix);
 
-  return (get_prefix_ptr(current_node, prefix_key) != NULL);
+  value_t *pdata = get_prefix_ptr(current_node, prefix_key);
+  if(pdata != NULL) {
+    *pvalue = *pdata;
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
+bool bf_lpm_trie_has_prefix(const bf_lpm_trie_t *trie,
+			    const char *prefix, int prefix_length) {
+  value_t value;
+  return bf_lpm_trie_retrieve_value(trie, prefix, prefix_length, &value);
 }
 
 bool bf_lpm_trie_lookup(const bf_lpm_trie_t *trie, const char *key,

--- a/src/bf_lpm_trie/bf_lpm_trie/bf_lpm_trie.h
+++ b/src/bf_lpm_trie/bf_lpm_trie/bf_lpm_trie.h
@@ -43,6 +43,10 @@ void bf_lpm_trie_insert(bf_lpm_trie_t *trie,
 bool bf_lpm_trie_has_prefix(const bf_lpm_trie_t *trie,
 			    const char *prefix, int prefix_length);
 
+bool bf_lpm_trie_retrieve_value(const bf_lpm_trie_t *trie,
+                                const char *prefix, int prefix_length,
+                                value_t *pvalue);
+
 bool bf_lpm_trie_lookup(const bf_lpm_trie_t *trie, const char *key,
 			value_t *pvalue);
 

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -438,6 +438,35 @@ template MatchErrorCode
 Context::mt_get_default_entry<MatchTableIndirectWS>(
     const std::string &, MatchTableIndirectWS::Entry *) const;
 
+template <typename T>
+MatchErrorCode
+Context::mt_get_entry_from_key(const std::string &table_name,
+                               const std::vector<MatchKeyParam> &match_key,
+                               typename T::Entry *entry,
+                               int priority) const {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  MatchTableAbstract *abstract_table =
+      p4objects_rt->get_abstract_match_table(table_name);
+  if (!abstract_table) return MatchErrorCode::INVALID_TABLE_NAME;
+  T *table = dynamic_cast<T *>(abstract_table);
+  if (!table) return MatchErrorCode::WRONG_TABLE_TYPE;
+  return table->get_entry_from_key(match_key, entry, priority);
+}
+
+// explicit instantiation
+template MatchErrorCode
+Context::mt_get_entry_from_key<MatchTable>(
+    const std::string &, const std::vector<MatchKeyParam> &,
+    MatchTable::Entry *, int) const;
+template MatchErrorCode
+Context::mt_get_entry_from_key<MatchTableIndirect>(
+    const std::string &, const std::vector<MatchKeyParam> &,
+    MatchTableIndirect::Entry *, int) const;
+template MatchErrorCode
+Context::mt_get_entry_from_key<MatchTableIndirectWS>(
+    const std::string &, const std::vector<MatchKeyParam> &,
+    MatchTableIndirectWS::Entry *, int) const;
+
 std::vector<MatchTableIndirect::Member>
 Context::mt_indirect_get_members(const std::string &table_name) const {
   MatchErrorCode rc;

--- a/src/bm_sim/lpm_trie.h
+++ b/src/bm_sim/lpm_trie.h
@@ -60,7 +60,8 @@ class LPMTrie {
 
   void insert_prefix(const ByteContainer &prefix, int prefix_length,
                      uintptr_t value) {
-    bf_lpm_trie_insert(trie, prefix.data(), prefix_length, (value_t) value);
+    bf_lpm_trie_insert(trie, prefix.data(), prefix_length,
+                       static_cast<value_t>(value));
   }
 
   bool delete_prefix(const ByteContainer &prefix, int prefix_length) {
@@ -69,6 +70,12 @@ class LPMTrie {
 
   bool has_prefix(const ByteContainer &prefix, int prefix_length) const {
     return bf_lpm_trie_has_prefix(trie, prefix.data(), prefix_length);
+  }
+
+  bool retrieve_value(const ByteContainer &prefix, int prefix_length,
+                      uintptr_t *value) const {
+    return bf_lpm_trie_retrieve_value(trie, prefix.data(), prefix_length,
+                                      reinterpret_cast<value_t *>(value));
   }
 
   bool lookup(const ByteContainer &key, uintptr_t *value) const {

--- a/src/bm_sim/match_units.cpp
+++ b/src/bm_sim/match_units.cpp
@@ -851,6 +851,14 @@ MatchUnitAbstract<V>::get_entry(entry_handle_t handle,
 }
 
 template<typename V>
+MatchErrorCode
+MatchUnitAbstract<V>::retrieve_handle(
+    const std::vector<MatchKeyParam> &match_key,
+    entry_handle_t *handle, int priority) const {
+  return retrieve_handle_(match_key, handle, priority);
+}
+
+template<typename V>
 std::string
 MatchUnitAbstract<V>::entry_to_string(entry_handle_t handle) const {
   std::ostringstream ret;
@@ -920,11 +928,12 @@ MatchUnitGeneric<K, V>::lookup_key(const ByteContainer &key) const {
   return MatchUnitLookup::empty_entry();
 }
 
+// used by add_entry_ and retrieve_handle_
 template <typename K, typename V>
 MatchErrorCode
-MatchUnitGeneric<K, V>::add_entry_(const std::vector<MatchKeyParam> &match_key,
-                                   V value, entry_handle_t *handle,
-                                   int priority) {
+MatchUnitGeneric<K, V>::build_entry_from_match_key(
+    const std::vector<MatchKeyParam> &match_key, int priority,
+    Entry *entry) const {
   const auto &KeyB = this->match_key_builder;
 
   if (!KeyB.match_params_sanity_check(match_key))
@@ -932,24 +941,37 @@ MatchUnitGeneric<K, V>::add_entry_(const std::vector<MatchKeyParam> &match_key,
 
   // for why "template" keyword is needed, see:
   // http://stackoverflow.com/questions/1840253/n/1840318#1840318
-  Entry entry = KeyB.template match_params_to_entry<Entry>(match_key);
+  *entry = KeyB.template match_params_to_entry<Entry>(match_key);
 
   // needs to go before duplicate check, because 2 different user keys can
   // become the same key. We would then have a problem when erasing the key from
   // the hash map.
   // TODO(antonin): maybe change this by modifying delete_entry method
   // TODO(antonin): does this really make sense for a Ternary/LPM table?
-  KeyB.apply_big_mask(&entry.key.data);
+  KeyB.apply_big_mask(&entry->key.data);
 
   // For ternary and range. Must be done before the entry_exists call below
-  set_priority(&entry.key, priority);
+  set_priority(&entry->key, priority);
+
+  return MatchErrorCode::SUCCESS;
+}
+
+template <typename K, typename V>
+MatchErrorCode
+MatchUnitGeneric<K, V>::add_entry_(const std::vector<MatchKeyParam> &match_key,
+                                   V value, entry_handle_t *handle,
+                                   int priority) {
+  MatchErrorCode status;
+  Entry entry;
+  status = build_entry_from_match_key(match_key, priority, &entry);
+  if (status != MatchErrorCode::SUCCESS) return status;
 
   // check if the key is already present
   if (lookup_structure->entry_exists(entry.key))
     return MatchErrorCode::DUPLICATE_ENTRY;
 
   internal_handle_t handle_;
-  MatchErrorCode status = this->get_and_set_handle(&handle_);
+  status = this->get_and_set_handle(&handle_);
   if (status != MatchErrorCode::SUCCESS) return status;
 
   uint32_t version = entries[handle_].key.version;
@@ -1022,6 +1044,24 @@ MatchUnitGeneric<K, V>::get_entry_(entry_handle_t handle,
   *match_key = this->match_key_builder.entry_to_match_params(entry.key);
   *value = &entry.value;
   if (priority) *priority = get_priority(entry.key);
+
+  return MatchErrorCode::SUCCESS;
+}
+
+template<typename K, typename V>
+MatchErrorCode
+MatchUnitGeneric<K, V>::retrieve_handle_(
+    const std::vector<MatchKeyParam> &match_key,
+    entry_handle_t *handle, int priority) const {
+  Entry entry;
+  auto status = build_entry_from_match_key(match_key, priority, &entry);
+  if (status != MatchErrorCode::SUCCESS) return status;
+
+  internal_handle_t handle_;
+  if (!lookup_structure->retrieve_handle(entry.key, &handle_))
+    return MatchErrorCode::BAD_MATCH_KEY;
+
+  *handle = HANDLE_SET(entry.key.version, handle_);
 
   return MatchErrorCode::SUCCESS;
 }

--- a/targets/simple_switch/tests/CLI_tests/testdata/table_dump.in
+++ b/targets/simple_switch/tests/CLI_tests/testdata/table_dump.in
@@ -7,3 +7,4 @@ table_dump ecmp_group
 table_dump_entry ecmp_group 0
 table_dump_member ecmp_group 0
 table_dump_group ecmp_group 0
+table_dump_entry_from_key ecmp_group 10.0.0.1/12

--- a/targets/simple_switch/tests/CLI_tests/testdata/table_dump.out
+++ b/targets/simple_switch/tests/CLI_tests/testdata/table_dump.out
@@ -48,3 +48,8 @@ Action entry: set_nhop - 0a000001, 01
 Dumping group 0
 Members: [0]
 ????
+Dumping entry 0x0
+Match key:
+* ipv4.dstAddr        : LPM       0a000001/12
+Index: member(0)
+????

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -466,6 +466,14 @@ service Standard {
     2:string table_name
   ) throws (1:InvalidTableOperation ouch),
 
+  // if match_key is empty, returns default entry
+  BmMtEntry bm_mt_get_entry_from_key(
+    1:i32 cxt_id,
+    2:string table_name,
+    3:BmMatchParams match_key,
+    4:BmAddEntryOptions options
+  ) throws (1:InvalidTableOperation ouch),
+
   list<BmMtIndirectMember> bm_mt_indirect_get_members(
     1:i32 cxt_id,
     2:string table_name

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1762,7 +1762,7 @@ class RuntimeAPI(cmd.Cmd):
 
     @handle_bad_input
     def do_table_dump_entry(self, line):
-        "Display some information about a table entry: table_dump <table name> <entry handle>"
+        "Display some information about a table entry: table_dump_entry <table name> <entry handle>"
         args = line.split()
         self.exactly_n_args(args, 2)
         table_name = args[0]
@@ -1873,6 +1873,39 @@ class RuntimeAPI(cmd.Cmd):
 
     def complete_table_dump_2(self, text, line, start_index, end_index):
         return self.complete_table_dump(text, line, start_index, end_index)
+
+    @handle_bad_input
+    def do_table_dump_entry_from_key(self, line):
+        "Display some information about a table entry: table_dump_entry_from_key <table name> <match fields> [priority]"
+        args = line.split()
+        self.at_least_n_args(args, 1)
+        table_name = args[0]
+
+        table = self.get_res("table", table_name, TABLES)
+
+        if table.match_type in {MatchType.TERNARY, MatchType.RANGE}:
+            try:
+                priority = int(args.pop(-1))
+            except:
+                raise UIn_Error(
+                    "Table is ternary, but could not extract a valid priority from args"
+                )
+        else:
+            priority = 0
+
+        match_key = args[1:]
+        if len(match_key) != table.num_key_fields():
+            raise UIn_Error(
+                "Table %s needs %d key fields" % (table_name, table.num_key_fields())
+            )
+        match_key = parse_match_key(table, match_key)
+
+        entry = self.client.bm_mt_get_entry_from_key(
+            0, table_name, match_key, BmAddEntryOptions(priority = priority))
+        self.dump_one_entry(table, entry)
+
+    def complete_table_dump_entry_from_key(self, text, line, start_index, end_index):
+        return self._complete_tables(text)
 
     @handle_bad_input
     def do_port_add(self, line):


### PR DESCRIPTION
The Thrift RPC now exposes a bm_mt_get_entry_from_key method which can
be used to retrieve a match-action entry (along with the handle) by
providing the same match_key (and priority for ternary + range). The
handle can then be used to modify an entry, retrieve
counters... Although this means having to do 2 successive RPC calls, it
was easier to do than having to provide alternatives to all RPC methods
which currently require a handle.

The corresponding CLI command was added.