### PR TITLE
Add support for string type for primitive params

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -11,7 +11,7 @@ per [this specification] (http://json-schema.org/).
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.1*.
+The version described in this document is *2.2*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -48,6 +48,7 @@ endian order); it can be prefixed with a negative sign, for negative values.
 - if `type` is a named P4 type (`header`, `header_stack`, `calculation`,
 `register_array`, `meter_array`, `counter_array`), `value` is a string
 corresponding to the name of the designated object.
+- if `type` is `string`, `value` is a sequence of characters.
 - if `type` is `lookahead` (parser only), `value` is a JSON 2-tuple, where the
 first item is the bit offset for the lookahead and the second item is the
 bitwidth.
@@ -285,7 +286,7 @@ call, with the following attributes:
   object with the following attributes:
     - `type`: one of `hexstr`, `runtime_data`, `header`, `field`, `calculation`,
     `meter_array`, `counter_array`, `register_array`, `header_stack`,
-    `expression`, `extern`
+    `expression`, `extern`, `string`
     - `value`: the appropriate parameter value. If `type` is `runtime_data`,
     this is an integer representing an index into the `runtime_data` (attribute
     of action) array. If `type` is `extern`, this is the name of the extern

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -863,6 +863,9 @@ P4Objects::init_objects(std::istream *is,
           const string name = cfg_parameter["value"].asString();
           ExternType *extern_instance = get_extern_instance(name);
           action_fn->parameter_push_back_extern_instance(extern_instance);
+        } else if (type == "string") {
+          action_fn->parameter_push_back_string(
+              cfg_parameter["value"].asString());
         } else {
           assert(0 && "parameter not supported");
         }

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -141,7 +141,7 @@ ActionFn::parameter_push_back_expression(
   std::unique_ptr<ArithExpression> expr
 ) {
   size_t nb_expression_params = 1;
-  for (const ActionParam &p : params)
+  for (const auto &p : params)
     if (p.tag == ActionParam::EXPRESSION) nb_expression_params += 1;
 
   assert(nb_expression_params <= ActionFn::nb_data_tmps);
@@ -163,6 +163,22 @@ ActionFn::parameter_push_back_extern_instance(ExternType *extern_instance) {
   ActionParam param;
   param.tag = ActionParam::EXTERN_INSTANCE;
   param.extern_instance = extern_instance;
+  params.push_back(param);
+}
+
+void
+ActionFn::parameter_push_back_string(const std::string &str) {
+  strings.push_back(str);
+  size_t idx = 0;
+  // we called push_back on the vector which may have invalidated the pointers,
+  // so we need to recompute them; alternatively we could add a level of
+  // indirection and store std::unique_ptr<std::string> in strings...
+  for (auto &p : params)
+    if (p.tag == ActionParam::STRING) p.str = &strings.at(idx++);
+  assert(strings.size() - 1 == idx);
+  ActionParam param;
+  param.tag = ActionParam::STRING;
+  param.str = &strings.back();
   params.push_back(param);
 }
 

--- a/tests/primitives.cpp
+++ b/tests/primitives.cpp
@@ -21,6 +21,8 @@
 #include <bm/bm_sim/actions.h>
 #include <bm/bm_sim/extern.h>
 
+#include <string>
+
 using namespace bm;
 
 class modify_field : public ActionPrimitive<Field &, const Data &> {
@@ -89,6 +91,14 @@ class pop : public ActionPrimitive<HeaderStack &, const Data &> {
 };
 
 REGISTER_PRIMITIVE(pop);
+
+class ignore_string : public ActionPrimitive<const std::string &> {
+  void operator ()(const std::string &s) {
+    (void)s;
+  }
+};
+
+REGISTER_PRIMITIVE(ignore_string);
 
 // one dummy extern
 

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -413,6 +413,16 @@ TEST(P4Objects, ParserVerify) {
   }
 }
 
+TEST(P4Objects, ActionParamString) {
+  std::stringstream is(
+      "{\"actions\":[{\"name\":\"a0\",\"id\":0,\"runtime_data\":[],"
+      "\"primitives\":[{\"op\":\"ignore_string\","
+      "\"parameters\":[{\"type\":\"string\",\"value\":\"testString\"}]}]}]}");
+  P4Objects objects;
+  LookupStructureFactory factory;
+  ASSERT_EQ(0, objects.init_objects(&is, &factory));
+}
+
 // convenience classes to generate some test JSON input; as of now this is
 // pretty limited but we could extend it if this proves useful
 namespace {


### PR DESCRIPTION
Architecture-specific action primitives can now support parameters with
a string type. In the C++ implementation of the primitive, the parameter
type can be either `const std::string &` or `const char *`. See
tests/test_actions.cpp for an example.

The JSON documentation was updated to reflect this addition, and the
version number was bumped up to 2.2.