### PR TITLE
Fix modify_field_with_hash_based_offset implementation

### DIFF
--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -264,8 +264,13 @@ class modify_field_with_hash_based_offset
                            const NamedCalculation &, const Data &> {
   void operator ()(Data &dst, const Data &base,
                    const NamedCalculation &hash, const Data &size) {
-    uint64_t v =
-      (hash.output(get_packet()) % size.get<uint64_t>()) + base.get<uint64_t>();
+    uint64_t v;
+    if (size.get<uint64_t>() == 0) {
+      v = hash.output(get_packet()) + base.get<uint64_t>();
+    } else {
+      v =
+        (hash.output(get_packet()) % size.get<uint64_t>()) + base.get<uint64_t>();
+    }
     dst.set(v);
   }
 };


### PR DESCRIPTION
According to the [spec](http://p4.org/wp-content/uploads/2016/03/p4_v1.1.pdf) for modify_field_with_hashed_based_offset, 

> If size is not zero, the hash value is used to generate a value between base and
> (base + size - 1) by calculating (base + (hash_value % size)). If size is 0 then the
> value used is (base + hash_value).

Previously, the implementation of modify_field_with_hash_based_offset did not handle the case where size is 0, which caused the switch to crash when size was set to zero.

This commit fixes this bug.