### PR TITLE
Add written_to to Field to keep track of writes

### DIFF
--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -75,6 +75,7 @@ class Field : public Data {
       bignum::clear_bit(&value, nbits - 1);
       value += min;
     }
+    written_to = true;
     // TODO(antonin): should notifications be disabled for hidden fields?
     DEBUGGER_NOTIFY_UPDATE(*packet_id, my_id, bytes.data(), nbits);
   }
@@ -123,6 +124,7 @@ class Field : public Data {
         bignum::export_bytes(bytes.data(), nbytes, value - min - min);
       }
     }
+    written_to = true;
     DEBUGGER_NOTIFY_UPDATE(*packet_id, my_id, bytes.data(), nbits);
   }
 
@@ -155,12 +157,26 @@ class Field : public Data {
     return hidden;
   }
 
+  //! Set the value of the written_to flag for the field. This flag can be
+  //! queried at any time using get_written_to() and is used to check whether
+  //! the field has been modified since written_to was last set to `false`.
+  void set_written_to(bool v) {
+    written_to = v;
+  }
+
+  //! Get the value of the written_to flag. See set_written_to() for more
+  //! information.
+  bool get_written_to() const {
+    return written_to;
+  }
+
  private:
   int nbits;
   int nbytes;
   ByteContainer bytes;
   bool is_signed{false};
   bool hidden{false};
+  bool written_to{false};  // used to keep track of whether a field was modified
   Bignum mask{1};
   Bignum max{1};
   Bignum min{1};

--- a/include/bm/bm_sim/headers.h
+++ b/include/bm/bm_sim/headers.h
@@ -172,11 +172,14 @@ class Header : public NamedP4Object {
   //! Marks the header as not-valid
   void mark_invalid();
 
-  //! Sets all the fields in the header to value `0`
-  void reset() {
-    for (Field &f : fields)
-      f.set(0);
-  }
+  //! Sets all the fields in the header to value `0`.
+  void reset();
+
+  //! Set the written_to flag maintained by each field. This flag can be queried
+  //! at any time by the target, using the Field interface, and can be used to
+  //! check whether the field has been modified since written_to was last set to
+  //! `false`.
+  void set_written_to(bool written_to_value);
 
   //! Returns a reference to the Field at the specified offset, with bounds
   //! checking. If pos not within the range of the container, an exception of

--- a/include/bm/bm_sim/phv.h
+++ b/include/bm/bm_sim/phv.h
@@ -183,6 +183,12 @@ class PHV {
   //! Reset all header fields to `0`.
   void reset_headers();
 
+  //! Set the written_to flag maintained by each field. This flag can be queried
+  //! at any time by the target, using the Field interface, and can be used to
+  //! check whether the field has been modified since written_to was last set to
+  //! `false`.
+  void set_written_to(bool written_to_value);
+
   //! Deleted copy constructor
   PHV(const PHV &other) = delete;
   //! Deleted copy assignment operator

--- a/src/bm_sim/headers.cpp
+++ b/src/bm_sim/headers.cpp
@@ -137,6 +137,18 @@ Header::mark_invalid() {
   valid_field->set(0);
 }
 
+void
+Header::reset() {
+  for (Field &f : fields)
+    f.set(0);
+}
+
+void
+Header::set_written_to(bool written_to_value) {
+  for (Field &f : fields)
+    f.set_written_to(written_to_value);
+}
+
 void Header::extract(const char *data, const PHV &phv) {
   if (is_VL_header()) return extract_VL(data, phv);
   int hdr_offset = 0;

--- a/src/bm_sim/phv.cpp
+++ b/src/bm_sim/phv.cpp
@@ -51,9 +51,14 @@ PHV::reset_metadata() {
 
 void
 PHV::reset_headers() {
-  for (auto &h : headers) {
+  for (auto &h : headers)
     h.reset();
-  }
+}
+
+void
+PHV::set_written_to(bool written_to_value) {
+  for (auto &h : headers)
+    h.set_written_to(written_to_value);
 }
 
 void

--- a/tests/test_phv.cpp
+++ b/tests/test_phv.cpp
@@ -89,7 +89,7 @@ TEST_F(PHVTest, CopyHeaders) {
   ASSERT_EQ(f48, f48_2);
 }
 
-// we are testing that the $valid$ hidden field is poperly added internally by
+// we are testing that the $valid$ hidden field is properly added internally by
 // the HeaderType class, that it is properly accessible and that it is updated
 // properly.
 TEST_F(PHVTest, HiddenValid) {
@@ -139,6 +139,48 @@ TEST_F(PHVTest, FieldAliasDup) {
   const Field &f_alias = phv_2->get_field("test1.f16");
 
   ASSERT_EQ(&f, &f_alias);
+}
+
+TEST_F(PHVTest, WrittenTo) {
+  auto &f = phv->get_field("test1.f16");
+  auto reset = [&f]() {
+    f.set_written_to(false);
+    ASSERT_FALSE(f.get_written_to());
+  };
+  ASSERT_FALSE(f.get_written_to());
+
+  // testing different ways of modifying a field
+  f.set(0xab);
+  ASSERT_TRUE(f.get_written_to());
+  reset();
+  f.add(Data(1), Data(1));
+  ASSERT_TRUE(f.get_written_to());
+  reset();
+  const char data[] = {'a', 'b'};
+  f.set_bytes(data, sizeof(data));
+  ASSERT_TRUE(f.get_written_to());
+  reset();
+  f.extract(data, 0);
+  ASSERT_TRUE(f.get_written_to());
+  reset();
+
+  // modifying flag directly
+  f.set_written_to(true);
+  ASSERT_TRUE(f.get_written_to());
+  reset();
+
+  // through header method
+  auto &hdr = phv->get_header("test1");
+  hdr.set_written_to(true);
+  ASSERT_TRUE(f.get_written_to());
+  hdr.set_written_to(false);
+  ASSERT_FALSE(f.get_written_to());
+
+  // through phv method
+  phv->set_written_to(true);
+  ASSERT_TRUE(f.get_written_to());
+  phv->set_written_to(false);
+  ASSERT_FALSE(f.get_written_to());
 }
 
 using testing::Types;


### PR DESCRIPTION
This can be used by targets to check whether the field was written to.