### PR TITLE
Minor improvements to mininet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ Then in a second terminal:
 Now the switch is running and the tables have been populated. You can run
 *pingall* in Mininet or start a TCP flow with iperf between hosts *h1* and *h2*.
 
+When running a P4 program with *simple_switch* (instead of *simple_router* in
+the above example), just provide the appropriate `simple_switch` binary to
+`1sw_demo.py` with `--behavioral-exe`.
+
 ## FAQ
 
 ### Why did we need bmv2 ?

--- a/mininet/1sw_demo.py
+++ b/mininet/1sw_demo.py
@@ -52,7 +52,7 @@ class SingleSwitchTopo(Topo):
                                 json_path = json_path,
                                 thrift_port = thrift_port,
                                 pcap_dump = pcap_dump)
-        
+
         for h in xrange(n):
             host = self.addHost('h%d' % (h + 1),
                                 ip = "10.0.%d.10/24" % h,

--- a/mininet/p4_mininet.py
+++ b/mininet/p4_mininet.py
@@ -15,7 +15,12 @@
 
 from mininet.net import Mininet
 from mininet.node import Switch, Host
-from mininet.log import setLogLevel, info
+from mininet.log import setLogLevel, info, error, debug
+from mininet.moduledeps import pathCheck
+from sys import exit
+import os
+import tempfile
+import socket
 
 class P4Host(Host):
     def config(self, **params):
@@ -43,25 +48,31 @@ class P4Host(Host):
             self.defaultIntf().MAC()
         )
         print "**********"
-        
+
 class P4Switch(Switch):
     """P4 virtual switch"""
     device_id = 0
 
-    def __init__( self, name, sw_path = None, json_path = None,
-                  thrift_port = None,
-                  pcap_dump = False,
-                  verbose = False,
-                  device_id = None,
-                  enable_debugger = False,
-                  **kwargs ):
-        Switch.__init__( self, name, **kwargs )
+    def __init__(self, name, sw_path = None, json_path = None,
+                 thrift_port = None,
+                 pcap_dump = False,
+                 verbose = False,
+                 device_id = None,
+                 enable_debugger = False,
+                 **kwargs):
+        Switch.__init__(self, name, **kwargs)
         assert(sw_path)
         assert(json_path)
+        # make sure that the provided sw_path is valid
+        pathCheck(sw_path)
+        # make sure that the provided JSON file exists
+        if not os.path.isfile(json_path):
+            error("Invalid JSON file.\n")
+            exit(1)
         self.sw_path = sw_path
         self.json_path = json_path
         self.verbose = verbose
-        logfile = '/tmp/p4s.%s.log' % self.name
+        logfile = "/tmp/p4s.{}.log".format(self.name)
         self.output = open(logfile, 'w')
         self.thrift_port = thrift_port
         self.pcap_dump = pcap_dump
@@ -72,52 +83,70 @@ class P4Switch(Switch):
         else:
             self.device_id = P4Switch.device_id
             P4Switch.device_id += 1
-        self.nanomsg = "ipc:///tmp/bm-%d-log.ipc" % self.device_id
+        self.nanomsg = "ipc:///tmp/bm-{}-log.ipc".format(self.device_id)
 
     @classmethod
-    def setup( cls ):
+    def setup(cls):
         pass
 
-    def start( self, controllers ):
+    def check_switch_started(self, pid):
+        """While the process is running (pid exists), we check if the Thrift
+        server has been started. If the Thrift server is ready, we assume that
+        the switch was started successfully. This is only reliable if the Thrift
+        server is started at the end of the init process"""
+        while True:
+            if not os.path.exists(os.path.join("/proc", str(pid))):
+                return False
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+            result = sock.connect_ex(("localhost", self.thrift_port))
+            if result == 0:
+                return  True
+
+    def start(self, controllers):
         "Start up a new P4 switch"
-        print "Starting P4 switch", self.name
+        info("Starting P4 switch {}.\n".format(self.name))
         args = [self.sw_path]
-        # args.extend( ['--name', self.name] )
-        # args.extend( ['--dpid', self.dpid] )
         for port, intf in self.intfs.items():
             if not intf.IP():
-                args.extend( ['-i', str(port) + "@" + intf.name] )
+                args.extend(['-i', str(port) + "@" + intf.name])
         if self.pcap_dump:
             args.append("--pcap")
             # args.append("--useFiles")
         if self.thrift_port:
-            args.extend( ['--thrift-port', str(self.thrift_port)] )
+            args.extend(['--thrift-port', str(self.thrift_port)])
         if self.nanomsg:
