### PR TITLE
Add ability to dump first packet bytes in log

### DIFF
--- a/include/bm/bm_sim/bytecontainer.h
+++ b/include/bm/bm_sim/bytecontainer.h
@@ -28,7 +28,6 @@
 #include <vector>
 #include <iterator>
 #include <string>
-#include <iomanip>
 
 #include "short_alloc.h"
 

--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -184,6 +184,10 @@ class DevMgr : public PacketDispatcherIface {
  protected:
   ~DevMgr();
 
+  std::string sample_packet_data(const char *buffer, int len);
+
+  size_t dump_packet_data{0};
+
  private:
   // Actual implementation (private)
   std::unique_ptr<DevMgrIface> pimp{nullptr};

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -82,6 +82,7 @@ class OptionsParser {
   bool debugger{false};
   std::string debugger_addr{};
   std::string state_file_path{};
+  size_t dump_packet_data{0};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -124,6 +124,8 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   //! simple_switch target uses this to reset PRE state.
   virtual void reset_target_state() { }
 
+  void receive_(int port_num, const char *buffer, int len);
+
   //! Returns the Thrift port used for the runtime RPC server.
   int get_runtime_port() const { return thrift_port; }
 

--- a/src/bm_sim/bytecontainer.cpp
+++ b/src/bm_sim/bytecontainer.cpp
@@ -21,8 +21,9 @@
 #include <bm/bm_sim/bytecontainer.h>
 
 #include <string>
-#include <iostream>
 #include <sstream>
+
+#include "utils.h"
 
 namespace bm {
 
@@ -31,15 +32,7 @@ ByteContainer::to_hex(size_t start, size_t s, bool upper_case) const {
   assert(start + s <= size());
 
   std::ostringstream ret;
-
-  for (std::string::size_type i = start; i < start + s; i++) {
-    ret << std::setw(2) << std::setfill('0') << std::hex
-        << (upper_case ? std::uppercase : std::nouppercase)
-        // the int cast was not sufficient 0xab -> 0xffffffab
-        // << static_cast<int>(bytes[i]);
-        << static_cast<int>(static_cast<unsigned char>(bytes[i]));
-  }
-
+  utils::dump_hexstring(ret, &bytes[start], &bytes[start + s], upper_case);
   return ret.str();
 }
 

--- a/src/bm_sim/dev_mgr.cpp
+++ b/src/bm_sim/dev_mgr.cpp
@@ -24,10 +24,14 @@
 #include <bm/bm_sim/nn.h>
 
 #include <cassert>
+#include <algorithm>  // std::min
 #include <thread>
 #include <mutex>
 #include <string>
 #include <map>
+#include <sstream>  // std::ostringstream
+
+#include "utils.h"
 
 #define UNUSED(x) (void)(x)
 
@@ -193,6 +197,10 @@ DevMgr::port_add(const std::string &iface_name, port_t port_num,
 void
 DevMgr::transmit_fn(int port_num, const char *buffer, int len) {
   assert(pimp);
+  if (dump_packet_data > 0) {
+    Logger::get()->info("Sending packet of length {} on port {}: {}",
+                        len, port_num, sample_packet_data(buffer, len));
+  }
   pimp->transmit_fn(port_num, buffer, len);
 }
 
@@ -229,6 +237,15 @@ std::map<DevMgrIface::port_t, DevMgrIface::PortInfo>
 DevMgr::get_port_info() const {
   assert(pimp);
   return pimp->get_port_info();
+}
+
+std::string
+DevMgr::sample_packet_data(const char *buffer, int len) {
+  size_t amount = std::min(dump_packet_data, static_cast<size_t>(len));
+  assert(amount > 0);
+  std::ostringstream ret;
+  utils::dump_hexstring(ret, &buffer[0], &buffer[amount]);
+  return ret.str();
 }
 
 }  // namespace bm

--- a/src/bm_sim/logger.cpp
+++ b/src/bm_sim/logger.cpp
@@ -78,17 +78,17 @@ spdlog::level::level_enum
 Logger::to_spd_level(LogLevel level) {
   namespace spdL = spdlog::level;
   switch (level) {
-  case LogLevel::TRACE: return spdL::trace;
-  case LogLevel::DEBUG: return spdL::debug;
-  case LogLevel::INFO: return spdL::info;
-  case LogLevel::NOTICE: return spdL::notice;
-  case LogLevel::WARN: return spdL::warn;
-  case LogLevel::ERROR: return spdL::err;
-  case LogLevel::CRITICAL: return spdL::critical;
-  case LogLevel::ALERT: return spdL::alert;
-  case LogLevel::EMERG: return spdL::emerg;
-  case LogLevel::OFF: return spdL::off;
-  default: return spdL::off;
+    case LogLevel::TRACE: return spdL::trace;
+    case LogLevel::DEBUG: return spdL::debug;
+    case LogLevel::INFO: return spdL::info;
+    case LogLevel::NOTICE: return spdL::notice;
+    case LogLevel::WARN: return spdL::warn;
+    case LogLevel::ERROR: return spdL::err;
+    case LogLevel::CRITICAL: return spdL::critical;
+    case LogLevel::ALERT: return spdL::alert;
+    case LogLevel::EMERG: return spdL::emerg;
+    case LogLevel::OFF: return spdL::off;
+    default: return spdL::off;
   }
 }
 

--- a/src/bm_sim/match_units.cpp
+++ b/src/bm_sim/match_units.cpp
@@ -67,22 +67,7 @@ MatchKeyParam::type_to_string(Type t) {
   return "";
 }
 
-namespace {
-
-// TODO(antonin): basically copied from ByteConatiner, need to avoid duplication
-void
-// NOLINTNEXTLINE(runtime/references)
-dump_hexstring(std::ostream &out, const std::string &s,
-               bool upper_case = false) {
-  utils::StreamStateSaver state_saver(out);
-  for (const char c : s) {
-    out << std::setw(2) << std::setfill('0') << std::hex
-        << (upper_case ? std::uppercase : std::nouppercase)
-        << static_cast<int>(static_cast<unsigned char>(c));
-  }
-}
-
-}  // namespace
+using utils::dump_hexstring;
 
 std::ostream& operator<<(std::ostream &out, const MatchKeyParam &p) {
   // need to restore the state right away (thus the additional scope), otherwise

--- a/src/bm_sim/parser.cpp
+++ b/src/bm_sim/parser.cpp
@@ -616,7 +616,7 @@ Parser::parse(Packet *pkt) const {
   size_t bytes_parsed = 0;
   while (next_state) {
     next_state = (*next_state)(pkt, data, &bytes_parsed);
-    BMLOG_TRACE("Bytes parsed: {}", bytes_parsed);
+    BMLOG_TRACE_PKT(*pkt, "Bytes parsed: {}", bytes_parsed);
   }
   pkt->remove(bytes_parsed);
   BMELOG(parser_done, *pkt, *this);

--- a/src/bm_sim/utils.h
+++ b/src/bm_sim/utils.h
@@ -21,6 +21,12 @@
 #ifndef BM_SIM_UTILS_H_
 #define BM_SIM_UTILS_H_
 
+#include <iterator>
+#include <iomanip>
+#include <ostream>
+#include <string>
+#include <type_traits>
+
 namespace bm {
 
 namespace utils {
@@ -39,6 +45,28 @@ struct StreamStateSaver final {
   std::ios &ref;
   std::ios state{nullptr};
 };
+
+template <typename It>
+inline void
+// NOLINTNEXTLINE(runtime/references)
+dump_hexstring(std::ostream &out , It first, It last, bool upper_case = false) {
+  static_assert(
+      std::is_same<typename std::iterator_traits<It>::value_type, char>::value,
+      "Iterator needs to dereference to char");
+  utils::StreamStateSaver state_saver(out);
+  for (auto it = first; it < last; ++it) {
+    out << std::setw(2) << std::setfill('0') << std::hex
+        << (upper_case ? std::uppercase : std::nouppercase)
+        << static_cast<int>(static_cast<unsigned char>(*it));
+  }
+}
+
+inline void
+// NOLINTNEXTLINE(runtime/references)
+dump_hexstring(std::ostream &out, const std::string &s,
+               bool upper_case = false) {
+  dump_hexstring(out, s.begin(), s.end(), upper_case);
+}
 
 }  // namespace utils
 


### PR DESCRIPTION
This is done using the --dump-packet-data command line option. This
option takes one argument (the number of bytes to dump). Bytes are
dumped when the packet is received and when its is sent. Because at this
stage no Packet instance exists yet, the packet id cannot be included in
the log message.

This commit also includes some minor improvements and fixes a casting
bug.

```
[17:11:00.986] [bmv2] [D] [thread 9960] [0.0] [cxt 0] Deparser 'deparser': end
[17:11:00.986] [bmv2] [D] [thread 9964] [0.0] [cxt 0] Transmitting packet of size 83 out of port 0
[17:11:00.986] [bmv2] [I] [thread 9964] Sending packet of length 83 on port 0: ffffffffffff0000000000000800450000450001000040067cb07f0000017f00
[17:11:03.462] [bmv2] [I] [thread 9957] Received packet of length 83 on port 1: ffffffffffff0000000000000800450000450001000040067cb07f0000017f00
[17:11:03.462] [bmv2] [D] [thread 9959] [1.0] [cxt 0] Processing packet received on port 1
[17:11:03.462] [bmv2] [D] [thread 9959] [1.0] [cxt 0] Parser 'parser': start
```