### PR TITLE
Add flag to configure to skip undeterministic test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,12 @@ AS_IF([test "x$enable_elogger" != "xno"], [
     MY_CPPFLAGS="$MY_CPPFLAGS -DBMELOG_ON"
 ])
 
+AC_ARG_ENABLE([undeterministic_tests],
+    AS_HELP_STRING([--disable-undeterministic-tests],
+                   [Skip undeterministic tests (e.g. queueing) when running "make check"]))
+AM_CONDITIONAL([SKIP_UNDETERMINISTIC_TESTS],
+               [test "x$enable_undeterministic_tests" = "xno"])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,11 @@ libtestutils_la_LIBADD = $(top_builddir)/src/bm_sim/libbmsim.la
 AM_CPPFLAGS += \
 -isystem $(top_srcdir)/third_party/gtest/include \
 -DTESTDATADIR=\"$(srcdir)/testdata\"
+
+if SKIP_UNDETERMINISTIC_TESTS
+    AM_CPPFLAGS += -DSKIP_UNDETERMINISTIC_TESTS
+endif
+
 LDADD = \
 $(top_builddir)/third_party/gtest/libgtest.la \
 $(top_builddir)/src/bm_runtime/libbmruntime.la \

--- a/tests/test_queueing.cpp
+++ b/tests/test_queueing.cpp
@@ -223,6 +223,8 @@ struct RndInputPri {
   size_t priority;
 };
 
+#ifndef SKIP_UNDETERMINISTIC_TESTS
+
 class QueueingPriRLTest : public ::testing::Test {
  protected:
   typedef std::unique_ptr<int> T;
@@ -320,7 +322,9 @@ TEST_F(QueueingPriRLTest, PriRateLimiter) {
   else
     diff = priority_0 - priority_1;
 
-  // was originally 10%, but replaced it with 25% as the test would fail from
+  // was originally 10%, but replaced it with 20% as the test would fail from
   // time to time (on slower machines?)
-  ASSERT_LT(diff, std::max(priority_0, priority_1) * 0.25);
+  ASSERT_LT(diff, std::max(priority_0, priority_1) * 0.2);
 }
+
+#endif  // SKIP_UNDETERMINISTIC_TESTS


### PR DESCRIPTION
The flag is --disable-undeterministic-tests. Right now the only tests
affected are QueueingPriRLTest unit tests, which tend to fail on slower
machines.