### PR TITLE
Typo in PYTHONPATH

### DIFF
--- a/mininet/stress_test_ipv4.py.in
+++ b/mininet/stress_test_ipv4.py.in
@@ -70,7 +70,7 @@ def configure_dp(commands_path, thrift_port):
         print " ".join(cmd)
         sub_env = os.environ.copy()
         pythonpath = ""
-        if "PYHTONPATH" in sub_env:
+        if "PYTHONPATH" in sub_env:
             pythonpath = sub_env["PYTHONPATH"] + ":"
         sub_env["PYTHONPATH"] = pythonpath + \
                                 "@abs_top_builddir@/thrift_src/gen-py/"

--- a/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
+++ b/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
@@ -104,7 +104,7 @@ def main():
     with open(command_path, "r") as f:
         sub_env = os.environ.copy()
         pythonpath = ""
-        if "PYHTONPATH" in sub_env:
+        if "PYTHONPATH" in sub_env:
             pythonpath = sub_env["PYTHONPATH"] + ":"
         sub_env["PYTHONPATH"] = pythonpath + \
                                 "@abs_top_builddir@/thrift_src/gen-py/"


### PR DESCRIPTION
There's a typo in PYTHONPATH in two .in files, which is causing issue #262. It isn't triggered unless you set PYTHONPATH on your own.