### PR TITLE
Allow switch to start without JSON configuration

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -404,7 +404,7 @@ EXTRACT_ALL            = NO
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES all members with package or internal
 # scope will be included in the documentation.

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -60,6 +60,7 @@ class OptionsParser {
 
  private:
   std::string config_file_path{};
+  bool no_p4{false};
   InterfaceList ifaces{};
   bool pcap{false};
   int thrift_port{};

--- a/include/bm/bm_sim/queueing.h
+++ b/include/bm/bm_sim/queueing.h
@@ -146,7 +146,7 @@ class QueueingLogic {
     return q_info.size;
   }
 
-  //! Set the capacity of the logical queue with id \id queue_id to \p c
+  //! Set the capacity of the logical queue with id \p queue_id to \p c
   //! elements.
   void set_capacity(size_t queue_id, size_t c) {
     size_t worker_id = map_to_worker(queue_id);

--- a/targets/l2_switch/l2_switch.cpp
+++ b/targets/l2_switch/l2_switch.cpp
@@ -62,7 +62,7 @@ class SimpleSwitch : public Switch {
     force_arith_header("intrinsic_metadata");
   }
 
-  int receive(int port_num, const char *buffer, int len) {
+  int receive_(int port_num, const char *buffer, int len) override {
     static int pkt_id = 0;
 
     auto packet = new_packet_ptr(port_num, pkt_id++, len,
@@ -74,7 +74,7 @@ class SimpleSwitch : public Switch {
     return 0;
   }
 
-  void start_and_return() {
+  void start_and_return_() override {
     std::thread t1(&SimpleSwitch::pipeline_thread, this);
     t1.detach();
     std::thread t2(&SimpleSwitch::transmit_thread, this);

--- a/targets/simple_router/simple_router.cpp
+++ b/targets/simple_router/simple_router.cpp
@@ -54,7 +54,7 @@ class SimpleSwitch : public Switch {
     add_required_field("standard_metadata", "egress_port");
   }
 
-  int receive(int port_num, const char *buffer, int len) {
+  int receive_(int port_num, const char *buffer, int len) override {
     static int pkt_id = 0;
 
     if (this->do_swap() == 0)  // a swap took place
@@ -69,7 +69,7 @@ class SimpleSwitch : public Switch {
     return 0;
   }
 
-  void start_and_return() {
+  void start_and_return_() override {
     std::thread t1(&SimpleSwitch::pipeline_thread, this);
     t1.detach();
     std::thread t2(&SimpleSwitch::transmit_thread, this);

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -112,7 +112,7 @@ SimpleSwitch::SimpleSwitch(int max_port, bool enable_swap)
 #define PACKET_LENGTH_REG_IDX 0
 
 int
-SimpleSwitch::receive(int port_num, const char *buffer, int len) {
+SimpleSwitch::receive_(int port_num, const char *buffer, int len) {
   static int pkt_id = 0;
 
   // this is a good place to call this, because blocking this thread will not
@@ -154,7 +154,7 @@ SimpleSwitch::receive(int port_num, const char *buffer, int len) {
 }
 
 void
-SimpleSwitch::start_and_return() {
+SimpleSwitch::start_and_return_() {
   check_queueing_metadata();
 
   std::thread t1(&SimpleSwitch::ingress_thread, this);
@@ -168,7 +168,7 @@ SimpleSwitch::start_and_return() {
 }
 
 void
-SimpleSwitch::reset_target_state() {
+SimpleSwitch::reset_target_state_() {
   bm::Logger::get()->debug("Resetting simple_switch target-specific state");
   get_component<McSimplePreLAG>()->reset_state();
 }

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -75,11 +75,11 @@ class SimpleSwitch : public Switch {
   // by default, swapping is off
   explicit SimpleSwitch(int max_port = 256, bool enable_swap = false);
 
-  int receive(int port_num, const char *buffer, int len) override;
+  int receive_(int port_num, const char *buffer, int len) override;
 
-  void start_and_return() override;
+  void start_and_return_() override;
 
-  void reset_target_state() override;
+  void reset_target_state_() override;
 
   int mirroring_mapping_add(mirror_id_t mirror_id, int egress_port) {
     mirroring_map[mirror_id] = egress_port;

--- a/tests/stress_tests/stress_utils.h
+++ b/tests/stress_tests/stress_utils.h
@@ -49,12 +49,12 @@ class RandomGen {
 
 class SwitchTest : public bm::Switch {
  public:
-  int receive(int port_num, const char *buffer, int len) override {
+  int receive_(int port_num, const char *buffer, int len) override {
     (void) port_num; (void) buffer; (void) len;
     return 0;
   }
 
-  void start_and_return() override {
+  void start_and_return_() override {
   }
 
   // using pointers as most targets are expected to do that

--- a/tests/test_runtime_iface.cpp
+++ b/tests/test_runtime_iface.cpp
@@ -32,12 +32,12 @@ namespace fs = boost::filesystem;
 
 class SwitchTest : public Switch {
  public:
-  int receive(int port_num, const char *buffer, int len) override {
+  int receive_(int port_num, const char *buffer, int len) override {
     (void) port_num; (void) buffer; (void) len;
     return 0;
   }
 
-  void start_and_return() override { }
+  void start_and_return_() override { }
 };
 
 class RuntimeIfaceTest : public ::testing::Test {

--- a/tools/nanomsg_client.py
+++ b/tools/nanomsg_client.py
@@ -46,6 +46,9 @@ class NameMap:
     def load_names(self, json_cfg):
         self.names = {}
         json_ = json.loads(json_cfg)
+        # special case where the switch was started with an empty config
+        if len(json_.keys()) == 0:
+            return
 
         for type_ in {"header_type", "header", "parser",
                       "deparser", "action", "pipeline", "checksum"}:

--- a/tools/p4dbg.py
+++ b/tools/p4dbg.py
@@ -61,6 +61,10 @@ class FieldMap:
         header_types_map = {}
         json_ = json.loads(json_cfg)
 
+        # special case where the switch was started with an empty config
+        if len(json_.keys()) == 0:
+            return
+
         header_types = json_["header_types"]
         for h in header_types:
             header_type = h["name"]
@@ -158,6 +162,11 @@ class ObjectMap:
 
     def load_names(self, json_cfg):
         json_ = json.loads(json_cfg)
+
+        # special case where the switch was started with an empty config
+        if len(json_.keys()) == 0:
+            return
+
         for type_ in {"parser", "deparser", "action", "pipeline"}:
             _map = self.store[type_]
             _map.pname = type_

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -244,12 +244,15 @@ def load_json_str(json_str):
     reset_config()
     json_ = json.loads(json_str)
 
-    for j_action in json_["actions"]:
+    def get_json_key(key):
+        return json_.get(key, [])
+
+    for j_action in get_json_key("actions"):
         action = Action(j_action["name"], j_action["id"])
         for j_param in j_action["runtime_data"]:
             action.runtime_data += [(j_param["name"], j_param["bitwidth"])]
 
-    for j_pipeline in json_["pipelines"]:
+    for j_pipeline in get_json_key("pipelines"):
         if "action_profiles" in j_pipeline:  # new JSON format
             for j_aprof in j_pipeline["action_profiles"]:
                 action_prof = ActionProf(j_aprof["name"], j_aprof["id"])
@@ -292,41 +295,36 @@ def load_json_str(json_str):
                                                   json_["header_types"])
                 table.key += [(field_name, match_type, bitwidth)]
 
-    if "meter_arrays" in json_:
-        for j_meter in json_["meter_arrays"]:
-            meter_array = MeterArray(j_meter["name"], j_meter["id"])
-            if "is_direct" in j_meter and j_meter["is_direct"]:
-                meter_array.is_direct = True
-                meter_array.binding = j_meter["binding"]
-            else:
-                meter_array.is_direct = False
-                meter_array.size = j_meter["size"]
-            meter_array.type_ = MeterType.from_str(j_meter["type"])
-            meter_array.rate_count = j_meter["rate_count"]
+    for j_meter in get_json_key("meter_arrays"):
+        meter_array = MeterArray(j_meter["name"], j_meter["id"])
+        if "is_direct" in j_meter and j_meter["is_direct"]:
+            meter_array.is_direct = True
+            meter_array.binding = j_meter["binding"]
+        else:
+            meter_array.is_direct = False
+            meter_array.size = j_meter["size"]
+        meter_array.type_ = MeterType.from_str(j_meter["type"])
+        meter_array.rate_count = j_meter["rate_count"]
 
-    if "counter_arrays" in json_:
-        for j_counter in json_["counter_arrays"]:
-            counter_array = CounterArray(j_counter["name"], j_counter["id"])
-            counter_array.is_direct = j_counter["is_direct"]
-            if counter_array.is_direct:
-                counter_array.binding = j_counter["binding"]
-            else:
-                counter_array.size = j_counter["size"]
+    for j_counter in get_json_key("counter_arrays"):
+        counter_array = CounterArray(j_counter["name"], j_counter["id"])
+        counter_array.is_direct = j_counter["is_direct"]
+        if counter_array.is_direct:
+            counter_array.binding = j_counter["binding"]
+        else:
+            counter_array.size = j_counter["size"]
 
-    if "register_arrays" in json_:
-        for j_register in json_["register_arrays"]:
-            register_array = RegisterArray(j_register["name"],
-                                           j_register["id"])
-            register_array.size = j_register["size"]
-            register_array.width = j_register["bitwidth"]
+    for j_register in get_json_key("register_arrays"):
+        register_array = RegisterArray(j_register["name"], j_register["id"])
+        register_array.size = j_register["size"]
+        register_array.width = j_register["bitwidth"]
 
-    if "calculations" in json_:
-        for j_calc in json_["calculations"]:
-            calc_name = j_calc["name"]
-            if j_calc["algo"] == "crc16_custom":
-                CUSTOM_CRC_CALCS[calc_name] = 16
-            elif j_calc["algo"] == "crc32_custom":
-                CUSTOM_CRC_CALCS[calc_name] = 32
+    for j_calc in get_json_key("calculations"):
+        calc_name = j_calc["name"]
+        if j_calc["algo"] == "crc16_custom":
+            CUSTOM_CRC_CALCS[calc_name] = 16
+        elif j_calc["algo"] == "crc32_custom":
+            CUSTOM_CRC_CALCS[calc_name] = 32
 
 class UIn_Error(Exception):
     def __init__(self, info=""):


### PR DESCRIPTION
The target binaries can be started without an input JSON config by using
the --no-p4 command line flag. Until a config has been pushed to the
switch however, no traffic can be processed. The start_and_return method
was modified to block until a config is pushed. The virtual method that
needs to be implemented by switches was renamed
start_and_return_. Similarly the receive virtual method was also renamed
receive_. This means that existing target switches outside of this repo
will need to be updated.

The tools (e.g. runtime CLI) needed to be updated as a result to support
the empty config case.