### PR TITLE
Support for stack_field type in expressions

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -11,7 +11,7 @@ per [this specification] (http://json-schema.org/).
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.5*.
+The version described in this document is *2.6*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -55,6 +55,9 @@ bitwidth.
 - if `type` is `register`, `value` is a JSON 2-tuple, where the first item is
 the register array name and the second is an `expression` used to evaluate the
 index.
+- if `type` is `stack_field`, `value` is a JSON 2-tuple, where the first item is
+the header stack name and the second is the field member name. This is used to
+access a field in the last valid header instance in the stack.
 - if `type` is `expression`, `value` is a JSON object with 3 attributes:
   - `op`: the operation performed (`+`, `-`, `*`, `<<`, `>>`, `==`, `!=`, `>`,
   `>=`, `<`, `<=`, `and`, `or`, `not`, `&`, `|`, `^`, `~`, `valid`)
@@ -63,7 +66,7 @@ index.
 
 For an expression, `left` and `right` will themselves be JSON objects, where the
 `value` attribute can be one of `field`, `hexstr`, `header`, `expression`,
-`bool`, `register`, `header_stack`.
+`bool`, `register`, `header_stack`, `stack_field`.
 
 bmv2 also supports these recently-added operations:
   - data-to-bool conversion (`op` is `d2b`): unary operation which can be used

--- a/include/bm/bm_sim/expressions.h
+++ b/include/bm/bm_sim/expressions.h
@@ -34,7 +34,7 @@ class RegisterArray;
 class RegisterSync;
 
 enum class ExprOpcode {
-  LOAD_FIELD, LOAD_HEADER, LOAD_HEADER_STACK,
+  LOAD_FIELD, LOAD_HEADER, LOAD_HEADER_STACK, LOAD_LAST_HEADER_STACK_FIELD,
   LOAD_BOOL, LOAD_CONST, LOAD_LOCAL,
   LOAD_REGISTER_REF, LOAD_REGISTER_GEN,
   ADD, SUB, MOD, DIV, MUL, SHIFT_LEFT, SHIFT_RIGHT,
@@ -79,6 +79,11 @@ struct Op {
 
     header_stack_id_t header_stack;
 
+    struct {
+      header_stack_id_t header_stack;
+      int field_offset;
+    } stack_field;
+
     bool bool_value;
 
     int const_offset;
@@ -110,6 +115,8 @@ class Expression {
   void push_back_load_bool(bool value);
   void push_back_load_header(header_id_t header);
   void push_back_load_header_stack(header_stack_id_t header_stack);
+  void push_back_load_last_header_stack_field(header_stack_id_t header_stack,
+                                              int field_offset);
   void push_back_load_const(const Data &data);
   void push_back_load_local(const int offset);
   void push_back_load_register_ref(RegisterArray *register_array,

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -67,6 +67,15 @@ ActionFn::parameter_push_back_header_stack(header_stack_id_t header_stack) {
 }
 
 void
+ActionFn::parameter_push_back_last_header_stack_field(
+    header_stack_id_t header_stack, int field_offset) {
+  ActionParam param;
+  param.tag = ActionParam::LAST_HEADER_STACK_FIELD;
+  param.stack_field = {header_stack, field_offset};
+  params.push_back(param);
+}
+
+void
 ActionFn::parameter_push_back_const(const Data &data) {
   const_values.push_back(data);
   ActionParam param;

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -73,7 +73,7 @@ class CopyHeader : public ActionPrimitive<Header &, const Header &> {
     if (!src.is_valid()) return;
     dst.mark_valid();
     assert(dst.get_header_type_id() == src.get_header_type_id());
-    for (unsigned int i = 0; i < dst.size(); i++) {
+    for (size_t i = 0; i < dst.size(); i++) {
       dst[i].set(src[i]);
     }
   }
@@ -246,11 +246,11 @@ TEST_F(ActionsTest, SetFromConst) {
   Field &f = phv->get_field(testHeader1, 3);  // f16
   f.set(0);
 
-  ASSERT_EQ((unsigned) 0, f.get_uint());
+  ASSERT_EQ(0u, f.get_uint());
 
   testActionFnEntry(pkt.get());
 
-  ASSERT_EQ((unsigned) 0xaba, f.get_uint());
+  ASSERT_EQ(0xabau, f.get_uint());
 }
 
 TEST_F(ActionsTest, SetFromActionData) {
@@ -264,11 +264,11 @@ TEST_F(ActionsTest, SetFromActionData) {
   Field &f = phv->get_field(testHeader1, 3);  // f16
   f.set(0);
 
-  ASSERT_EQ((unsigned) 0, f.get_uint());
+  ASSERT_EQ(0u, f.get_uint());
 
   testActionFnEntry(pkt.get());
 
-  ASSERT_EQ((unsigned) 0xaba, f.get_uint());
+  ASSERT_EQ(0xabau, f.get_uint());
 }
 
 TEST_F(ActionsTest, SetFromField) {
@@ -283,11 +283,11 @@ TEST_F(ActionsTest, SetFromField) {
   Field &dst = phv->get_field(testHeader1, 3);  // f16
   dst.set(0);
 
-  ASSERT_EQ((unsigned) 0, dst.get_uint());
+  ASSERT_EQ(0u, dst.get_uint());
 
   testActionFnEntry(pkt.get());
 
-  ASSERT_EQ((unsigned) 0xaba, dst.get_uint());
+  ASSERT_EQ(0xabau, dst.get_uint());
 }
 
 TEST_F(ActionsTest, SetFromRegisterRef) {
@@ -367,11 +367,31 @@ TEST_F(ActionsTest, SetFromExpression) {
   Field &dst = phv->get_field(testHeader1, 3);  // f16
   dst.set(0);
 
-  ASSERT_EQ((unsigned) 0, dst.get_uint());
+  ASSERT_EQ(0u, dst.get_uint());
 
   testActionFnEntry(pkt.get());
 
-  ASSERT_EQ((unsigned) 0xabb, dst.get_uint());
+  ASSERT_EQ(0xabbu, dst.get_uint());
+}
+
+TEST_F(ActionsTest, SetFromLastStackField) {
+  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+  ASSERT_EQ(1u, stack.push_back());
+
+  SetField primitive;
+  testActionFn.push_back_primitive(&primitive);
+  testActionFn.parameter_push_back_field(testHeader1, 3);  // f16
+  // f32
+  testActionFn.parameter_push_back_last_header_stack_field(testHeaderStack, 0);
+
+  auto &src = phv->get_field(testHeaderS0, 0);
+  auto &dst = phv->get_field(testHeader1, 3);
+  dst.set(0);
+  src.set(0xaba);
+
+  testActionFnEntry(pkt.get());
+
+  ASSERT_EQ(0xaba, dst.get<int>());
 }
 
 TEST_F(ActionsTest, SetFromConstStress) {
@@ -385,9 +405,9 @@ TEST_F(ActionsTest, SetFromConstStress) {
 
   for (int i = 0; i < 100000; i++) {
     f.set(0);
-    ASSERT_EQ((unsigned) 0, f.get_uint());
+    ASSERT_EQ(0u, f.get_uint());
     testActionFnEntry(pkt.get());
-    ASSERT_EQ((unsigned) 0xaba, f.get_uint());
+    ASSERT_EQ(0xabau, f.get_uint());
   }
 }
 
@@ -495,11 +515,11 @@ TEST_F(ActionsTest, CRSet) {
   Field &f = phv->get_field(testHeader1, 3);  // f16
   f.set(0);
 
-  ASSERT_EQ((unsigned) 0, f.get_uint());
+  ASSERT_EQ(0u, f.get_uint());
 
   testActionFnEntry(pkt.get());
 
-  ASSERT_EQ((unsigned) 666, f.get_uint());
+  ASSERT_EQ(666u, f.get_uint());
 }
 
 TEST_F(ActionsTest, Pop) {
@@ -622,13 +642,13 @@ TEST_F(ActionsTest, TwoPrimitives) {
   Field &dst2 = phv->get_field(testHeader2, 3);  // f16
   dst1.set(0); dst2.set(0);
 
-  ASSERT_EQ((unsigned) 0, dst1.get_uint());
-  ASSERT_EQ((unsigned) 0, dst2.get_uint());
+  ASSERT_EQ(0u, dst1.get_uint());
+  ASSERT_EQ(0u, dst2.get_uint());
 
   testActionFnEntry(pkt.get());
 
-  ASSERT_EQ((unsigned) 0xaba, dst1.get_uint());
-  ASSERT_EQ((unsigned) 0xaba, dst2.get_uint());
+  ASSERT_EQ(0xabau, dst1.get_uint());
+  ASSERT_EQ(0xabau, dst2.get_uint());
 }
 
 extern bool WITH_VALGRIND;  // defined in main.cpp

--- a/tests/test_conditionals.cpp
+++ b/tests/test_conditionals.cpp
@@ -676,6 +676,23 @@ TEST_F(ConditionalsTest, Stacks) {
   }
 }
 
+TEST_F(ConditionalsTest, LastHeaderStackField) {
+  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+  ASSERT_EQ(1u, stack.push_back());
+
+  Conditional c("ctest", 0);
+  c.push_back_load_last_header_stack_field(testHeaderStack, 3);  // f16
+  c.push_back_load_const(Data(0xaba));
+  c.push_back_op(ExprOpcode::EQ_DATA);
+  c.build();
+
+  auto &f = phv->get_field(testHeader1, 3);  // f16
+  f.set(0xaba);
+  ASSERT_TRUE(c.eval(*phv));
+  f.set(0xabb);
+  ASSERT_FALSE(c.eval(*phv));
+}
+
 TEST_F(ConditionalsTest, AccessField) {
   Conditional c("ctest", 0);
   c.push_back_load_header(testHeader1);
@@ -684,7 +701,7 @@ TEST_F(ConditionalsTest, AccessField) {
   c.push_back_op(ExprOpcode::EQ_DATA);
   c.build();
 
-  Field &f = phv->get_field(testHeader1, 3);  // f16
+  auto &f = phv->get_field(testHeader1, 3);  // f16
   f.set(0xaba);
 
   ASSERT_TRUE(c.eval(*phv));


### PR DESCRIPTION
The special stack_field type gives access to a field in the last valid
header instance of a stack. Until now, this was only supported in the
parser transition key. For the sake of uniformity it is now supported in
expressions and as an action parameter. This may go away in the future
if we adopt a more uniform scheme and treat "everything" as an
exception. In particular we should probably try to allow expressions in
parser transition keys.

The JSON documentation was updated to reflect this, and the version
number was bumped up to 2.6.