### PR TITLE
Allow ActionPrimitive_ access to p4objects that created it.

### DIFF
--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -433,7 +433,8 @@ class P4Objects {
   ConfigOptionMap config_options{};
 
   // maps primitive names to primitive instances
-  std::unordered_map<std::string, std::unique_ptr<ActionPrimitive_> > primitives{};
+  std::unordered_map<std::string, std::unique_ptr<ActionPrimitive_>>
+      primitives{};
 
  private:
   int get_field_offset(header_id_t header_id,
@@ -453,7 +454,6 @@ class P4Objects {
 
   std::unique_ptr<Calculation> process_cfg_selector(
       const Json::Value &cfg_selector) const;
-
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -216,6 +216,9 @@ class P4Objects {
 
   bool header_exists(const std::string &header_name) const;
 
+  // public to be accessed by test class
+  ActionPrimitive_ *get_primitive(const std::string &name);
+
   ConfigOptionMap get_config_options() const;
 
   // public to be accessed by test class
@@ -429,6 +432,9 @@ class P4Objects {
 
   ConfigOptionMap config_options{};
 
+  // maps primitive names to primitive instances
+  std::unordered_map<std::string, std::unique_ptr<ActionPrimitive_> > primitives{};
+
  private:
   int get_field_offset(header_id_t header_id,
                        const std::string &field_name) const;
@@ -447,6 +453,7 @@ class P4Objects {
 
   std::unique_ptr<Calculation> process_cfg_selector(
       const Json::Value &cfg_selector) const;
+
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -424,8 +424,6 @@ struct unpack_caller {
   }
 };
 
-class P4Objects;
-
 class ActionPrimitive_ {
  public:
   virtual ~ActionPrimitive_() { }

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -595,7 +595,9 @@ class ActionFnEntry {
   ActionFnEntry(const ActionFnEntry &other) = default;
   ActionFnEntry &operator=(const ActionFnEntry &other) = default;
 
+  // NOLINTNEXTLINE(whitespace/operators)
   ActionFnEntry(ActionFnEntry &&other) /*noexcept*/ = default;
+  // NOLINTNEXTLINE(whitespace/operators)
   ActionFnEntry &operator=(ActionFnEntry &&other) /*noexcept*/ = default;
 
  private:

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -83,6 +83,7 @@
 #include "counters.h"
 #include "stateful.h"
 #include "expressions.h"
+//#include "P4Objects.h"
 
 namespace bm {
 
@@ -424,6 +425,8 @@ struct unpack_caller {
   }
 };
 
+class P4Objects;
+
 class ActionPrimitive_ {
  public:
   virtual ~ActionPrimitive_() { }
@@ -434,6 +437,10 @@ class ActionPrimitive_ {
 
   virtual size_t get_num_params() = 0;
 
+  void _set_p4objects(P4Objects *p4objects) {
+    p4objects = p4objects;
+  }
+
  protected:
   // This used to be regular members in ActionPrimitive, but there could be a
   // race condition. Making them thread_local solves the issue. I moved these
@@ -442,6 +449,13 @@ class ActionPrimitive_ {
   // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60056).
   static thread_local Packet *pkt;
   static thread_local PHV *phv;
+
+  P4Objects *get_p4objects() {
+    return p4objects;
+  }
+
+ private:
+  P4Objects *p4objects;
 };
 
 //! This acts as the base class for all target-specific action primitives. It

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -437,7 +437,7 @@ class ActionPrimitive_ {
   virtual size_t get_num_params() = 0;
 
   void _set_p4objects(P4Objects *p4objects) {
-    p4objects = p4objects;
+    this->p4objects = p4objects;
   }
 
  protected:

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -83,7 +83,6 @@
 #include "counters.h"
 #include "stateful.h"
 #include "expressions.h"
-//#include "P4Objects.h"
 
 namespace bm {
 

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -648,6 +648,8 @@ P4Objects::init_objects(std::istream *is,
         return 1;
       }
 
+      primitive->_set_p4objects(this);
+
       for (const auto &cfg_parameter : cfg_primitive_parameters) {
         const string type = cfg_parameter["type"].asString();
 

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -647,8 +647,6 @@ P4Objects::init_objects(std::istream *is,
         return 1;
       }
 
-      primitive->_set_p4objects(this);
-
       for (const auto &cfg_parameter : cfg_primitive_parameters) {
         const string type = cfg_parameter["type"].asString();
 

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -624,8 +624,7 @@ P4Objects::init_objects(std::istream *is,
     for (const auto &cfg_primitive_call : cfg_primitive_calls) {
       const string primitive_name = cfg_primitive_call["op"].asString();
 
-      ActionPrimitive_ *primitive =
-        ActionOpcodesMap::get_instance()->get_primitive(primitive_name);
+      ActionPrimitive_ *primitive = get_primitive(primitive_name);
       if (!primitive) {
         outstream << "Unknown primitive action: " << primitive_name
                   << std::endl;
@@ -1353,6 +1352,19 @@ P4Objects::process_cfg_selector(const Json::Value &cfg_selector) const {
   if (!check_hash(selector_algo)) return nullptr;
 
   return std::unique_ptr<Calculation>(new Calculation(builder, selector_algo));
+}
+
+ActionPrimitive_ *
+P4Objects::get_primitive(const std::string &name) {
+  auto it = primitives.find(name);
+  if (it == primitives.end()) {
+    auto prim = ActionOpcodesMap::get_instance()->get_primitive(name);
+    if (!prim) return nullptr;
+    prim->_set_p4objects(this);
+    primitives[name] = std::move(prim);
+    return primitives[name].get();
+  }
+  return it->second.get();
 }
 
 void

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -175,17 +175,19 @@ ActionFn::push_back_primitive(ActionPrimitive_ *primitive) {
 bool
 ActionOpcodesMap::register_primitive(
     const char *name,
-    std::unique_ptr<ActionPrimitive_> primitive) {
+    ActionPrimitiveFactoryFn fn) {
   const std::string str_name = std::string(name);
   auto it = map_.find(str_name);
   if (it != map_.end()) return false;
-  map_[str_name] = std::move(primitive);
+  map_[str_name] = std::move(fn);
   return true;
 }
 
-ActionPrimitive_ *
+std::unique_ptr<ActionPrimitive_>
 ActionOpcodesMap::get_primitive(const std::string &name) {
-  return map_[name].get();
+  auto it = map_.find(name);
+  if (it == map_.end()) return nullptr;
+  return it->second();
 }
 
 ActionOpcodesMap *

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <bm/bm_sim/actions.h>
+#include <bm/bm_sim/P4Objects.h>
 
 #include <memory>
 #include <chrono>
@@ -129,6 +130,12 @@ class WritePacketRegister : public ActionPrimitive<const Data &> {
 };
 
 REGISTER_PRIMITIVE(WritePacketRegister);
+
+class _nop : public ActionPrimitive<> {
+  void operator ()() {}
+};
+
+REGISTER_PRIMITIVE(_nop);
 
 // Google Test fixture for actions tests
 class ActionsTest : public ::testing::Test {
@@ -587,7 +594,7 @@ TEST_F(ActionsTest, ConcurrentPrimitiveExecution) {
   auto primitive = ActionOpcodesMap::get_instance()->get_primitive(
       "ModifyFieldWithHashBasedOffset");
 
-  testActionFn.push_back_primitive(primitive);
+  testActionFn.push_back_primitive(primitive.get());
   testActionFn.parameter_push_back_field(testHeader2, 3);  // f16
   testActionFn.parameter_push_back_const(Data(base));
   testActionFn.parameter_push_back_calculation(&calculation);
@@ -623,7 +630,7 @@ TEST_F(ActionsTest, ConcurrentRegisterPrimitiveExecution) {
 
   auto primitive = ActionOpcodesMap::get_instance()->get_primitive("Set");
 
-  testActionFn.push_back_primitive(primitive);
+  testActionFn.push_back_primitive(primitive.get());
   testActionFn.parameter_push_back_register_ref(&register_array, 12);
   testActionFn.parameter_push_back_const(Data(0xabababab));
 
@@ -640,6 +647,30 @@ TEST_F(ActionsTest, ConcurrentRegisterPrimitiveExecution) {
   std::thread t1(action_loop, iterations, std::ref(testActionFnEntry));
   std::thread t2(action_loop, iterations, std::ref(testActionFnEntry));
   t1.join(); t2.join();
+}
+
+TEST_F(ActionsTest, UniquePrimitivesForEachP4Objects) {
+  // NOLINTNEXTLINE(whitespace/line_length)
+  std::istringstream first_is("{\"actions\":[{\"name\":\"nop\",\"id\":2,\"runtime_data\":[],\"primitives\":[{\"op\":\"_nop\",\"parameters\":[]}]}]}");
+  std::stringstream first_os;
+  P4Objects first_objects(first_os);
+  LookupStructureFactory first_factory;
+  ASSERT_EQ(0, first_objects.init_objects(&first_is, &first_factory));
+
+  // NOLINTNEXTLINE(whitespace/line_length)
+  std::istringstream second_is("{\"actions\":[{\"name\":\"nop\",\"id\":2,\"runtime_data\":[],\"primitives\":[{\"op\":\"_nop\",\"parameters\":[]}]}]}");
+  std::stringstream second_os;
+  P4Objects second_objects(second_os);
+  LookupStructureFactory second_factory;
+  ASSERT_EQ(0, second_objects.init_objects(&second_is, &second_factory));
+
+  // check primitives are unique across p4objects instances
+  ASSERT_TRUE(first_objects.get_primitive(std::string("_nop"))
+              != second_objects.get_primitive(std::string("_nop")));
+
+  // check only one copy of a primitive for one p4objects instance
+  ASSERT_TRUE(first_objects.get_primitive(std::string("_nop"))
+              == first_objects.get_primitive(std::string("_nop")));
 }
 
 class RegisterSpin : public ActionPrimitive<RegisterArray &, const Data &> {

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 
 #include <cassert>
+#include <string>
 
 using namespace bm;
 

--- a/tests/test_extern.cpp
+++ b/tests/test_extern.cpp
@@ -203,7 +203,7 @@ class ExternTest : public ::testing::Test {
     phv_factory.push_back_header("test2", testHeader2, testHeaderType);
   }
 
-  static ActionPrimitive_ *get_extern_primitive(
+  static std::unique_ptr<ActionPrimitive_> get_extern_primitive(
       const std::string &extern_name, const std::string &method_name) {
     return ActionOpcodesMap::get_instance()->get_primitive(
         "_" + extern_name + "_" + method_name);
@@ -230,7 +230,7 @@ TEST_F(ExternTest, ExternCounterExecute) {
   auto primitive = get_extern_primitive("ExternCounter", "increment_by");
 
   size_t increment_value = 44u;
-  testActionFn.push_back_primitive(primitive);
+  testActionFn.push_back_primitive(primitive.get());
   testActionFn.parameter_push_back_extern_instance(extern_instance.get());
   testActionFn.parameter_push_back_const(Data(increment_value));
 
@@ -261,7 +261,7 @@ TEST_F(ExternTest, ExternCounterSetAttribute) {
   auto primitive = get_extern_primitive("ExternCounter", "increment_by");
 
   size_t increment_value = 44u;
-  testActionFn.push_back_primitive(primitive);
+  testActionFn.push_back_primitive(primitive.get());
   testActionFn.parameter_push_back_extern_instance(extern_instance.get());
   testActionFn.parameter_push_back_const(Data(increment_value));
 
@@ -322,10 +322,10 @@ TEST_F(ExternTest, ExternExpression) {
 
   auto primitive_1 = get_extern_primitive("ExternExpression", "set_var2");
   auto primitive_2 = get_extern_primitive("ExternExpression", "execute");
-  testActionFn.push_back_primitive(primitive_1);
+  testActionFn.push_back_primitive(primitive_1.get());
   testActionFn.parameter_push_back_extern_instance(extern_instance.get());
   testActionFn.parameter_push_back_const(var2);
-  testActionFn.push_back_primitive(primitive_2);
+  testActionFn.push_back_primitive(primitive_2.get());
   testActionFn.parameter_push_back_extern_instance(extern_instance.get());
   testActionFn.parameter_push_back_field(testHeader1, 0);  // f32
   testActionFnEntry(pkt.get());
@@ -347,7 +347,7 @@ TEST_F(ExternTest, ExternCounterRename) {
     ASSERT_NE(nullptr, counter_instance);
 
     auto primitive = get_extern_primitive(name, "increment_by");
-    ASSERT_NE(nullptr, primitive);
+    ASSERT_NE(nullptr, primitive.get());
   };
 
   check_name("ExternCounter");


### PR DESCRIPTION
This is useful for the "hash" extern function found here: https://github.com/p4lang/p4c/blob/master/p4include/v1model.p4#L99

Typically a tuple literal is supplied as the "data" parameter to this function, which causes the compiler to create a field_list out of the tuple literal and replace the tuple literal with the field_list's id. The hash primitive must then resolve this field_list id to the FieldList object in order to create a Calculation using the "algo" parameter. In needs access to P4Objects to do this. 