### PR TITLE
Fix deparsing of VL field with length 0

### DIFF
--- a/src/bm_sim/extract.h
+++ b/src/bm_sim/extract.h
@@ -68,6 +68,8 @@ static inline void generic_extract(const char *data, int bit_offset,
 
 static inline void generic_deparse(const char *data, int bitwidth,
                                    char *dst, int hdr_offset) {
+  if (bitwidth == 0) return;
+
   int nbytes = (bitwidth + 7) / 8;
 
   if (hdr_offset == 0 && bitwidth % 8 == 0) {

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -41,7 +41,11 @@ int Field::extract_VL(const char *data, int hdr_offset, int computed_nbits) {
 }
 
 int Field::deparse(char *data, int hdr_offset) const {
-  extract::generic_deparse(&bytes[0], nbits, data, hdr_offset);
+  // this does not work for empty variable-length fields, as we assert in the
+  // ByteContainer's [] operator. The right thing to do would probably be to add
+  // a at() method to ByteContainer and not perform any check in [].
+  // extract::generic_deparse(&bytes[0], nbits, data, hdr_offset);
+  extract::generic_deparse(bytes.data(), nbits, data, hdr_offset);
   return nbits;
 }
 


### PR DESCRIPTION
This edge case had not been tested previously.
This fixes issue #282.