### PR TITLE
Add tentative support for parser errors and verify

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -50,6 +50,7 @@ bm/bm_sim/packet.h \
 bm/bm_sim/packet_buffer.h \
 bm/bm_sim/packet_handler.h \
 bm/bm_sim/parser.h \
+bm/bm_sim/parser_error.h \
 bm/bm_sim/pcap_file.h \
 bm/bm_sim/phv.h \
 bm/bm_sim/phv_forward.h \

--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -221,6 +221,8 @@ class P4Objects {
 
   ConfigOptionMap get_config_options() const;
 
+  ErrorCodeMap get_error_codes() const;
+
   // public to be accessed by test class
   std::ostream &outstream;
 
@@ -393,6 +395,8 @@ class P4Objects {
 
   // parse vsets
   std::unordered_map<std::string, std::unique_ptr<ParseVSet> > parse_vsets{};
+
+  ErrorCodeMap error_codes;
 
   // checksums
   std::vector<std::unique_ptr<Checksum> > checksums{};

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -447,6 +447,10 @@ class Context final {
   //! input config JSON for this context.
   ConfigOptionMap get_config_options() const;
 
+  //! Return a copy of the error codes map (a bi-directional map between an
+  //! error code's integral value and its name / description).
+  ErrorCodeMap get_error_codes() const;
+
  private:  // data members
   size_t cxt_id{};
 

--- a/include/bm/bm_sim/expressions.h
+++ b/include/bm/bm_sim/expressions.h
@@ -154,6 +154,14 @@ class ArithExpression : public Expression {
 };
 
 
+class BoolExpression : public Expression {
+ public:
+  bool eval(const PHV &phv, const std::vector<Data> &locals = {}) const {
+    return eval_bool(phv, locals);
+  }
+};
+
+
 class VLHeaderExpression {
  public:
   explicit VLHeaderExpression(const ArithExpression &expr);

--- a/include/bm/bm_sim/header_stacks.h
+++ b/include/bm/bm_sim/header_stacks.h
@@ -170,6 +170,11 @@ class HeaderStack : public NamedP4Object {
     return headers[next];
   }
 
+  //! Returns true if the header stack is full
+  bool is_full() const {
+    return (next >= headers.size());
+  }
+
   void reset() {
     next = 0;
   }

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -36,6 +36,7 @@
 #include <cassert>
 
 #include "packet_buffer.h"
+#include "parser_error.h"
 #include "phv_source.h"
 #include "phv.h"
 
@@ -226,6 +227,12 @@ class Packet final {
   //! Packet::INVALID_ENTRY_INDEX if lookup was a miss.
   size_t get_entry_index() const { return entry_index; }
 
+  void set_error_code(const ErrorCode &code) { error_code = code; }
+  //! Get the error code for this Packet, as set by the most recent Parser
+  //! object the packet went through. For most packets, this error code should
+  //! be set to "NoError".
+  ErrorCode get_error_code() const { return error_code; }
+
   //! Mark the packet for exit by setting an exit flag. If this is called from
   //! an action, the current pipeline will be interrupted as soon as the current
   //! table is done processing the packet. This effectively skips the rest of
@@ -357,6 +364,8 @@ class Packet final {
   // Used to store the index of the entry returned by the last match table
   // lookup; INVALID_ENTRY_INDEX if lookup was a miss.
   size_t entry_index{INVALID_ENTRY_INDEX};
+
+  ErrorCode error_code{ErrorCode::make_invalid()};
 
  private:
   static CopyIdGenerator *copy_id_gen;

--- a/include/bm/bm_sim/parser_error.h
+++ b/include/bm/bm_sim/parser_error.h
@@ -1,0 +1,141 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+//! @file parser_error.h
+
+#ifndef BM_BM_SIM_PARSER_ERROR_H_
+#define BM_BM_SIM_PARSER_ERROR_H_
+
+#include <exception>
+#include <limits>
+#include <string>
+#include <unordered_map>
+
+namespace bm {
+
+//! Used to represent an error code (used in the parser) internally. This is
+//! really just a wrapper around an integral type.
+class ErrorCode {
+  friend class ErrorCodeMap;
+ public:
+  using type_t = int;
+
+  explicit ErrorCode(type_t v)
+      : v(v) { }
+
+  type_t get() { return v; }
+
+  //! Equality operator
+  bool operator==(const ErrorCode &other) const {
+    return (v == other.v);
+  }
+
+  //! Inequality operator
+  bool operator!=(const ErrorCode &other) const {
+    return !(*this == other);
+  }
+
+  //! An invalid ErrorCode, with an integral value distinct from all other
+  //! P4-specified error codes.
+  static ErrorCode make_invalid() { return ErrorCode(INVALID_V); }
+
+ private:
+  type_t v;
+
+  static constexpr type_t INVALID_V = std::numeric_limits<type_t>::max();
+};
+
+//! A bi-directional map between error codes and their P4 names.
+class ErrorCodeMap {
+ public:
+  //! The core erros, as per core.p4.
+  enum class Core {
+    //! No error raised in parser
+    NoError,
+    //! Not enough bits in packet for extract or lookahead
+    PacketTooShort,
+    //! Match statement has no matches (unused for now)
+    NoMatch,
+    //! Reference to invalid element of a header stack (partial support)
+    StackOutOfBounds,
+    //! Extracting on top of a valid header
+    OverwritingHeader,
+    //! Extracting too many bits into a varbit field (unused for now)
+    HeaderTooShort,
+    //! %Parser execution time limit exceeded (unused for now)
+    ParserTimeout
+  };
+
+  bool add(const std::string &name, ErrorCode::type_t v);
+  bool exists(const std::string &name) const;
+  bool exists(ErrorCode::type_t v) const;
+  // Add the core error codes to the map, providing they are not already
+  // present. If they need to be added, we make sure to use different integral
+  // values than for the existing codes.
+  void add_core();
+
+  //! Retrieve an error code from a P4 error name. Will throw std::out_of_range
+  //! exception if name does not exist.
+  ErrorCode from_name(const std::string &name) const;
+  //! Retrieve an error code for one of the core errors.
+  ErrorCode from_core(const Core &core) const;
+  //! Retrieve an error code's name. Will throw std::out_of_range exception if
+  //! the error code is not valid.
+  const std::string &to_name(const ErrorCode &code) const;
+
+  static ErrorCodeMap make_with_core();
+
+ private:
+  static const char *core_to_name(const Core &core);
+
+  std::unordered_map<ErrorCode::type_t, std::string> map_v_to_name{};
+  std::unordered_map<std::string, ErrorCode::type_t> map_name_to_v{};
+};
+
+class parser_exception : public std::exception {
+ public:
+  virtual ~parser_exception() { }
+
+  virtual ErrorCode get(const ErrorCodeMap &error_codes) const = 0;
+};
+
+class parser_exception_arch : public parser_exception {
+ public:
+  explicit parser_exception_arch(const ErrorCode &code);
+
+  ErrorCode get(const ErrorCodeMap &error_codes) const override;
+
+ private:
+  const ErrorCode code;
+};
+
+class parser_exception_core : public parser_exception {
+ public:
+  explicit parser_exception_core(ErrorCodeMap::Core core);
+
+  ErrorCode get(const ErrorCodeMap &error_codes) const override;
+
+ private:
+  ErrorCodeMap::Core core;
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_PARSER_ERROR_H_

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -280,6 +280,13 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).get_config_options();
   }
 
+  //! Return a copy of the error codes map (a bi-directional map between an
+  //! error code's integral value and its name / description) for a given
+  //! context.
+  ErrorCodeMap get_error_codes(size_t cxt_id) const {
+    return contexts.at(cxt_id).get_error_codes();
+  }
+
   // ---------- RuntimeInterface ----------
 
   MatchErrorCode
@@ -935,6 +942,14 @@ class Switch : public SwitchWContexts {
   using SwitchWContexts::get_config_options;
   ConfigOptionMap get_config_options() const {
     return get_config_options(0);
+  }
+
+  // to avoid C++ name hiding
+  using SwitchWContexts::get_error_codes;
+  //! Return a copy of the error codes map (a bi-directional map between an
+  //! error code's integral value and its name / description) for the switch.
+  ErrorCodeMap get_error_codes() const {
+    return get_error_codes(0);
   }
 
   //! Add a component to this Switch. Each Switch maintains a map `T` ->

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -48,6 +48,7 @@ options_parse.cpp \
 P4Objects.cpp \
 packet.cpp \
 parser.cpp \
+parser_error.cpp \
 pcap_file.cpp \
 pipeline.cpp \
 port_monitor.cpp \

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -779,4 +779,10 @@ Context::get_config_options() const {
   return p4objects->get_config_options();
 }
 
+ErrorCodeMap
+Context::get_error_codes() const {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  return p4objects->get_error_codes();
+}
+
 }  // namespace bm

--- a/src/bm_sim/parser_error.cpp
+++ b/src/bm_sim/parser_error.cpp
@@ -1,0 +1,130 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/parser_error.h>
+
+#include <algorithm>  // for std::max_element
+#include <cassert>
+#include <string>
+
+namespace bm {
+
+constexpr ErrorCode::type_t ErrorCode::INVALID_V;
+
+bool
+ErrorCodeMap::add(const std::string &name, ErrorCode::type_t v) {
+  if (exists(name) || exists(v)) return false;
+  map_v_to_name[v] = name;
+  map_name_to_v[name] = v;
+  return true;
+}
+
+bool
+ErrorCodeMap::exists(const std::string &name) const {
+  return map_name_to_v.find(name) != map_name_to_v.end();
+}
+
+bool
+ErrorCodeMap::exists(ErrorCode::type_t v) const {
+  return map_v_to_name.find(v) != map_v_to_name.end();
+}
+
+void
+ErrorCodeMap::add_core() {
+  using pair_type = decltype(map_v_to_name)::value_type;
+  auto max_p = std::max_element(
+      std::begin(map_v_to_name), std::end(map_v_to_name),
+      [] (const pair_type &p1, const pair_type &p2) {
+        return p1.first < p2.first;
+      });
+  auto max_v = (max_p == map_v_to_name.end()) ? 0 : (max_p->first + 1);
+  // TODO(antonin): write an iterator for Core enum class instead
+  for (const auto core : {Core::NoError, Core::PacketTooShort, Core::NoMatch,
+                          Core::StackOutOfBounds, Core::OverwritingHeader,
+                          Core::HeaderTooShort, Core::ParserTimeout}) {
+    auto name = core_to_name(core);
+    if (!exists(name)) assert(add(name, max_v++));
+  }
+}
+
+ErrorCode
+ErrorCodeMap::from_name(const std::string &name) const {
+  return ErrorCode(map_name_to_v.at(name));
+}
+
+ErrorCode
+ErrorCodeMap::from_core(const Core &core) const {
+  return ErrorCode(map_name_to_v.at(core_to_name(core)));
+}
+
+const std::string &
+ErrorCodeMap::to_name(const ErrorCode &code) const {
+  return map_v_to_name.at(code.v);
+}
+
+ErrorCodeMap
+ErrorCodeMap::make_with_core() {
+  ErrorCodeMap error_codes;
+  error_codes.add_core();
+  return error_codes;
+}
+
+// could be constexpr in C++14
+const char *
+ErrorCodeMap::core_to_name(const Core &core) {
+  switch (core) {
+    case Core::NoError:
+      return "NoError";
+    case Core::PacketTooShort:
+      return "PacketTooShort";
+    case Core::NoMatch:
+      return "NoMatch";
+    case Core::StackOutOfBounds:
+      return "StackOutOfBounds";
+    case Core::OverwritingHeader:
+      return "OverwritingHeader";
+    case Core::HeaderTooShort:
+      return "HeaderTooShort";
+    case Core::ParserTimeout:
+      return "ParserTimeout";
+  }
+  // unreachable but gcc complains without it
+  assert(0);
+  return nullptr;
+}
+
+parser_exception_arch::parser_exception_arch(const ErrorCode &code)
+    : code(code) { }
+
+ErrorCode
+parser_exception_arch::get(const ErrorCodeMap &error_codes) const {
+  (void) error_codes;
+  return code;
+}
+
+parser_exception_core::parser_exception_core(ErrorCodeMap::Core core)
+    : core(core) { }
+
+ErrorCode
+parser_exception_core::get(const ErrorCodeMap &error_codes) const {
+  return error_codes.from_core(core);
+}
+
+}  // namespace bm

--- a/tests/stress_tests/test_LPM_match_1.cpp
+++ b/tests/stress_tests/test_LPM_match_1.cpp
@@ -140,6 +140,10 @@ int main(int argc, char* argv[]) {
       parser->parse(pkt);
       ingress->apply(pkt);
       deparser->deparse(pkt);
+      // need to reset headers (i.e. mark them invalid) since we are re-using
+      // the same Packet objects, otherwise we get a parser error
+      // (OverwritingHeader)
+      pkt->get_phv()->reset();
     }
   }
   chrono.end();

--- a/tests/stress_tests/test_exact_match_1.cpp
+++ b/tests/stress_tests/test_exact_match_1.cpp
@@ -120,6 +120,10 @@ int main(int argc, char* argv[]) {
       parser->parse(pkt);
       ingress->apply(pkt);
       deparser->deparse(pkt);
+      // need to reset headers (i.e. mark them invalid) since we are re-using
+      // the same Packet objects, otherwise we get a parser error
+      // (OverwritingHeader)
+      pkt->get_phv()->reset();
     }
   }
   chrono.end();

--- a/tests/stress_tests/test_parser_deparser_1.cpp
+++ b/tests/stress_tests/test_parser_deparser_1.cpp
@@ -56,6 +56,10 @@ int main(int argc, char* argv[]) {
       auto pkt = packets[p].get();
       parser->parse(pkt);
       deparser->deparse(pkt);
+      // need to reset headers (i.e. mark them invalid) since we are re-using
+      // the same Packet objects, otherwise we get a parser error
+      // (OverwritingHeader)
+      pkt->get_phv()->reset();
     }
   }
   chrono.end();

--- a/tests/stress_tests/test_ternary_match_1.cpp
+++ b/tests/stress_tests/test_ternary_match_1.cpp
@@ -135,6 +135,10 @@ int main(int argc, char* argv[]) {
       parser->parse(pkt);
       ingress->apply(pkt);
       deparser->deparse(pkt);
+      // need to reset headers (i.e. mark them invalid) since we are re-using
+      // the same Packet objects, otherwise we get a parser error
+      // (OverwritingHeader)
+      pkt->get_phv()->reset();
     }
   }
   chrono.end();

--- a/tests/test_calculations.cpp
+++ b/tests/test_calculations.cpp
@@ -39,6 +39,7 @@ class CalculationTest : public ::testing::Test {
   header_id_t testHeader1{0}, testHeader2{1}, testHeader3{2};
 
   ParseState oneParseState;
+  ErrorCodeMap error_codes;
   Parser parser;
 
   std::unique_ptr<PHVSourceIface> phv_source{nullptr};
@@ -53,7 +54,8 @@ class CalculationTest : public ::testing::Test {
       : testHeaderType("test_t", 0),
         testHeaderType2("test2_t", 1),
         oneParseState("parse_state", 0),
-        parser("test_parser", 0),
+        error_codes(ErrorCodeMap::make_with_core()),
+        parser("test_parser", 0, &error_codes),
         phv_source(PHVSourceIface::make_phv_source()) {
     testHeaderType.push_back_field("f16", 16);
     testHeaderType.push_back_field("f48", 48);

--- a/tests/test_checksums.cpp
+++ b/tests/test_checksums.cpp
@@ -50,6 +50,7 @@ class ChecksumTest : public ::testing::Test {
   header_id_t ethernetHeader{0}, ipv4Header{1}, udpHeader{2}, tcpHeader{3};
   header_id_t metaHeader{4};
 
+  ErrorCodeMap error_codes;
   Parser parser;
 
   std::unique_ptr<NamedCalculation> tcp_cksum_engine_calc{nullptr};
@@ -65,7 +66,8 @@ class ChecksumTest : public ::testing::Test {
         ipv4ParseState("parse_ipv4", 1),
         udpParseState("parse_udp", 2),
         tcpParseState("parse_tcp", 3),
-        parser("test_parser", 0),
+        error_codes(ErrorCodeMap::make_with_core()),
+        parser("test_parser", 0, &error_codes),
         phv_source(PHVSourceIface::make_phv_source()) {
     ethernetHeaderType.push_back_field("dstAddr", 48);
     ethernetHeaderType.push_back_field("srcAddr", 48);


### PR DESCRIPTION
P4_16 introduces error declarations. The core library defines a few
standard errors and each architecture can extend erros with additional
declarations. Parsers may 'raise' errors and architectures may make the
erros status available to controls.

In this pull request we try to add support for P4_16 declarations. It is
expected that the bmv2 compiler will assign a unique numerical value to
each error constant. This mapping (error name to value) will be made
available in the bmv2 JSON input. In the rest of the JSON file, the
errors are referenced only through their numerical value. However, for
parser verify statements, because the mapping is available, it is
possible to log a meaningful message using the error P4 name. The
mapping is also made available to architecture implementations, through
Context::get_error_codes and Switch::get_error_codes.

The bmv2 parser implementation supports (partially) the errors declared
in the P4 core library. Additional architecture-specific errors can be
raised through verify statements, which are now supported.

In the case where an architecture needs to make the error code available
to controls, it is the architecture implementation's responsibility to
copy the error code value to the appropriate metadata field.

Few changes were required to make this work. We use C++ exceptions to
manage P4 errors in the parser implementation, which proved convenient.

The JSON documentation was updated to include error support and the JSON
version was bumped up to 2.1.

This pull request also includes some minor cleanups in the parser code and in
the parser unit tests.