### PR TITLE
Add methods to simple_switch to get elapsed time

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -201,6 +201,17 @@ SimpleSwitch::set_all_egress_queue_rates(const uint64_t rate_pps) {
   return 0;
 }
 
+uint64_t
+SimpleSwitch::get_time_elapsed_us() const {
+  return get_ts().count();
+}
+
+uint64_t
+SimpleSwitch::get_time_since_epoch_us() const {
+  auto tp = clock::now();
+  return duration_cast<ts_res>(tp.time_since_epoch()).count();
+}
+
 void
 SimpleSwitch::transmit_thread() {
   while (1) {

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -100,6 +100,12 @@ class SimpleSwitch : public Switch {
   int set_egress_queue_rate(int port, const uint64_t rate_pps);
   int set_all_egress_queue_rates(const uint64_t rate_pps);
 
+  // returns the number of microseconds elapsed since the switch started
+  uint64_t get_time_elapsed_us() const;
+
+  // returns the number of microseconds elasped since the clock's epoch
+  uint64_t get_time_since_epoch_us() const;
+
  private:
   static constexpr size_t nb_egress_threads = 4u;
 

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -68,6 +68,14 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
         mirror_id = int(line)
         self.sswitch_client.mirroring_mapping_delete(mirror_id)
 
+    def do_get_time_elapsed(self, line):
+        "Get time elapsed (in microseconds) since the switch started: get_time_elapsed"
+        print self.sswitch_client.get_time_elapsed_us()
+
+    def do_get_time_since_epoch(self, line):
+        "Get time elapsed (in microseconds) since the switch clock's epoch: get_time_since_epoch"
+        print self.sswitch_client.get_time_since_epoch_us()
+
 def main():
     args = runtime_CLI.get_parser().parse_args()
 

--- a/targets/simple_switch/thrift/simple_switch.thrift
+++ b/targets/simple_switch/thrift/simple_switch.thrift
@@ -32,4 +32,9 @@ service SimpleSwitch {
   i32 set_egress_queue_rate(1:i32 port_num, 2:i64 rate_pps);
   i32 set_all_egress_queue_rates(1:i64 rate_pps);
 
+  // these methods are here as an experiment, prefer get_time_elapsed_us() when
+  // possible
+  i64 get_time_elapsed_us();
+  i64 get_time_since_epoch_us();
+
 }

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -89,6 +89,18 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     return switch_->set_all_egress_queue_rates(static_cast<uint64_t>(rate_pps));
   }
 
+  int64_t get_time_elapsed_us() {
+    bm::Logger::get()->trace("get_time_elapsed_us");
+    // cast from unsigned to signed
+    return static_cast<int64_t>(switch_->get_time_elapsed_us());
+  }
+
+  int64_t get_time_since_epoch_us() {
+    bm::Logger::get()->trace("get_time_since_epoch_us");
+    // cast from unsigned to signed
+    return static_cast<int64_t>(switch_->get_time_since_epoch_us());
+  }
+
  private:
   SimpleSwitch *switch_;
 };


### PR DESCRIPTION
Added Thrift RPC methods get_time_elapsed_us() and
get_time_since_epoch_us(). These methods are also exposed in the
simple_switch CLI.

These methods are more of an experiment here. One or both may move to
the main bmv2 code in the future if they prove useful.