### PR TITLE
More flexible externs

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -379,5 +379,6 @@ type
 - `attribute_values`: a JSON array with the initial values for the attributes of
 this extern instance. Each array item has the following attributes:
   - `name`: the name of the attribute
-  - `type`: the type of the attribute, only `hexstr` is supported for now
+  - `type`: the type of the attribute, only `hexstr` (integral values), `string`
+  (for character sequences) and `expression` are supported for now
   - `value`: the initial value for the attribute

--- a/include/bm/bm_sim/expressions.h
+++ b/include/bm/bm_sim/expressions.h
@@ -93,7 +93,7 @@ struct Op {
 
 class Expression {
  public:
-  Expression() { }
+  Expression();
 
   void push_back_load_field(header_id_t header, int field_offset);
   void push_back_load_bool(bool value);
@@ -114,6 +114,8 @@ class Expression {
   Data eval_arith(const PHV &phv, const std::vector<Data> &locals = {}) const;
   void eval_arith(const PHV &phv, Data *data,
                   const std::vector<Data> &locals = {}) const;
+
+  bool empty() const;
 
   // I am authorizing copy for this object
   Expression(const Expression &other) = default;

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -102,6 +102,9 @@ class Packet final {
   //! Number of general purpose registers per packet
   static constexpr size_t nb_registers = 2u;
 
+  static constexpr size_t INVALID_ENTRY_INDEX =
+      std::numeric_limits<size_t>::max();
+
   ~Packet();
 
   //! Obtain the packet_id. The packet_id is the one assigned by the target when
@@ -217,6 +220,11 @@ class Packet final {
   void set_register(size_t idx, uint64_t v) { registers.at(idx) = v; }
   //! Read general purpose register at index \p idx
   uint64_t get_register(size_t idx) { return registers.at(idx); }
+
+  void set_entry_index(size_t idx) { entry_index = idx; }
+  //! Get the index of the entry returned by the last match table lookup, or
+  //! Packet::INVALID_ENTRY_INDEX if lookup was a miss.
+  size_t get_entry_index() const { return entry_index; }
 
   //! Mark the packet for exit by setting an exit flag. If this is called from
   //! an action, the current pipeline will be interrupted as soon as the current
@@ -345,6 +353,10 @@ class Packet final {
   // General purpose registers available to a target, they can be written with
   // Packet::set_register and read with Packet::get_register
   std::array<uint64_t, nb_registers> registers;
+
+  // Used to store the index of the entry returned by the last match table
+  // lookup; INVALID_ENTRY_INDEX if lookup was a miss.
+  size_t entry_index{INVALID_ENTRY_INDEX};
 
  private:
   static CopyIdGenerator *copy_id_gen;

--- a/src/bm_sim/extern.cpp
+++ b/src/bm_sim/extern.cpp
@@ -49,6 +49,11 @@ ExternFactoryMap::get_extern_instance(
 }
 
 void
+ExternType::_set_p4objects(P4Objects *p4objects) {
+  this->p4objects = p4objects;
+}
+
+void
 ExternType::_set_name_and_id(const std::string &name, p4object_id_t id) {
   this->name = name;
   this->id = id;

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -100,6 +100,13 @@ MatchTableAbstract::apply_action(Packet *pkt) {
 
   const ActionEntry &action_entry = lookup(*pkt, &hit, &handle);
 
+  // TODO(antonin): I hate this part, which requires this class to know that the
+  // lower 24 bits of the handle are used as an index. Is is expected that few
+  // people will ever use this index, but it is required for the implementation
+  // of direct-like extern instances.
+  pkt->set_entry_index(
+      hit ? (handle & 0x00ffffff) : Packet::INVALID_ENTRY_INDEX);
+
   if (hit && with_meters) {
     // we only execute the direct meter if hit, should we have a miss meter?
     Field &target_f = pkt->get_phv()->get_field(

--- a/src/bm_sim/packet.cpp
+++ b/src/bm_sim/packet.cpp
@@ -30,6 +30,7 @@ namespace bm {
 typedef Debugger::PacketId PacketId;
 
 constexpr size_t Packet::nb_registers;
+constexpr size_t Packet::INVALID_ENTRY_INDEX;
 
 copy_id_t
 CopyIdGenerator::add_one(packet_id_t packet_id) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,6 +28,7 @@ $(builddir)/libtestutils.la \
 common_source = main.cpp bmi_stubs.c primitives.cpp
 TESTS = test_actions \
 test_checksums \
+test_expressions \
 test_conditionals \
 test_data \
 test_handle_mgr \
@@ -59,6 +60,7 @@ check_PROGRAMS = $(TESTS) test_all
 # Sources for tests
 test_actions_SOURCES       = $(common_source) test_actions.cpp
 test_checksums_SOURCES     = $(common_source) test_checksums.cpp
+test_expressions_SOURCES   = $(common_source) test_expressions.cpp
 test_conditionals_SOURCES  = $(common_source) test_conditionals.cpp
 test_data_SOURCES          = $(common_source) test_data.cpp
 test_handle_mgr_SOURCES    = $(common_source) test_handle_mgr.cpp
@@ -88,6 +90,7 @@ test_bm_apps_SOURCES       = $(common_source) test_bm_apps.cpp
 test_all_SOURCES = $(common_source) \
 test_actions.cpp \
 test_checksums.cpp \
+test_expressions.cpp \
 test_conditionals.cpp \
 test_data.cpp \
 test_handle_mgr.cpp \

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -1,0 +1,71 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_sim/expressions.h>
+#include <bm/bm_sim/phv.h>
+
+// expressions are mostly tested in test_conditionals.cpp. This file is only
+// used for some edge case testing.
+
+using namespace::bm;
+
+class ExpressionsTest : public ::testing::Test {
+ protected:
+  PHVFactory phv_factory;
+  std::unique_ptr<PHV> phv;
+
+  HeaderType testHeaderType;
+  header_id_t testHeader1{0}, testHeader2{1};
+
+  ExpressionsTest()
+      : testHeaderType("test_t", 0) {
+    testHeaderType.push_back_field("f32", 32);
+    testHeaderType.push_back_field("f48", 48);
+    testHeaderType.push_back_field("f8", 8);
+    testHeaderType.push_back_field("f16", 16);
+    testHeaderType.push_back_field("f128", 128);
+    phv_factory.push_back_header("test1", testHeader1, testHeaderType);
+    phv_factory.push_back_header("test2", testHeader2, testHeaderType);
+  }
+
+  virtual void SetUp() {
+    phv = phv_factory.create();
+  }
+
+  // virtual void TearDown() {}
+};
+
+TEST_F(ExpressionsTest, EmptyArith) {
+  Expression expr;
+  expr.build();
+  ASSERT_TRUE(expr.empty());
+  const auto data = expr.eval_arith(*phv.get());
+  ASSERT_EQ(0, data.get<int>());
+}
+
+TEST_F(ExpressionsTest, EmptyBool) {
+  Expression expr;
+  expr.build();
+  ASSERT_TRUE(expr.empty());
+  const auto b = expr.eval_bool(*phv.get());
+  ASSERT_FALSE(b);
+}

--- a/tests/test_extern.cpp
+++ b/tests/test_extern.cpp
@@ -21,8 +21,10 @@
 #include <gtest/gtest.h>
 
 #include <bm/bm_sim/extern.h>
+#include <bm/bm_sim/P4Objects.h>
 
 #include <string>
+#include <vector>
 #include <cassert>
 
 using namespace bm;
@@ -76,6 +78,7 @@ class ExternCounter : public ExternType {
   size_t count{0};
 };
 
+// do not put these inside an anonymous namespace or some compilers may complain
 BM_REGISTER_EXTERN(ExternCounter);
 BM_REGISTER_EXTERN_METHOD(ExternCounter, increment);
 BM_REGISTER_EXTERN_METHOD(ExternCounter, increment_by, const Data &);
@@ -84,6 +87,81 @@ BM_REGISTER_EXTERN_METHOD(ExternCounter, get);
 
 constexpr unsigned int ExternCounter::PACKETS;
 constexpr unsigned int ExternCounter::BYTES;
+
+// this demonstrates how p4objects can be used in an extern for more advanced
+// use cases
+class ExternP4Objects : public ExternType {
+ public:
+  BM_EXTERN_ATTRIBUTES {
+    BM_EXTERN_ATTRIBUTE_ADD(register_name);
+  }
+
+  void init() override {
+    register_array = get_p4objects().get_register_array(register_name);
+  }
+
+  size_t read(const Data &idx) const {
+    const auto idx_v = idx.get<size_t>();
+    return register_array->at(idx_v).get<size_t>();
+  }
+
+  // not exposed as an extern method, for testing
+  RegisterArray *get_register_array() const {
+    return register_array;
+  }
+
+ private:
+  // declared attributes
+  std::string register_name{};
+
+  // implementation members
+  RegisterArray *register_array{nullptr};
+};
+
+BM_REGISTER_EXTERN(ExternP4Objects);
+BM_REGISTER_EXTERN_METHOD(ExternP4Objects, read, const Data &);
+
+// this demonstrates how expressions can be used as extern attributes
+// this extern type has 2 attributes: an expression and one integral value
+// (var1); it has one additional integral value which is not an attribute but
+// can be set by a method (var2). The execute method evaluates the expression,
+// using var1 and var2 as locals.
+class ExternExpression : public ExternType {
+ public:
+  BM_EXTERN_ATTRIBUTES {
+    BM_EXTERN_ATTRIBUTE_ADD(expr);
+    BM_EXTERN_ATTRIBUTE_ADD(var1);
+  }
+
+  void init() override {
+    vars.push_back(var1);
+    vars.emplace_back(0);
+  }
+
+  void set_var2(const Data &v) {
+    vars.at(1) = v;
+  }
+
+  void execute(Data &dest) const {
+    auto phv = get_packet().get_phv();
+    // 'vars' passed as locals to evaluate expression
+    expr.eval_arith(*phv, &dest, vars);
+  }
+
+ private:
+  // declared attributes
+  Expression expr{};
+  Data var1{0};
+
+  // implementation members
+  std::vector<Data> vars{};
+};
+
+BM_REGISTER_EXTERN(ExternExpression);
+BM_REGISTER_EXTERN_METHOD(ExternExpression, set_var2, const Data &);
+BM_REGISTER_EXTERN_METHOD(ExternExpression, execute, Data &);
+
+namespace {
 
 // Google Test fixture for extern tests
 class ExternTest : public ::testing::Test {
@@ -196,3 +274,58 @@ TEST_F(ExternTest, NameAndId) {
   ASSERT_EQ(name, extern_instance->get_name());
   ASSERT_EQ(id, extern_instance->get_id());
 }
+
+TEST_F(ExternTest, ExternP4Objects) {
+  auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
+      "ExternP4Objects");
+  auto typed_instance = dynamic_cast<ExternP4Objects *>(extern_instance.get());
+  ASSERT_NE(nullptr, typed_instance);
+  extern_instance->_register_attributes();
+  ASSERT_TRUE(extern_instance->_has_attribute("register_name"));
+  extern_instance->_set_attribute<std::string>("register_name", "my_register");
+
+  // build a P4Objects instance with just one register array for testing
+  std::stringstream is;
+  is << "{\"register_arrays\":[{\"name\":\"my_register\",\"id\":0,"
+     << "\"size\":1024,\"bitwidth\":32}]}";
+  P4Objects objects;
+  LookupStructureFactory factory;
+  ASSERT_EQ(0, objects.init_objects(&is, &factory));
+  auto register_array = objects.get_register_array("my_register");
+  ASSERT_NE(nullptr, register_array);
+
+  extern_instance->_set_p4objects(&objects);
+  extern_instance->init();
+  ASSERT_EQ(register_array, typed_instance->get_register_array());
+}
+
+TEST_F(ExternTest, ExternExpression) {
+  auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
+      "ExternExpression");
+  extern_instance->_register_attributes();
+  Data var1(77), var2(55);
+  extern_instance->_set_attribute<Data>("var1", var1);
+  Expression expr;
+  expr.push_back_load_local(0);
+  expr.push_back_load_local(1);
+  expr.push_back_op(ExprOpcode::ADD);
+  expr.build();
+  extern_instance->_set_attribute<Expression>("expr", expr);
+  extern_instance->init();
+
+  auto primitive_1 = get_extern_primitive("ExternExpression", "set_var2");
+  auto primitive_2 = get_extern_primitive("ExternExpression", "execute");
+  testActionFn.push_back_primitive(primitive_1);
+  testActionFn.parameter_push_back_extern_instance(extern_instance.get());
+  testActionFn.parameter_push_back_const(var2);
+  testActionFn.push_back_primitive(primitive_2);
+  testActionFn.parameter_push_back_extern_instance(extern_instance.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);  // f32
+  testActionFnEntry(pkt.get());
+
+  const auto &dst = pkt->get_phv()->get_field(testHeader1, 0);
+  const auto expected = var1.get<int>() + var2.get<int>();
+  ASSERT_EQ(expected, dst.get<int>());
+}
+
+}  // namespace

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -269,8 +269,8 @@ TEST(P4Objects, ExternInstanceDeclaration) {
     create_extern_instance_json(&is, "my_extern_instance", "my_extern_type",
                                 "attr1", "unsupported_type");
     std::string expected_error_msg(
-        "Only attributes of type 'hexstr' are supported for "
-        "extern instance attribute initialization\n");
+        "Only attributes of type 'hexstr', 'string' or 'expression' are "
+        "supported for extern instance attribute initialization\n");
     ASSERT_NE(0, objects.init_objects(&is, &factory));
     EXPECT_EQ(expected_error_msg, os.str());
   }


### PR DESCRIPTION
This adds more flexibility to the prototype extern implementation. An
extern instance can now access p4objects and can therefore get a
reference to any top-level P4 object by name. In order to achieve this,
I also added support for 'string' as an extern attribute type.

Furthermore, 'expression' is now also supported as an extern attribute
type.