### PR TITLE
Accept general expressions in verify statements

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -11,7 +11,7 @@ per [this specification] (http://json-schema.org/).
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.3*.
+The version described in this document is *2.4*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -195,8 +195,8 @@ parser. The attributes for these objects are:
     `lookahead` or `expression`, with the appropriate value (see [here]
     (#the-type-value-object)). Finally, for a verify operation, we expect an
     array with exactly 2 elements: the first should be a boolean expression
-    while the second should be a valid integral value for an error constant (see
-    [here] (#errors)).
+    while the second should be an expression resolving to a valid integral value
+    for an error constant (see [here] (#errors)).
   - `transition_key`: a JSON array (in the correct order) of objects which
   describe the different fields of the parse state transition key. Each object
   has 2 attributes, `type` and `value`, where `type` can be either

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -265,7 +265,8 @@ class ParseState : public NamedP4Object {
   void add_set_from_expression(header_id_t dst_header, int dst_offset,
                                const ArithExpression &expr);
 
-  void add_verify(const BoolExpression &condition, const ErrorCode &error);
+  void add_verify(const BoolExpression &condition,
+                  const ArithExpression &error_expr);
 
   void set_key_builder(const ParseSwitchKeyBuilder &builder);
 

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -386,8 +386,8 @@ TEST(P4Objects, InvalidErrors) {
 }
 
 TEST(P4Objects, ParserVerify) {
-  auto create_json = [](int error_v, std::ostream *ss) {
-    *ss << "{\"errors\":[[\"NoError\",0]],"
+  auto create_json = [](const std::string &error_v, std::ostream *os) {
+    *os << "{\"errors\":[[\"NoError\",0]],"
         << "\"parsers\":[{\"name\":\"parser\",\"id\":0,\"init_state\":"
         << "\"start\",\"parse_states\":[{\"name\":\"start\",\"id\":0,"
         << "\"parser_ops\":[{\"op\":\"verify\",\"parameters\":[null,"
@@ -396,7 +396,7 @@ TEST(P4Objects, ParserVerify) {
 
   {
     std::stringstream is;
-    create_json(0, &is);
+    create_json("0", &is);
     P4Objects objects;
     LookupStructureFactory factory;
     ASSERT_EQ(0, objects.init_objects(&is, &factory));
@@ -404,7 +404,15 @@ TEST(P4Objects, ParserVerify) {
 
   {
     std::stringstream is;
-    create_json(1000, &is);
+    create_json("{\"type\":\"hexstr\",\"value\":\"0x00\"}", &is);
+    P4Objects objects;
+    LookupStructureFactory factory;
+    ASSERT_EQ(0, objects.init_objects(&is, &factory));
+  }
+
+  {
+    std::stringstream is;
+    create_json("1000", &is);
     std::stringstream os;
     P4Objects objects(os);
     LookupStructureFactory factory;

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1654,6 +1654,13 @@ class ParserVerifyTest : public ParserErrorTest {
     return condition;
   }
 
+  ArithExpression build_simple_error_expr(ErrorCode error_code) {
+    ArithExpression expr;
+    expr.push_back_load_const(Data(error_code.get()));
+    expr.build();
+    return expr;
+  }
+
   void verify_test(bool with_error) {
     bool value = !with_error;
     auto condition = build_simple_condition(value);
@@ -1662,7 +1669,8 @@ class ParserVerifyTest : public ParserErrorTest {
     const auto &phv = *packet.get_phv();
     ASSERT_EQ(value, condition.eval(phv));
 
-    parse_state.add_verify(condition, error_codes.from_name(verify_error));
+    auto error_code = error_codes.from_name(verify_error);
+    parse_state.add_verify(condition, build_simple_error_expr(error_code));
     if (with_error)
       parse_and_check_error(&packet, verify_error);
     else


### PR DESCRIPTION
The second parameter of verify can now be an expression (instead of a
simple integral value). The json parser code is backward-compatible and
still accepts integers.

The JSON documentation was updated to reflect this, and the version
number was bumped up to 2.4.