### PR TITLE
Add tentative support for method calls in parser

### DIFF
--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -301,6 +301,9 @@ class P4Objects {
   void build_expression(const Json::Value &json_expression, Expression *expr,
                         ExprType *expr_type);
 
+  int add_primitive_to_action(const Json::Value &primitive,
+                              ActionFn *action_fn);
+
   void parse_config_options(const Json::Value &root);
 
  private:
@@ -353,6 +356,8 @@ class P4Objects {
   std::unordered_map<std::string, std::unique_ptr<Parser> > parsers{};
   // this is to give the objects a place where to live
   std::vector<std::unique_ptr<ParseState> > parse_states{};
+  // this is to give ActionFn objects a place to live
+  std::vector<std::unique_ptr<ActionFn> > parse_methods{};
 
   // parse vsets
   std::unordered_map<std::string, std::unique_ptr<ParseVSet> > parse_vsets{};

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -573,6 +573,8 @@ class ActionFn :  public NamedP4Object {
 
   void push_back_primitive(ActionPrimitive_ *primitive);
 
+  void grab_register_accesses(RegisterSync *register_sync) const;
+
  private:
   std::vector<ActionPrimitive_ *> primitives{};
   std::vector<ActionParam> params{};
@@ -597,7 +599,10 @@ class ActionFnEntry {
   explicit ActionFnEntry(const ActionFn *action_fn)
     : action_fn(action_fn) { }
 
+  // log event, notify debugger if needed, lock registers, then call execute()
   void operator()(Packet *pkt) const;
+
+  void execute(Packet *pkt) const;
 
   void push_back_action_data(const Data &data);
 

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -42,6 +42,7 @@ class Packet;
 
 class BoolExpression;
 class ArithExpression;
+class ActionFn;
 
 struct field_t {
   header_id_t header;
@@ -226,6 +227,8 @@ class ParseState : public NamedP4Object {
 
   void add_verify(const BoolExpression &condition,
                   const ArithExpression &error_expr);
+
+  void add_method_call(ActionFn *action_fn);
 
   void set_key_builder(const ParseSwitchKeyBuilder &builder);
 

--- a/include/bm/bm_sim/stateful.h
+++ b/include/bm/bm_sim/stateful.h
@@ -191,7 +191,9 @@ class RegisterSync {
     LockVector<> v{a};
   };
 
-  void add_register_array(RegisterArray *register_array);
+  void add_register_array(const RegisterArray *register_array);
+
+  void merge_from(const RegisterSync &other);
 
   // tried NRVO, but RegisterLocks not movable
   void lock(RegisterLocks *RL) const {

--- a/src/bm_sim/stateful.cpp
+++ b/src/bm_sim/stateful.cpp
@@ -72,9 +72,15 @@ RegisterArray::notify(const Register &reg) const {
 }
 
 void
-RegisterSync::add_register_array(RegisterArray *register_array) {
+RegisterSync::add_register_array(const RegisterArray *register_array) {
   if (register_arrays.insert(register_array).second)
     mutexes.push_back(&register_array->m_mutex);
+}
+
+void
+RegisterSync::merge_from(const RegisterSync &other) {
+  for (auto register_array : other.register_arrays)
+    add_register_array(register_array);  // takes care of duplicates
 }
 
 }  // namespace bm

--- a/tests/primitives.cpp
+++ b/tests/primitives.cpp
@@ -25,6 +25,7 @@
 #include <bm/bm_sim/packet.h>
 
 #include <string>
+#include <thread>
 
 using namespace bm;
 
@@ -102,6 +103,15 @@ class ignore_string : public ActionPrimitive<const std::string &> {
 };
 
 REGISTER_PRIMITIVE(ignore_string);
+
+class RegisterSpin : public ActionPrimitive<RegisterArray &, const Data &> {
+  void operator ()(RegisterArray &register_array, const Data &ts) {
+    register_array.at(0).set(ts);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ts.get_uint()));
+  }
+};
+
+REGISTER_PRIMITIVE(RegisterSpin);
 
 // one dummy extern
 


### PR DESCRIPTION
We add support for calling primitive actions (in bmv2 terminology that
includes extern methods) in parse states. This is a tentative change
with a tentative JSON format, which is not documented in JSON_format.md
yet.

I re-organized some P4Objects code to avoid code duplication in
primitive initialization between the action code and the parser code.