### PR TITLE
Increase tolerance margin in queueing unit test

### DIFF
--- a/tests/test_queueing.cpp
+++ b/tests/test_queueing.cpp
@@ -320,5 +320,7 @@ TEST_F(QueueingPriRLTest, PriRateLimiter) {
   else
     diff = priority_0 - priority_1;
 
-  ASSERT_LT(diff, std::max(priority_0, priority_1) * 0.1);
+  // was originally 10%, but replaced it with 25% as the test would fail from
+  // time to time (on slower machines?)
+  ASSERT_LT(diff, std::max(priority_0, priority_1) * 0.25);
 }


### PR DESCRIPTION
The test is PriRateLimiter. Related to issue #247.