### PR TITLE
Fix missing dependencies in install_deps.sh and install-thrift.sh

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -22,7 +22,8 @@ sudo apt-get install -y \
     mktemp \
     libffi-dev \
     python-dev \
-    python-pip
+    python-pip \
+    wget
 
 tmpdir=`mktemp -d -p .`
 cd $tmpdir

--- a/travis/install-thrift.sh
+++ b/travis/install-thrift.sh
@@ -11,4 +11,6 @@ tar -xzvf thrift-0.9.2.tar.gz
 cd thrift-0.9.2
 ./configure --with-cpp=yes --with-c_glib=no --with-java=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no
 make -j2 && sudo make install
-cd ..
+cd lib/py
+sudo python setup.py install
+cd ../../..


### PR DESCRIPTION
I've been building a Dockerfile that includes `behavioral-model` based on Ubuntu 14.04. During the process, I noticed that `install_deps.sh` doesn't install everything that's needed. There are two issues, both related to thrift:

- We need to install `wget` to download thrift.
- We need to install the thrift python package, which apparently is not installed by `make install` by default.