### PR TITLE
Enable the debugger in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /behavioral-model/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
     ./autogen.sh && \
-    ./configure --with-pdfixed --with-stress-tests && \
+    ./configure --enable-debugger --with-pdfixed --with-stress-tests && \
     make && \
     make install && \
     ldconfig && \


### PR DESCRIPTION
It'd be nice to be able to use the debugger in the Docker image.

It would be even better to be able to install the debugger globally, so we wouldn't need to run it out of the source tree. It might be that automake can take care of that easily; I haven't investigated.