### PR TITLE
Add a shift operation to parser

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -11,7 +11,7 @@ per [this specification] (http://json-schema.org/).
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.7*.
+The version described in this document is *2.8*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -205,7 +205,7 @@ parser. The attributes for these objects are:
   - `parser_ops`: a JSON array of the operations (set or extract) performed in
   this parse state, in the correct order. Each parser operation is represented
   by a JSON object, whose attributes are:
-    - `op`: the type of operation, either `extract`, `set` or `verify`
+    - `op`: the type of operation, either `extract`, `set`, `verify` or `shift`
     - `parameters`: a JSON array of objects encoding the parameters to the
     parser operation. Each parameter object has 2 string attributes: `type` for
     the parameter type and `value` for its value. Depending on the type of
@@ -216,10 +216,12 @@ parser. The attributes for these objects are:
     takes exactly 2 parameters. The first one needs to be of type `field` with
     the appropriate value. The second one can be of type `field`, `hexstr`,
     `lookahead` or `expression`, with the appropriate value (see [here]
-    (#the-type-value-object)). Finally, for a verify operation, we expect an
-    array with exactly 2 elements: the first should be a boolean expression
-    while the second should be an expression resolving to a valid integral value
-    for an error constant (see [here] (#errors)).
+    (#the-type-value-object)). For a verify operation, we expect an array with
+    exactly 2 elements: the first should be a boolean expression while the
+    second should be an expression resolving to a valid integral value for an
+    error constant (see [here] (#errors)). Finally for a shift operation, we
+    expect a single parameter: the number of bytes to shift (shifted packet data
+    will be discarded).
   - `transition_key`: a JSON array (in the correct order) of objects which
   describe the different fields of the parse state transition key. Each object
   has 2 attributes, `type` and `value`, where `type` can be either

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -230,6 +230,8 @@ class ParseState : public NamedP4Object {
 
   void add_method_call(ActionFn *action_fn);
 
+  void add_shift(size_t shift_bytes);
+
   void set_key_builder(const ParseSwitchKeyBuilder &builder);
 
   void add_switch_case(const ByteContainer &key, const ParseState *next_state);

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -762,6 +762,10 @@ P4Objects::init_parsers(const Json::Value &cfg_root) {
           add_primitive_to_action(cfg_parameters[0], action_fn.get());
           parse_state->add_method_call(action_fn.get());
           parse_methods.push_back(std::move(action_fn));
+        } else if (op_type == "shift") {
+          assert(cfg_parameters.size() == 1);
+          auto shift_bytes = static_cast<size_t>(cfg_parameters[0].asInt());
+          parse_state->add_shift(shift_bytes);
         } else {
           throw json_exception(
               EFormat() << "Parser op '" << op_type << "'not supported",

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -835,3 +835,18 @@ TEST(P4Objects, ImmutableEntriesBadJson) {
     check(builder, expected_error_msg);
   }
 }
+
+TEST(P4Objects, ParserShift) {
+  auto create_json = [](size_t shift_bytes, std::ostream *os) {
+    *os << "{\"parsers\":[{\"name\":\"parser\",\"id\":0,\"init_state\":"
+        << "\"start\",\"parse_states\":[{\"name\":\"start\",\"id\":0,"
+        << "\"parser_ops\":[{\"op\":\"shift\",\"parameters\":["
+        << shift_bytes << "]}],\"transition_key\":[],\"transitions\":[]}]}]}";
+  };
+
+  std::stringstream is;
+  create_json(4, &is);
+  P4Objects objects;
+  LookupStructureFactory factory;
+  ASSERT_EQ(0, objects.init_objects(&is, &factory));
+}


### PR DESCRIPTION
This can be used to shift over a given number of bytes, which are
discarded.

The JSON documentation was updated to reflect this, and the version
number was bumped up to 2.8