### PR TITLE
Improve log messages for parser set operations

### DIFF
--- a/include/bm/bm_sim/headers.h
+++ b/include/bm/bm_sim/headers.h
@@ -257,6 +257,13 @@ class Header : public NamedP4Object {
 
   void set_packet_id(const Debugger::PacketId *id);
 
+  //! Returns a reference to the name of the field at the given offset.
+  const std::string &get_field_name(int field_offset) const;
+
+  //! Returns the full name of the field at the given offset as a new
+  //! string. The name is of the form <hdr_name>.<f_name>.
+  const std::string get_field_full_name(int field_offset) const;
+
   Header(const Header &other) = delete;
   Header &operator=(const Header &other) = delete;
 

--- a/include/bm/bm_sim/phv.h
+++ b/include/bm/bm_sim/phv.h
@@ -267,6 +267,11 @@ class PHV {
   //! Returns the number of headers included in the PHV
   size_t num_headers() const { return headers.size(); }
 
+  //! Returns the full name of the field as a new string. The name is of the
+  //! form <hdr_name>.<f_name>.
+  const std::string get_field_name(header_id_t header_index,
+                                   int field_offset) const;
+
  private:
   // To  be used only by PHVFactory
   // all headers need to be pushed back in order (according to header_index) !!!

--- a/src/bm_sim/headers.cpp
+++ b/src/bm_sim/headers.cpp
@@ -213,6 +213,16 @@ void Header::set_packet_id(const Debugger::PacketId *id) {
   for (Field &f : fields) f.set_packet_id(id);
 }
 
+const std::string &
+Header::get_field_name(int field_offset) const {
+  return header_type.get_field_name(field_offset);
+}
+
+const std::string
+Header::get_field_full_name(int field_offset) const {
+  return name + "." + get_field_name(field_offset);
+}
+
 bool Header::cmp(const Header &other) const {
   return (header_type.get_type_id() == other.header_type.get_type_id()) &&
       is_valid() && other.is_valid() &&

--- a/src/bm_sim/parser.cpp
+++ b/src/bm_sim/parser.cpp
@@ -61,8 +61,10 @@ ParserOpSet<field_t>::operator()(Packet *pkt, const char *data,
   f_dst.set(f_src);
   BMLOG_DEBUG_PKT(
     *pkt,
-    "Parser set: setting field ({}, {}) from field ({}, {}) ({})",
-    dst.header, dst.offset, src.header, src.offset, f_dst);
+    "Parser set: setting field '{}' from field '{}' ({})",
+    phv->get_field_name(dst.header, dst.offset),
+    phv->get_field_name(src.header, src.offset),
+    f_dst);
 }
 
 template<>
@@ -73,8 +75,8 @@ ParserOpSet<Data>::operator()(Packet *pkt, const char *data,
   auto phv = pkt->get_phv();
   auto &f_dst = phv->get_field(dst.header, dst.offset);
   f_dst.set(src);
-  BMLOG_DEBUG_PKT(*pkt, "Parser set: setting field ({}, {}) to {}",
-                  dst.header, dst.offset, f_dst);
+  BMLOG_DEBUG_PKT(*pkt, "Parser set: setting field '{}' to {}",
+                  phv->get_field_name(dst.header, dst.offset), f_dst);
 }
 
 template<>
@@ -105,9 +107,9 @@ ParserOpSet<ParserLookAhead>::operator()(Packet *pkt, const char *data,
   }
   BMLOG_DEBUG_PKT(
     *pkt,
-    "Parser set: setting field ({}, {}) from lookahead ({}, {}), "
-    "new value is {}",
-    dst.header, dst.offset, src.bit_offset, src.bitwidth, f_dst);
+    "Parser set: setting field '{}' from lookahead ({}, {}), new value is {}",
+    phv->get_field_name(dst.header, dst.offset), src.bit_offset, src.bitwidth,
+    f_dst);
 }
 
 template<>
@@ -120,8 +122,8 @@ ParserOpSet<ArithExpression>::operator()(Packet *pkt, const char *data,
   src.eval(*phv, &f_dst);
   BMLOG_DEBUG_PKT(
     *pkt,
-    "Parser set: setting field ({}, {}) from expression, new value is {}",
-    dst.header, dst.offset, f_dst);
+    "Parser set: setting field '{}' from expression, new value is {}",
+    phv->get_field_name(dst.header, dst.offset), f_dst);
 }
 
 ParseSwitchKeyBuilder::Entry

--- a/src/bm_sim/phv.cpp
+++ b/src/bm_sim/phv.cpp
@@ -113,6 +113,11 @@ PHV::add_field_alias(const std::string &from, const std::string &to) {
   // fields_map.emplace(from, ref);
 }
 
+const std::string
+PHV::get_field_name(header_id_t header_index, int field_offset) const {
+  return get_header(header_index).get_field_full_name(field_offset);
+}
+
 
 void
 PHVFactory::push_back_header(const std::string &header_name,


### PR DESCRIPTION
The log messages used to display the header id and field offset
(e.g. for destination field). It now displays the actual name of the
field.

This is definitely not the most efficient implementation, as we do a
name "lookup" every time, but it was the easiest to write. If there is a
need to increase performance even when logging is enabled, we can change
the implementaion to cache the name.