### PR TITLE
Improve the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,43 @@
 FROM p4lang/third-party:latest
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
-# Install dependencies.
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-      libjudy-dev \
-      libgmp-dev \
-      libpcap-dev \
-      libboost-program-options-dev \
-      libboost-system-dev \
-      libboost-filesystem-dev \
-      libboost-thread-dev
+# Select the type of image we're building. Use `build` for a normal build, which
+# is optimized for image size. Use `test` if this image will be used for
+# testing; in this case, the source code and build-only dependencies will not be
+# removed from the image.
+ARG IMAGE_TYPE=build
 
-# Copy entire repository.
+ENV BM_DEPS automake \
+            build-essential \
+            git \
+            libjudy-dev \
+            libgmp-dev \
+            libpcap-dev \
+            libboost-dev \
+            libboost-program-options-dev \
+            libboost-system-dev \
+            libboost-filesystem-dev \
+            libboost-thread-dev \
+            libtool
+ENV BM_RUNTIME_DEPS libboost-program-options1.54.0 \
+                    libboost-system1.54.0 \
+                    libboost-thread1.54.0 \
+                    libgmp10 libjudydebian1 \
+                    libpcap0.8 \
+                    python
 COPY . /behavioral-model/
 WORKDIR /behavioral-model/
-
-# Build.
-RUN ./autogen.sh && \
-    ./configure && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
+    ./autogen.sh && \
+    ./configure --with-pdfixed --with-stress-tests && \
     make && \
     make install && \
-    ldconfig
-
-# Clean up to reduce the size of the final image.
-WORKDIR /
-RUN rm -rf behavioral-model
+    ldconfig && \
+    (test "$IMAGE_TYPE" = "build" && \
+      apt-get purge -y $BM_DEPS && \
+      apt-get autoremove --purge -y && \
+      rm -rf /behavioral-model /var/cache/apt/* /var/lib/apt/lists/* && \
+      echo 'Build image ready') || \
+    (test "$IMAGE_TYPE" = "test" && \
+      echo 'Test image ready')


### PR DESCRIPTION
This PR makes some major improvements to the Dockerfile. The changes are:

- The additional `configure` options requested in the comments for the previous version of the Dockerfile have been added.
- Additional dependencies have been added because of the changes in p4lang/third-party#2, which made us uninstall all non-runtime dependencies to minimize the size of the image.
- The methods of p4lang/third-party#2 have been applied here as well. Packages necessary for building are installed and removed within the same layer; only packages which are necessary at runtime are left installed. The source code and intermediate build results are also removed. This reduces the size of the final image from over 2GB to ~700MB, which will improve the build time of Docker images in downstream repos since less data has to be transferred over the network.
- Although this PR doesn't make any changes to `.travis.yml`, we may want to start running tests for this repo using this Docker image. If we do that, we *don't* want to uninstall the build-related packages and source code from the image. To that end, a build argument `IMAGE_TYPE` has been added; if this argument is set to `test`, we will leave those files in place.

The resulting image is building successfully on Docker Hub. (Unlike the current Dockerfile, which was broken by p4lang/third-party#2.)