### PR TITLE
Arbitrary names for externs.

### DIFF
--- a/include/bm/bm_sim/extern.h
+++ b/include/bm/bm_sim/extern.h
@@ -66,20 +66,22 @@ class ExternFactoryMap {
 #define BM_REGISTER_EXTERN(extern_name) \
   BM_REGISTER_EXTERN_W_NAME(extern_name, extern_name)
 
-#define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__, extern_method_name, ...) \
-  template <typename... Args>                                                            \
-  struct _##extern_name##_##extern_method_name##_0                                       \
-      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {                      \
-    void operator ()(::bm::ExternType *instance, Args... args) override {                \
-      auto lock = instance->_unique_lock();                                              \
-      instance->_set_packet_ptr(&this->get_packet());                                    \
-      dynamic_cast<extern__ *>(instance)->extern_method_name(args...);                   \
-    }                                                                                    \
-  };                                                                                     \
-  struct _##extern_name##_##extern_method_name                                           \
-      : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {};                \
-  REGISTER_PRIMITIVE_W_NAME(_BM_EXTERN_TO_STRING(_##extern_name##_##extern_method_name), \
-                            _##extern_name##_##extern_method_name)
+#define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__,           \
+                                         extern_method_name, ...)         \
+  template <typename... Args>                                             \
+  struct _##extern_name##_##extern_method_name##_0                        \
+      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {       \
+    void operator ()(::bm::ExternType *instance, Args... args) override { \
+      auto lock = instance->_unique_lock();                               \
+      instance->_set_packet_ptr(&this->get_packet());                     \
+      dynamic_cast<extern__ *>(instance)->extern_method_name(args...);    \
+    }                                                                     \
+  };                                                                      \
+  struct _##extern_name##_##extern_method_name                            \
+      : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {}; \
+  REGISTER_PRIMITIVE_W_NAME(                                              \
+    _BM_EXTERN_TO_STRING(_##extern_name##_##extern_method_name),          \
+    _##extern_name##_##extern_method_name)
 
 #define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...)   \
   template <typename... Args>                                             \
@@ -97,7 +99,7 @@ class ExternFactoryMap {
 
 #define BM_EXTERN_ATTRIBUTES void _register_attributes() override
 
-#define BM_EXTERN_ATTRIBUTE_ADD(attr_name)                      \
+#define BM_EXTERN_ATTRIBUTE_ADD(attr_name) \
   _add_attribute(#attr_name, static_cast<void *>(&attr_name));
 
 

--- a/include/bm/bm_sim/extern.h
+++ b/include/bm/bm_sim/extern.h
@@ -64,25 +64,36 @@ class ExternFactoryMap {
            [](){ return std::unique_ptr<ExternType>(new extern__()); });
 
 #define BM_REGISTER_EXTERN(extern_name) \
-    BM_REGISTER_EXTERN_W_NAME(extern_name, extern_name)
+  BM_REGISTER_EXTERN_W_NAME(extern_name, extern_name)
 
-#define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__, extern_method_name, ...)  \
-  template <typename... Args>                                                             \
-  struct _##extern__##_##extern_method_name##_0                                           \
-      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {                       \
-    void operator ()(::bm::ExternType *instance, Args... args) override {                 \
-      auto lock = instance->_unique_lock();                                               \
-      instance->_set_packet_ptr(&this->get_packet());                                     \
-      dynamic_cast<extern__ *>(instance)->extern_method_name(args...);                    \
-    }                                                                                     \
-  };                                                                                      \
-  struct _##extern__##_##extern_method_name                                               \
-      : public _##extern__##_##extern_method_name##_0<__VA_ARGS__> {};                    \
-  REGISTER_PRIMITIVE_W_NAME(_BM_EXTERN_TO_STRING(_##extern_name##_##extern_method_name),  \
-                            _##extern__##_##extern_method_name)
+#define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__, extern_method_name, ...) \
+  template <typename... Args>                                                            \
+  struct _##extern_name##_##extern_method_name##_0                                       \
+      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {                      \
+    void operator ()(::bm::ExternType *instance, Args... args) override {                \
+      auto lock = instance->_unique_lock();                                              \
+      instance->_set_packet_ptr(&this->get_packet());                                    \
+      dynamic_cast<extern__ *>(instance)->extern_method_name(args...);                   \
+    }                                                                                    \
+  };                                                                                     \
+  struct _##extern_name##_##extern_method_name                                           \
+      : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {};                \
+  REGISTER_PRIMITIVE_W_NAME(_BM_EXTERN_TO_STRING(_##extern_name##_##extern_method_name), \
+                            _##extern_name##_##extern_method_name)
 
 #define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...)   \
-    BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern_name, extern_method_name, ...)
+  template <typename... Args>                                             \
+  struct _##extern_name##_##extern_method_name##_0                        \
+      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {       \
+    void operator ()(::bm::ExternType *instance, Args... args) override { \
+      auto lock = instance->_unique_lock();                               \
+      instance->_set_packet_ptr(&this->get_packet());                     \
+      dynamic_cast<extern_name *>(instance)->extern_method_name(args...); \
+    }                                                                     \
+  };                                                                      \
+  struct _##extern_name##_##extern_method_name                            \
+      : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {}; \
+  REGISTER_PRIMITIVE(_##extern_name##_##extern_method_name)
 
 #define BM_EXTERN_ATTRIBUTES void _register_attributes() override
 

--- a/include/bm/bm_sim/extern.h
+++ b/include/bm/bm_sim/extern.h
@@ -64,8 +64,8 @@ class ExternFactoryMap {
            [](){ return std::unique_ptr<ExternType>(new extern_name()); });
 
 #define BM_REGISTER_EXTERN_W_NAME(extern_name, extern__)                \
-  static_assert(std::is_default_constructible<extern__>::value,          \
-                "User-defined extern type " #extern__                    \
+  static_assert(std::is_default_constructible<extern__>::value,         \
+                "User-defined extern type " #extern__                   \
                 " needs to be default-constructible");                  \
   int _extern_##extern_name##_create_ =                                 \
       ::bm::ExternFactoryMap::get_instance()->register_extern_type(     \
@@ -97,8 +97,9 @@ class ExternFactoryMap {
     }                                                                                     \
   };                                                                                      \
   struct _##extern__##_##extern_method_name                                               \
-      : public _##extern__##_##extern_method_name##_0<__VA_ARGS__> {};                 \
-  REGISTER_PRIMITIVE_W_NAME(TO_STRING(_##extern_name##_##extern_method_name), _##extern__##_##extern_method_name)
+      : public _##extern__##_##extern_method_name##_0<__VA_ARGS__> {};                    \
+  REGISTER_PRIMITIVE_W_NAME(TO_STRING(_##extern_name##_##extern_method_name),             \
+                            _##extern__##_##extern_method_name)
 
 #define BM_EXTERN_ATTRIBUTES void _register_attributes() override
 

--- a/include/bm/bm_sim/extern.h
+++ b/include/bm/bm_sim/extern.h
@@ -52,6 +52,8 @@ class ExternFactoryMap {
   std::unordered_map<std::string, ExternFactoryFn> factory_map{};
 };
 
+#define TO_STRING(name) #name
+
 #define BM_REGISTER_EXTERN(extern_name)                                 \
   static_assert(std::is_default_constructible<extern_name>::value,      \
                 "User-defined extern type " #extern_name                \
@@ -61,19 +63,42 @@ class ExternFactoryMap {
            #extern_name,                                                \
            [](){ return std::unique_ptr<ExternType>(new extern_name()); });
 
-#define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...) \
-  template <typename... Args>                                           \
-  struct _##extern_name##_##extern_method_name##_0                      \
-      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {     \
+#define BM_REGISTER_EXTERN_W_NAME(extern_name, extern__)                \
+  static_assert(std::is_default_constructible<extern__>::value,          \
+                "User-defined extern type " #extern__                    \
+                " needs to be default-constructible");                  \
+  int _extern_##extern_name##_create_ =                                 \
+      ::bm::ExternFactoryMap::get_instance()->register_extern_type(     \
+           #extern_name,                                                \
+           [](){ return std::unique_ptr<ExternType>(new extern__()); });
+
+#define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...)   \
+  template <typename... Args>                                             \
+  struct _##extern_name##_##extern_method_name##_0                        \
+      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {       \
     void operator ()(::bm::ExternType *instance, Args... args) override { \
-      auto lock = instance->_unique_lock();                             \
-      instance->_set_packet_ptr(&this->get_packet());                   \
+      auto lock = instance->_unique_lock();                               \
+      instance->_set_packet_ptr(&this->get_packet());                     \
       dynamic_cast<extern_name *>(instance)->extern_method_name(args...); \
-    }                                                                   \
-  };                                                                    \
-  struct _##extern_name##_##extern_method_name                          \
+    }                                                                     \
+  };                                                                      \
+  struct _##extern_name##_##extern_method_name                            \
       : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {}; \
   REGISTER_PRIMITIVE(_##extern_name##_##extern_method_name)
+
+#define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__, extern_method_name, ...)  \
+  template <typename... Args>                                                             \
+  struct _##extern__##_##extern_method_name##_0                                           \
+      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {                       \
+    void operator ()(::bm::ExternType *instance, Args... args) override {                 \
+      auto lock = instance->_unique_lock();                                               \
+      instance->_set_packet_ptr(&this->get_packet());                                     \
+      dynamic_cast<extern__ *>(instance)->extern_method_name(args...);                    \
+    }                                                                                     \
+  };                                                                                      \
+  struct _##extern__##_##extern_method_name                                               \
+      : public _##extern__##_##extern_method_name##_0<__VA_ARGS__> {};                 \
+  REGISTER_PRIMITIVE_W_NAME(TO_STRING(_##extern_name##_##extern_method_name), _##extern__##_##extern_method_name)
 
 #define BM_EXTERN_ATTRIBUTES void _register_attributes() override
 

--- a/include/bm/bm_sim/extern.h
+++ b/include/bm/bm_sim/extern.h
@@ -52,16 +52,7 @@ class ExternFactoryMap {
   std::unordered_map<std::string, ExternFactoryFn> factory_map{};
 };
 
-#define TO_STRING(name) #name
-
-#define BM_REGISTER_EXTERN(extern_name)                                 \
-  static_assert(std::is_default_constructible<extern_name>::value,      \
-                "User-defined extern type " #extern_name                \
-                " needs to be default-constructible");                  \
-  int _extern_##extern_name##_create_ =                                 \
-      ::bm::ExternFactoryMap::get_instance()->register_extern_type(     \
-           #extern_name,                                                \
-           [](){ return std::unique_ptr<ExternType>(new extern_name()); });
+#define _BM_EXTERN_TO_STRING(name) #name
 
 #define BM_REGISTER_EXTERN_W_NAME(extern_name, extern__)                \
   static_assert(std::is_default_constructible<extern__>::value,         \
@@ -72,19 +63,11 @@ class ExternFactoryMap {
            #extern_name,                                                \
            [](){ return std::unique_ptr<ExternType>(new extern__()); });
 
+#define BM_REGISTER_EXTERN(extern_name) \
+    BM_REGISTER_EXTERN_W_NAME(#extern_name, extern_name)
+
 #define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...)   \
-  template <typename... Args>                                             \
-  struct _##extern_name##_##extern_method_name##_0                        \
-      : public ::bm::ActionPrimitive<::bm::ExternType *, Args...> {       \
-    void operator ()(::bm::ExternType *instance, Args... args) override { \
-      auto lock = instance->_unique_lock();                               \
-      instance->_set_packet_ptr(&this->get_packet());                     \
-      dynamic_cast<extern_name *>(instance)->extern_method_name(args...); \
-    }                                                                     \
-  };                                                                      \
-  struct _##extern_name##_##extern_method_name                            \
-      : public _##extern_name##_##extern_method_name##_0<__VA_ARGS__> {}; \
-  REGISTER_PRIMITIVE(_##extern_name##_##extern_method_name)
+    BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern_name, extern_method_name, ...)
 
 #define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__, extern_method_name, ...)  \
   template <typename... Args>                                                             \
@@ -98,7 +81,7 @@ class ExternFactoryMap {
   };                                                                                      \
   struct _##extern__##_##extern_method_name                                               \
       : public _##extern__##_##extern_method_name##_0<__VA_ARGS__> {};                    \
-  REGISTER_PRIMITIVE_W_NAME(TO_STRING(_##extern_name##_##extern_method_name),             \
+  REGISTER_PRIMITIVE_W_NAME(_BM_EXTERN_TO_STRING(_##extern_name##_##extern_method_name),  \
                             _##extern__##_##extern_method_name)
 
 #define BM_EXTERN_ATTRIBUTES void _register_attributes() override

--- a/include/bm/bm_sim/extern.h
+++ b/include/bm/bm_sim/extern.h
@@ -64,10 +64,7 @@ class ExternFactoryMap {
            [](){ return std::unique_ptr<ExternType>(new extern__()); });
 
 #define BM_REGISTER_EXTERN(extern_name) \
-    BM_REGISTER_EXTERN_W_NAME(#extern_name, extern_name)
-
-#define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...)   \
-    BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern_name, extern_method_name, ...)
+    BM_REGISTER_EXTERN_W_NAME(extern_name, extern_name)
 
 #define BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern__, extern_method_name, ...)  \
   template <typename... Args>                                                             \
@@ -83,6 +80,9 @@ class ExternFactoryMap {
       : public _##extern__##_##extern_method_name##_0<__VA_ARGS__> {};                    \
   REGISTER_PRIMITIVE_W_NAME(_BM_EXTERN_TO_STRING(_##extern_name##_##extern_method_name),  \
                             _##extern__##_##extern_method_name)
+
+#define BM_REGISTER_EXTERN_METHOD(extern_name, extern_method_name, ...)   \
+    BM_REGISTER_EXTERN_W_NAME_METHOD(extern_name, extern_name, extern_method_name, ...)
 
 #define BM_EXTERN_ATTRIBUTES void _register_attributes() override
 

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -135,7 +135,7 @@ REGISTER_PRIMITIVE(shift_right);
 class drop : public ActionPrimitive<> {
   void operator ()() {
     get_field("standard_metadata.egress_spec").set(511);
-    if (get_phv().has_header("intrinsic_metadata")) {
+    if (get_phv().has_field("intrinsic_metadata.mcast_grp")) {
       get_field("intrinsic_metadata.mcast_grp").set(0);
     }
   }

--- a/tests/test_extern.cpp
+++ b/tests/test_extern.cpp
@@ -87,7 +87,8 @@ BM_REGISTER_EXTERN_METHOD(ExternCounter, get);
 
 BM_REGISTER_EXTERN_W_NAME(counter2, ExternCounter);
 BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, increment);
-BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, increment_by, const Data &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter,
+                                 increment_by, const Data &);
 BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, reset);
 BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, get);
 
@@ -337,11 +338,12 @@ TEST_F(ExternTest, ExternExpression) {
 TEST_F(ExternTest, ExternCounterRename) {
   // check the objects are both retrievable
   auto check_name = [](const std::string &name) {
-    auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
-        name);
+    auto extern_instance =
+        ExternFactoryMap::get_instance()->get_extern_instance(name);
     extern_instance->_register_attributes();
     extern_instance->init();
-    auto counter_instance = dynamic_cast<ExternCounter *>(extern_instance.get());
+    auto counter_instance =
+        dynamic_cast<ExternCounter *>(extern_instance.get());
     ASSERT_NE(nullptr, counter_instance);
 
     auto primitive = get_extern_primitive(name, "increment_by");

--- a/tests/test_extern.cpp
+++ b/tests/test_extern.cpp
@@ -85,6 +85,12 @@ BM_REGISTER_EXTERN_METHOD(ExternCounter, increment_by, const Data &);
 BM_REGISTER_EXTERN_METHOD(ExternCounter, reset);
 BM_REGISTER_EXTERN_METHOD(ExternCounter, get);
 
+BM_REGISTER_EXTERN_W_NAME(counter2, ExternCounter);
+BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, increment);
+BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, increment_by, const Data &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, reset);
+BM_REGISTER_EXTERN_W_NAME_METHOD(counter2, ExternCounter, get);
+
 constexpr unsigned int ExternCounter::PACKETS;
 constexpr unsigned int ExternCounter::BYTES;
 
@@ -326,6 +332,24 @@ TEST_F(ExternTest, ExternExpression) {
   const auto &dst = pkt->get_phv()->get_field(testHeader1, 0);
   const auto expected = var1.get<int>() + var2.get<int>();
   ASSERT_EQ(expected, dst.get<int>());
+}
+
+TEST_F(ExternTest, ExternCounterRename) {
+  // check the objects are both retrievable
+  auto check_name = [](const std::string &name) {
+    auto extern_instance = ExternFactoryMap::get_instance()->get_extern_instance(
+        name);
+    extern_instance->_register_attributes();
+    extern_instance->init();
+    auto counter_instance = dynamic_cast<ExternCounter *>(extern_instance.get());
+    ASSERT_NE(nullptr, counter_instance);
+
+    auto primitive = get_extern_primitive(name, "increment_by");
+    ASSERT_NE(nullptr, primitive);
+  };
+
+  check_name("ExternCounter");
+  check_name("counter2");
 }
 
 }  // namespace


### PR DESCRIPTION
Allows you to register externs with names different from the respective class name. This is useful for externs like "register", because "register" is a reserved word in C++.