### PR TITLE
Update JSON files for examples

### DIFF
--- a/targets/l2_switch/l2_switch.json
+++ b/targets/l2_switch/l2_switch.json
@@ -1,4 +1,10 @@
 {
+    "__meta__": {
+        "version": [
+            2,
+            0
+        ]
+    },
     "header_types": [
         {
             "name": "standard_metadata_t",
@@ -36,7 +42,9 @@
                     "_padding",
                     5
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         },
         {
             "name": "ethernet_t",
@@ -54,7 +62,9 @@
                     "etherType",
                     16
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         },
         {
             "name": "intrinsic_metadata_t",
@@ -68,24 +78,29 @@
                     "mgid",
                     4
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         }
     ],
     "headers": [
         {
             "name": "standard_metadata",
             "id": 0,
-            "header_type": "standard_metadata_t"
+            "header_type": "standard_metadata_t",
+            "metadata": true
         },
         {
             "name": "ethernet",
             "id": 1,
-            "header_type": "ethernet_t"
+            "header_type": "ethernet_t",
+            "metadata": false
         },
         {
             "name": "intrinsic_metadata",
             "id": 2,
-            "header_type": "intrinsic_metadata_t"
+            "header_type": "intrinsic_metadata_t",
+            "metadata": true
         }
     ],
     "header_stacks": [],
@@ -102,7 +117,8 @@
                     "transition_key": [],
                     "transitions": [
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": "parse_ethernet"
                         }
@@ -125,7 +141,8 @@
                     "transition_key": [],
                     "transitions": [
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": null
                         }
@@ -134,6 +151,7 @@
             ]
         }
     ],
+    "parse_vsets": [],
     "deparsers": [
         {
             "name": "deparser",
@@ -146,59 +164,8 @@
     "meter_arrays": [],
     "actions": [
         {
-            "name": "forward",
-            "id": 0,
-            "runtime_data": [
-                {
-                    "name": "port",
-                    "bitwidth": 9
-                }
-            ],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "standard_metadata",
-                                "egress_port"
-                            ]
-                        },
-                        {
-                            "type": "runtime_data",
-                            "value": 0
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "broadcast",
-            "id": 1,
-            "runtime_data": [],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "intrinsic_metadata",
-                                "mgid"
-                            ]
-                        },
-                        {
-                            "type": "hexstr",
-                            "value": "0x1"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "name": "mac_learn",
-            "id": 2,
+            "id": 0,
             "runtime_data": [],
             "primitives": [
                 {
@@ -233,6 +200,57 @@
             ]
         },
         {
+            "name": "broadcast",
+            "id": 1,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "intrinsic_metadata",
+                                "mgid"
+                            ]
+                        },
+                        {
+                            "type": "hexstr",
+                            "value": "0x1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "forward",
+            "id": 2,
+            "runtime_data": [
+                {
+                    "name": "port",
+                    "bitwidth": 9
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "standard_metadata",
+                                "egress_port"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "name": "_nop",
             "id": 3,
             "runtime_data": [],
@@ -252,13 +270,16 @@
                     "type": "simple",
                     "max_size": 512,
                     "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
                     "key": [
                         {
                             "match_type": "exact",
                             "target": [
                                 "ethernet",
                                 "srcAddr"
-                            ]
+                            ],
+                            "mask": null
                         }
                     ],
                     "actions": [
@@ -269,7 +290,7 @@
                         "mac_learn": "dmac",
                         "_nop": "dmac"
                     },
-                    "default_action": null
+                    "base_default_next": "dmac"
                 },
                 {
                     "name": "dmac",
@@ -278,13 +299,16 @@
                     "type": "simple",
                     "max_size": 512,
                     "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
                     "key": [
                         {
                             "match_type": "exact",
                             "target": [
                                 "ethernet",
                                 "dstAddr"
-                            ]
+                            ],
+                            "mask": null
                         }
                     ],
                     "actions": [
@@ -295,9 +319,10 @@
                         "forward": null,
                         "broadcast": null
                     },
-                    "default_action": null
+                    "base_default_next": null
                 }
             ],
+            "action_profiles": [],
             "conditionals": []
         },
         {
@@ -305,6 +330,7 @@
             "id": 1,
             "init_table": null,
             "tables": [],
+            "action_profiles": [],
             "conditionals": []
         }
     ],
@@ -331,5 +357,50 @@
                 }
             ]
         }
+    ],
+    "field_lists": [],
+    "counter_arrays": [],
+    "register_arrays": [],
+    "force_arith": [
+        [
+            "standard_metadata",
+            "ingress_port"
+        ],
+        [
+            "standard_metadata",
+            "packet_length"
+        ],
+        [
+            "standard_metadata",
+            "egress_spec"
+        ],
+        [
+            "standard_metadata",
+            "egress_port"
+        ],
+        [
+            "standard_metadata",
+            "egress_instance"
+        ],
+        [
+            "standard_metadata",
+            "instance_type"
+        ],
+        [
+            "standard_metadata",
+            "clone_spec"
+        ],
+        [
+            "standard_metadata",
+            "_padding"
+        ],
+        [
+            "intrinsic_metadata",
+            "learn_id"
+        ],
+        [
+            "intrinsic_metadata",
+            "mgid"
+        ]
     ]
 }