-            args.extend( ['--nanolog', self.nanomsg] )
-        args.extend( ['--device-id', str(self.device_id)] )
+            args.extend(['--nanolog', self.nanomsg])
+        args.extend(['--device-id', str(self.device_id)])
         P4Switch.device_id += 1
         args.append(self.json_path)
         if self.enable_debugger:
             args.append("--debugger")
-        logfile = '/tmp/p4s.%s.log' % self.name
-        print ' '.join(args)
+        logfile = "/tmp/p4s.{}.log".format(self.name)
+        info(' '.join(args) + "\n")
 
-        self.cmd( ' '.join(args) + ' >' + logfile + ' 2>&1 &' )
-        # self.cmd( ' '.join(args) + ' > /dev/null 2>&1 &' )
+        pid = None
+        with tempfile.NamedTemporaryFile() as f:
+            # self.cmd(' '.join(args) + ' > /dev/null 2>&1 &')
+            self.cmd(' '.join(args) + ' >' + logfile + ' 2>&1 & echo $! >> ' + f.name)
+            pid = int(f.read())
+        debug("P4 switch {} PID is {}.\n".format(self.name, pid))
+        if not self.check_switch_started(pid):
+            error("P4 switch {} did not start correctly.\n".format(self.name))
+            exit(1)
+        info("P4 switch {} has been started.\n".format(self.name))
 
-        print "switch has been started"
-
-    def stop( self ):
-        "Terminate IVS switch."
+    def stop(self):
+        "Terminate P4 switch."
         self.output.flush()
-        self.cmd( 'kill %' + self.sw_path )
-        self.cmd( 'wait' )
+        self.cmd('kill %' + self.sw_path)
+        self.cmd('wait')
         self.deleteIntfs()
 
-    def attach( self, intf ):
+    def attach(self, intf):
         "Connect a data port"
         assert(0)
 
-    def detach( self, intf ):
+    def detach(self, intf):
         "Disconnect a data port"
         assert(0)

--- a/targets/simple_router/simple_router.json
+++ b/targets/simple_router/simple_router.json
@@ -261,8 +261,47 @@
     "meter_arrays": [],
     "actions": [
         {
-            "name": "set_nhop",
+            "name": "rewrite_mac",
             "id": 0,
+            "runtime_data": [
+                {
+                    "name": "smac",
+                    "bitwidth": 48
+                }
+            ],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "ethernet",
+                                "srcAddr"
+                            ]
+                        },
+                        {
+                            "type": "runtime_data",
+                            "value": 0
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "_drop",
+            "id": 1,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "drop",
+                    "parameters": []
+                }
+            ]
+        },
+        {
+            "name": "set_nhop",
+            "id": 2,
             "runtime_data": [
                 {
                     "name": "nhop_ipv4",
@@ -297,7 +336,7 @@
                             "type": "field",
                             "value": [
                                 "standard_metadata",
-                                "egress_port"
+                                "egress_spec"
                             ]
                         },
                         {
@@ -321,45 +360,6 @@
                             "value": "-0x1"
                         }
                     ]
-                }
-            ]
-        },
-        {
-            "name": "rewrite_mac",
-            "id": 1,
-            "runtime_data": [
-                {
-                    "name": "smac",
-                    "bitwidth": 48
-                }
-            ],
-            "primitives": [
-                {
-                    "op": "modify_field",
-                    "parameters": [
-                        {
-                            "type": "field",
-                            "value": [
-                                "ethernet",
-                                "srcAddr"
-                            ]
-                        },
-                        {
-                            "type": "runtime_data",
-                            "value": 0
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "_drop",
-            "id": 2,
-            "runtime_data": [],
-            "primitives": [
-                {
-                    "op": "drop",
-                    "parameters": []
                 }
             ]
         },

--- a/targets/simple_router/simple_router.p4
+++ b/targets/simple_router/simple_router.p4
@@ -103,7 +103,7 @@ metadata routing_metadata_t routing_metadata;
 
 action set_nhop(nhop_ipv4, port) {
     modify_field(routing_metadata.nhop_ipv4, nhop_ipv4);
-    modify_field(standard_metadata.egress_port, port);
+    modify_field(standard_metadata.egress_spec, port);
     add_to_field(ipv4.ttl, -1);
 }
 


### PR DESCRIPTION
The simple_router target is now using standard_metadata.egress_spec just
like simple_switch. The discrepancy between the two was creating
confusion among people.

Made mininet/1sw_demo.py executable.

Improved mininet/p4_mininet.py to check validity of provided switch and
json paths. Also checks that the switch started correctly.

Updated README to indicate that the mininet demo can be run with
simple_switch, not just simple_router.