### PR TITLE
Add support for P4_16 enum declarations

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -11,7 +11,7 @@ per [this specification] (http://json-schema.org/).
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.2*.
+The version described in this document is *2.3*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -148,6 +148,22 @@ error constants are not used anywhere in the program).
 We recommend using 0 for the core library error `NoError`, but this is not
 strictly necessary. Note that the value `2**31 - 1` is reserved and cannot be
 assigned by the compiler.
+
+### `enums`
+
+Its is a JSON array of all the enums declared in the P4 program (enum
+declarations were introduced in P4_16). Each array item has the following
+attributes:
+- `name`: name of the enum, as it appears in the p4 program
+- `entries`: a JSON array of all the constants declared inside the enum. Each
+array item is itself an array with exactly 2 elements: the name of the enum
+constant as it appears in the P4 program and an integer value in the range `[0,
+2**31 - 1)`. It is up to the compiler to assign a *unique* integer value (unique
+with respect to the other constants in the enum) to each enum constant; if the
+enum constant is used in an expression in the P4 program, it is up to the
+compiler to consistently replace each reference with its assigned value when
+producing the bmv2 JSON. This is very similar to how we handle [errors]
+(#errors).
 
 ### `parsers`
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -26,6 +26,7 @@ bm/bm_sim/debugger.h \
 bm/bm_sim/deparser.h \
 bm/bm_sim/dev_mgr.h \
 bm/bm_sim/entries.h \
+bm/bm_sim/enums.h \
 bm/bm_sim/event_logger.h \
 bm/bm_sim/expressions.h \
 bm/bm_sim/extern.h \

--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -46,6 +46,7 @@
 #include "ageing.h"
 #include "field_lists.h"
 #include "extern.h"
+#include "enums.h"
 
 // forward declaration of Json::Value
 namespace Json {
@@ -225,6 +226,10 @@ class P4Objects {
 
   ErrorCodeMap get_error_codes() const;
 
+  EnumMap::type_t get_enum_value(const std::string &name) const;
+  const std::string &get_enum_name(const std::string &enum_name,
+                                   EnumMap::type_t entry_value) const;
+
   // public to be accessed by test class
   std::ostream &outstream;
 
@@ -401,6 +406,8 @@ class P4Objects {
   std::unordered_map<std::string, std::unique_ptr<ParseVSet> > parse_vsets{};
 
   ErrorCodeMap error_codes;
+
+  EnumMap enums{};
 
   // checksums
   std::vector<std::unique_ptr<Checksum> > checksums{};

--- a/include/bm/bm_sim/enums.h
+++ b/include/bm/bm_sim/enums.h
@@ -1,0 +1,59 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef BM_BM_SIM_ENUMS_H_
+#define BM_BM_SIM_ENUMS_H_
+
+#include <string>
+#include <unordered_map>
+
+namespace bm {
+
+// for this class, "name" refers to an enum entry's full name (i.e. enum name +
+// "." + entry name), "enum_name" refers to an enum's name, and "entry_name"
+// refers to an entry's name within an enum declaration.
+class EnumMap {
+ public:
+  using type_t = int;
+
+  // returns an enum entry value from its full name; will thow a
+  // std::out_of_range exception if does not exist
+  type_t from_name(const std::string &name) const;
+  // returns an enum entry full name from the enum name and the entry value;
+  // will throw a std::out_of_range exception if does not exist
+  const std::string &to_name(const std::string &enum_name, type_t v) const;
+
+  // returns true iff the enum does not already exist
+  bool add_enum(const std::string &enum_name);
+  // returns true iff the enum exists and the entry name / value have not been
+  // taken yet
+  bool add_entry(const std::string &enum_name, const std::string &entry_name,
+                 type_t v);
+
+ private:
+  using EntryMap = std::unordered_map<type_t, std::string>;
+
+  std::unordered_map<std::string, type_t> map_name_to_v{};
+  std::unordered_map<std::string, EntryMap> map_enum_name_to_entries{};
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_ENUMS_H_

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -29,6 +29,7 @@ deparser.cpp \
 dev_mgr.cpp \
 dev_mgr_bmi.cpp \
 dev_mgr_packet_in.cpp \
+enums.cpp \
 event_logger.cpp \
 expressions.cpp \
 extern.cpp \

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -254,6 +254,28 @@ P4Objects::init_objects(std::istream *is,
         TransportIface::make_dummy());
   }
 
+  // enums
+
+  const auto &cfg_enums = cfg_root["enums"];
+  for (const auto &cfg_enum : cfg_enums) {
+    auto enum_name = cfg_enum["name"].asString();
+    auto enum_added = enums.add_enum(enum_name);
+    if (!enum_added) {
+      outstream << "Invalid enums specification in json\n";
+      return 1;
+    }
+    const auto &cfg_enum_entries = cfg_enum["entries"];
+    for (const auto &cfg_enum_entry : cfg_enum_entries) {
+      auto entry_name = cfg_enum_entry[0].asString();
+      auto value = static_cast<EnumMap::type_t>(cfg_enum_entry[1].asInt());
+      auto entry_added = enums.add_entry(enum_name, entry_name, value);
+      if (!entry_added) {
+        outstream << "Invalid enums specification in json\n";
+        return 1;
+      }
+    }
+  }
+
   // header types
 
   const Json::Value &cfg_header_types = cfg_root["header_types"];
@@ -1594,6 +1616,17 @@ P4Objects::get_config_options() const {
 ErrorCodeMap
 P4Objects::get_error_codes() const {
   return error_codes;
+}
+
+EnumMap::type_t
+P4Objects::get_enum_value(const std::string &name) const {
+  return enums.from_name(name);
+}
+
+const std::string &
+P4Objects::get_enum_name(const std::string &enum_name,
+                         EnumMap::type_t entry_value) const {
+  return enums.to_name(enum_name, entry_value);
 }
 
 }  // namespace bm

--- a/src/bm_sim/enums.cpp
+++ b/src/bm_sim/enums.cpp
@@ -1,0 +1,66 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/enums.h>
+
+#include <string>
+
+namespace bm {
+
+bool
+EnumMap::add_enum(const std::string &enum_name) {
+  auto it = map_enum_name_to_entries.find(enum_name);
+  if (it != map_enum_name_to_entries.end()) return false;
+  map_enum_name_to_entries[enum_name] = {};
+  return true;
+}
+
+bool
+EnumMap::add_entry(const std::string &enum_name, const std::string &entry_name,
+                   type_t v) {
+  // make sure that the enum exists
+  auto it = map_enum_name_to_entries.find(enum_name);
+  if (it == map_enum_name_to_entries.end()) return false;
+  auto &entry_map = it->second;
+  // make sure that the value is not used yet for this enum
+  auto it2 = entry_map.find(v);
+  if (it2 != entry_map.end()) return false;
+  auto name = enum_name + "." + entry_name;
+  // make sure that the entry name is not used yet for this enum
+  auto it3 = map_name_to_v.find(name);
+  if (it3 != map_name_to_v.end()) return false;
+  // add necessary entries to maps
+  entry_map[v] = name;
+  map_name_to_v[name] = v;
+  return true;
+}
+
+EnumMap::type_t
+EnumMap::from_name(const std::string &name) const {
+  return map_name_to_v.at(name);
+}
+
+const std::string &
+EnumMap::to_name(const std::string &enum_name, type_t v) const {
+  const auto &entry_map = map_enum_name_to_entries.at(enum_name);
+  return entry_map.at(v);
+}
+
+}  // namespace bm

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,7 +61,8 @@ test_switch \
 test_target_parser \
 test_runtime_iface \
 test_bm_apps \
-test_stateful
+test_stateful \
+test_enums
 
 check_PROGRAMS = $(TESTS) test_all
 
@@ -96,6 +97,7 @@ test_target_parser_SOURCES = $(common_source) test_target_parser.cpp
 test_runtime_iface_SOURCES = $(common_source) test_runtime_iface.cpp
 test_bm_apps_SOURCES       = $(common_source) test_bm_apps.cpp
 test_stateful_SOURCES      = $(common_source) test_stateful.cpp
+test_enums_SOURCES         = $(common_source) test_enums.cpp
 
 test_all_SOURCES = $(common_source) \
 test_actions.cpp \
@@ -127,7 +129,8 @@ test_switch.cpp \
 test_target_parser.cpp \
 test_runtime_iface.cpp \
 test_bm_apps.cpp \
-test_stateful.cpp
+test_stateful.cpp \
+test_enums.cpp
 
 EXTRA_DIST = \
 testdata/en0.pcap \

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -718,12 +718,12 @@ TEST_F(ActionsTest, UniquePrimitivesForEachP4Objects) {
   ASSERT_EQ(0, second_objects.init_objects(&second_is, &second_factory));
 
   // check primitives are unique across p4objects instances
-  ASSERT_TRUE(first_objects.get_primitive(std::string("_nop"))
-              != second_objects.get_primitive(std::string("_nop")));
+  ASSERT_NE(first_objects.get_primitive(std::string("_nop")),
+            second_objects.get_primitive(std::string("_nop")));
 
   // check only one copy of a primitive for one p4objects instance
-  ASSERT_TRUE(first_objects.get_primitive(std::string("_nop"))
-              == first_objects.get_primitive(std::string("_nop")));
+  ASSERT_EQ(first_objects.get_primitive(std::string("_nop")),
+            first_objects.get_primitive(std::string("_nop")));
 }
 
 class RegisterSpin : public ActionPrimitive<RegisterArray &, const Data &> {

--- a/tests/test_enums.cpp
+++ b/tests/test_enums.cpp
@@ -1,0 +1,72 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_sim/enums.h>
+
+#include <string>
+
+using namespace bm;
+
+// Google Test fixture for enums tests
+class EnumsTest : public ::testing::Test {
+ protected:
+  EnumMap enums{};
+
+  static const std::string get_name(const std::string &enum_name,
+                                    const std::string &entry_name) {
+    return enum_name + "." + entry_name;
+  }
+};
+
+TEST_F(EnumsTest, AddAndAccess) {
+  const std::string enum_name("MyEnum");
+  const std::string bad_enum_name("BadEnum");
+  const std::string enum_entry_1("Entry1");
+  const std::string enum_entry_2("Entry2");
+  const std::string name_1(get_name(enum_name, enum_entry_1));
+  const std::string name_2(get_name(enum_name, enum_entry_2));
+  const std::string bad_name("BadName");
+  const EnumMap::type_t v_1(0);
+  const EnumMap::type_t v_2(1);
+  const EnumMap::type_t bad_v(2);
+
+  ASSERT_TRUE(enums.add_enum(enum_name));
+  ASSERT_FALSE(enums.add_enum(enum_name));  // error: tries to add twice
+
+  ASSERT_TRUE(enums.add_entry(enum_name, enum_entry_1, v_1));
+  // error: tries to add with same name
+  ASSERT_FALSE(enums.add_entry(enum_name, enum_entry_1, v_2));
+  // error: tries to add with same value
+  ASSERT_FALSE(enums.add_entry(enum_name, enum_entry_2, v_1));
+  // error: tries to add with invalid enum name
+  ASSERT_FALSE(enums.add_entry(bad_enum_name, enum_entry_2, v_2));
+  ASSERT_TRUE(enums.add_entry(enum_name, enum_entry_2, v_2));
+
+  ASSERT_EQ(v_1, enums.from_name(name_1));
+  ASSERT_EQ(v_2, enums.from_name(name_2));
+  ASSERT_THROW(enums.from_name(bad_name), std::out_of_range);
+
+  ASSERT_EQ(name_1, enums.to_name(enum_name, v_1));
+  ASSERT_EQ(name_2, enums.to_name(enum_name, v_2));
+  ASSERT_THROW(enums.to_name(bad_enum_name, v_1), std::out_of_range);
+  ASSERT_THROW(enums.to_name(enum_name, bad_v), std::out_of_range);
+}


### PR DESCRIPTION
This is very similar to how we handle errors (see #259). It is expected
that the bmv2 compiler will assign a unique numerical value to each
enum constant. This mapping (enum name to value) will be made
available in the bmv2 JSON input. In the rest of the JSON file, the
enum constants are referenced only through their numerical value.

The JSON documentation was updated to include enum support and the JSON
version was bumped up to 2.3.