--- a/targets/simple_router/simple_router.json
+++ b/targets/simple_router/simple_router.json
@@ -1,4 +1,10 @@
 {
+    "__meta__": {
+        "version": [
+            2,
+            0
+        ]
+    },
     "header_types": [
         {
             "name": "standard_metadata_t",
@@ -36,7 +42,9 @@
                     "_padding",
                     5
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         },
         {
             "name": "ethernet_t",
@@ -54,7 +62,9 @@
                     "etherType",
                     16
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         },
         {
             "name": "ipv4_t",
@@ -108,7 +118,9 @@
                     "dstAddr",
                     32
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         },
         {
             "name": "routing_metadata_t",
@@ -118,7 +130,9 @@
                     "nhop_ipv4",
                     32
                 ]
-            ]
+            ],
+            "length_exp": null,
+            "max_length": null
         }
     ],
     "headers": [
@@ -161,7 +175,8 @@
                     "transition_key": [],
                     "transitions": [
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": "parse_ethernet"
                         }
@@ -192,12 +207,14 @@
                     ],
                     "transitions": [
                         {
-                            "value": "0x800",
+                            "type": "hexstr",
+                            "value": "0x0800",
                             "mask": null,
                             "next_state": "parse_ipv4"
                         },
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": null
                         }
@@ -220,7 +237,8 @@
                     "transition_key": [],
                     "transitions": [
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": null
                         }
@@ -229,6 +247,7 @@
             ]
         }
     ],
+    "parse_vsets": [],
     "deparsers": [
         {
             "name": "deparser",
@@ -240,23 +259,10 @@
         }
     ],
     "meter_arrays": [],
-    "counter_arrays": [],
-    "register_arrays": [],
     "actions": [
         {
-            "name": "_drop",
-            "id": 0,
-            "runtime_data": [],
-            "primitives": [
-                {
-                    "op": "drop",
-                    "parameters": []
-                }
-            ]
-        },
-        {
             "name": "set_nhop",
-            "id": 1,
+            "id": 0,
             "runtime_data": [
                 {
                     "name": "nhop_ipv4",
@@ -320,7 +326,7 @@
         },
         {
             "name": "rewrite_mac",
-            "id": 2,
+            "id": 1,
             "runtime_data": [
                 {
                     "name": "smac",
@@ -343,6 +349,17 @@
                             "value": 0
                         }
                     ]
+                }
+            ]
+        },
+        {
+            "name": "_drop",
+            "id": 2,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "drop",
+                    "parameters": []
                 }
             ]
         },
@@ -388,6 +405,7 @@
                     "type": "simple",
                     "max_size": 1024,
                     "with_counters": false,
+                    "direct_meters": null,
                     "support_timeout": false,
                     "key": [
                         {
@@ -395,7 +413,8 @@
                             "target": [
                                 "ipv4",
                                 "dstAddr"
-                            ]
+                            ],
+                            "mask": null
                         }
                     ],
                     "actions": [
@@ -406,7 +425,7 @@
                         "set_nhop": "forward",
                         "_drop": "forward"
                     },
-                    "default_action": null
+                    "base_default_next": "forward"
                 },
                 {
                     "name": "forward",
@@ -415,6 +434,7 @@
                     "type": "simple",
                     "max_size": 512,
                     "with_counters": false,
+                    "direct_meters": null,
                     "support_timeout": false,
                     "key": [
                         {
@@ -422,7 +442,8 @@
                             "target": [
                                 "routing_metadata",
                                 "nhop_ipv4"
-                            ]
+                            ],
+                            "mask": null
                         }
                     ],
                     "actions": [
@@ -433,9 +454,10 @@
                         "set_dmac": null,
                         "_drop": null
                     },
-                    "default_action": null
+                    "base_default_next": null
                 }
             ],
+            "action_profiles": [],
             "conditionals": [
                 {
                     "name": "_condition_0",
@@ -491,6 +513,7 @@
                     "type": "simple",
                     "max_size": 256,
                     "with_counters": false,
+                    "direct_meters": null,
                     "support_timeout": false,
                     "key": [
                         {
@@ -498,7 +521,8 @@
                             "target": [
                                 "standard_metadata",
                                 "egress_port"
-                            ]
+                            ],
+                            "mask": null
                         }
                     ],
                     "actions": [
@@ -509,9 +533,10 @@
                         "rewrite_mac": null,
                         "_drop": null
                     },
-                    "default_action": null
+                    "base_default_next": null
                 }
             ],
+            "action_profiles": [],
             "conditionals": []
         }
     ],
@@ -603,16 +628,21 @@
     ],
     "checksums": [
         {
-            "name": "ipv4.hdrChecksum",
+            "name": "ipv4.hdrChecksum|ipv4_checksum",
             "id": 0,
             "target": [
                 "ipv4",
                 "hdrChecksum"
             ],
-            "type": "ipv4"
+            "type": "generic",
+            "calculation": "ipv4_checksum",
+            "if_cond": null
         }
     ],
     "learn_lists": [],
+    "field_lists": [],
+    "counter_arrays": [],
+    "register_arrays": [],
     "force_arith": [
         [
             "standard_metadata",


### PR DESCRIPTION
The checked-in JSON files for simple_router and l2_switch were old. The
one for l2_switch was so old it was causing the CLI to crash. I ran a
recent version of the compiler to obtain up-to-date JSON files.