### PR TITLE
No nanomsg

### DIFF
--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,0 +1,104 @@
+FROM ubuntu:16.04
+MAINTAINER Antonin Bas <antonin@barefootnetworks.com>
+
+ARG MAKEFLAGS
+ENV MAKEFLAGS ${MAKEFLAGS:--j2}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git ca-certificates
+
+# Build Protocol Buffers.
+ENV PROTOCOL_BUFFERS_DEPS autoconf \
+                          automake \
+                          g++ \
+                          libtool \
+                          make \
+                          curl \
+                          unzip
+RUN git clone https://github.com/google/protobuf.git
+WORKDIR /protobuf/
+RUN git checkout tags/v3.0.2
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $PROTOCOL_BUFFERS_DEPS && \
+    export CFLAGS="-Os" && \
+    export CXXFLAGS="-Os" && \
+    export LDFLAGS="-Wl,-s" && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig && \
+    apt-get purge -y $PROTOCOL_BUFFERS_DEPS && apt-get autoremove --purge -y && \
+    rm -rf /protobuf /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
+
+WORKDIR /
+
+# Build gRPC.
+# The gRPC build system should detect that a version of protobuf is already
+# installed and should not try to install the third-party one included as a
+# submodule in the grpc repository.
+ENV GRPC_DEPS build-essential \
+              autoconf \
+              libtool
+RUN git clone https://github.com/google/grpc.git
+WORKDIR /grpc/
+RUN git checkout tags/v1.0.1 && \
+    git submodule update --init --recursive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $GRPC_DEPS && \
+    export LDFLAGS="-Wl,-s" && \
+    make && \
+    make install && \
+    ldconfig && \
+    apt-get purge -y $GRPC_DEPS && apt-get autoremove --purge -y && \
+    rm -rf /grpc /var/cache/apt/* /var/lib/apt/lists/* /var/cache/debconf/* /var/lib/dpkg/*-old /var/log/*
+
+WORKDIR /
+
+ENV BM_DEPS automake \
+            build-essential \
+            libjudy-dev \
+            libgmp-dev \
+            libpcap-dev \
+            libboost-dev \
+            libboost-program-options-dev \
+            libboost-system-dev \
+            libboost-filesystem-dev \
+            libboost-thread-dev \
+            libtool \
+            pkg-config
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $BM_DEPS
+ADD https://api.github.com/repos/p4lang/PI/git/refs/heads/master .PI.head.json
+RUN git clone https://github.com/p4lang/PI/
+WORKDIR /PI
+RUN git submodule update --init --recursive
+RUN export CFLAGS="-O0" && \
+    export CXXFLAGS="-O0" && \
+    ./autogen.sh && \
+    ./configure --with-proto --without-cli --without-internal-rpc && \
+    make && \
+    make install && ldconfig && \
+    rm -rf /PI/
+
+WORKDIR /
+COPY . /behavioral-model/
+
+WORKDIR /behavioral-model/
+
+RUN export CFLAGS="-O0" && \
+    export CXXFLAGS="-O0" && \
+    ./autogen.sh && \
+    ./configure --without-thrift --without-nanomsg --with-pi && \
+    make && \
+    make install && ldconfig
+
+WORKDIR /behavioral-model/targets/simple_switch_grpc
+
+RUN export CFLAGS="-O0" && \
+    export CXXFLAGS="-O0" && \
+    ./autogen.sh && \
+    ./configure &&\
+    make

--- a/PI/src/common.cpp
+++ b/PI/src/common.cpp
@@ -20,8 +20,6 @@
 
 #include "common.h"
 
-#include <bm/Standard.h>
-
 #include <algorithm>  // for std::copy
 
 namespace pibmv2 {

--- a/configure.ac
+++ b/configure.ac
@@ -46,12 +46,22 @@ AM_CONDITIONAL([COND_PDFIXED], [test "$want_pdfixed" = yes])
 
 MY_CPPFLAGS=""
 
+AC_ARG_WITH([nanomsg],
+    AS_HELP_STRING([--with-nanomsg], [Build Nanomsg RPC service, if disabled then you must have some other way of controlling the switch]),
+    [want_nanomsg="$withval"], [want_nanomsg=yes])
+
+AM_CONDITIONAL([COND_NANOMSG], [test "$want_nanomsg" = yes])
+
 debugger_enabled=no
 AC_ARG_ENABLE([debugger],
     AS_HELP_STRING([--enable-debugger], [Enable bmv2 remote debugger]))
 AS_IF([test "x$enable_debugger" = "xyes"], [
-    debugger_enabled=yes
-    MY_CPPFLAGS="$MY_CPPFLAGS -DBMDEBUG_ON"
+    AS_IF([test "$want_nanomsg" = "yes"], [
+        debugger_enabled=yes
+        MY_CPPFLAGS="$MY_CPPFLAGS -DBMDEBUG_ON"
+    ], [
+        AC_MSG_ERROR([Cannot use debugger without nanomsg])
+    ])
 ])
 
 logging_macros_enabled=no
@@ -68,9 +78,14 @@ elogger_enabled=no
 AC_ARG_ENABLE([elogger],
     AS_HELP_STRING([--disable-elogger],
                    [Disable nanomsg event logger (some unit tests may fail)]))
+
 AS_IF([test "x$enable_elogger" != "xno"], [
-    elogger_enabled=yes
-    MY_CPPFLAGS="$MY_CPPFLAGS -DBMELOG_ON"
+    AS_IF([test "$want_nanomsg" = "yes"], [
+        elogger_enabled=yes
+        MY_CPPFLAGS="$MY_CPPFLAGS -DBMELOG_ON"
+    ], [
+        AC_MSG_WARN([Cannot use elogger without nanomsg])
+    ])
 ])
 
 AC_ARG_ENABLE([undeterministic_tests],
@@ -145,11 +160,15 @@ AC_CHECK_HEADERS([algorithm array cassert cmath queue \
 cstdio string sys/stat.h sys/types.h ctime tuple unistd.h unordered_map \
 utility vector], [], [AC_MSG_ERROR([Missing header file])])
 
-# Check for pthread, libjudy, libgmp, libnanomsg, libpcap
+AS_IF([test "$want_nanomsg" = yes], [
+    AC_CHECK_LIB([nanomsg], [nn_errno], [], [AC_MSG_ERROR([Missing libnanomsg])])
+    MY_CPPFLAGS="$MY_CPPFLAGS -DBMNANOMSG_ON"
+])
+
+# Check for pthread, libjudy, libgmp, libpcap
 AX_PTHREAD([], [AC_MSG_ERROR([Missing pthread library])])
 AC_CHECK_LIB([Judy], [Judy1Next], [], [AC_MSG_ERROR([Missing libJudy])])
 AC_CHECK_LIB([gmp], [__gmpz_init], [], [AC_MSG_ERROR([Missing libgmp])])
-AC_CHECK_LIB([nanomsg], [nn_errno], [], [AC_MSG_ERROR([Missing libnanomsg])])
 AC_CHECK_LIB([pcap], [pcap_create], [], [AC_MSG_ERROR([Missing libpcap])])
 AC_CHECK_LIB([pcap], [pcap_set_immediate_mode], [pcap_fix=yes], [pcap_fix=no])
 if test -n "$COVERAGE_FLAGS"; then
@@ -247,9 +266,10 @@ AC_OUTPUT
 AS_ECHO("")
 AS_ECHO("Features recap ......................")
 AS_ECHO("Coverage enabled .............. : $coverage_enabled")
-AS_ECHO("Debugger enabled .............. : $debugger_enabled")
 AS_ECHO("Logging macros enabled ........ : $logging_macros_enabled")
+AS_ECHO("With Nanomsg .................. : $want_nanomsg")
 AS_ECHO("Event logger enabled .......... : $elogger_enabled")
+AS_ECHO("Debugger enabled .............. : $debugger_enabled")
 AS_ECHO("With Thrift ................... : $want_thrift")
 AS_IF([test "$want_thrift" = yes], [
 AS_ECHO("  With p4Thrift ............... : $want_p4thrift")

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,12 +1,16 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
-nobase_include_HEADERS = \
+nobase_include_HEADERS =
+
+if COND_NANOMSG
+nobase_include_HEADERS += \
 bm/bm_apps/notifications.h \
 bm/bm_apps/packet_pipe.h
 if COND_THRIFT
 nobase_include_HEADERS += \
 bm/bm_apps/learn.h
-endif
+endif  # COND_THRIFT
+endif  # COND_NANOMSG
 
 if COND_THRIFT
 nobase_include_HEADERS += \

--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -145,12 +145,14 @@ class DevMgr : public PacketDispatcherIface {
   // wait before starting to process packets.
   void set_dev_mgr_files(unsigned wait_time_in_seconds);
 
+#ifdef BMNANOMSG_ON
   // if enforce ports is set to true, packets coming in on un-registered ports
   // are dropped
   void set_dev_mgr_packet_in(
       int device_id, const std::string &addr,
       std::shared_ptr<TransportIface> notifications_transport = nullptr,
       bool enforce_ports = false);
+#endif
 
   ReturnCode port_add(const std::string &iface_name, port_t port_num,
                       const char *in_pcap, const char *out_pcap);

--- a/include/bm/bm_sim/transport.h
+++ b/include/bm/bm_sim/transport.h
@@ -59,7 +59,9 @@ class TransportIface {
     return send_msgs_(msgs);
   }
 
+#ifdef BMNANOMSG_ON
   static std::unique_ptr<TransportIface> make_nanomsg(const std::string &addr);
+#endif
   static std::unique_ptr<TransportIface> make_dummy();
   static std::unique_ptr<TransportIface> make_stdout();
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,14 +4,21 @@ if COND_THRIFT
 MAYBE_BM_RUNTIME = bm_runtime
 endif
 
-SUBDIRS = bf_lpm_trie BMI bm_sim $(MAYBE_BM_RUNTIME) bm_apps
+if COND_NANOMSG
+MAYBE_BM_APPS = bm_apps
+endif
 
-lib_LTLIBRARIES = libbmp4apps.la libbmall.la
+SUBDIRS = bf_lpm_trie BMI bm_sim $(MAYBE_BM_RUNTIME) $(MAYBE_BM_APPS)
 
+lib_LTLIBRARIES = libbmall.la
+
+if COND_NANOMSG
+lib_LTLIBRARIES += libbmp4apps.la
 libbmp4apps_la_SOURCES =
 # Dummy C++ source to cause C++ linking.
 nodist_EXTRA_libbmp4apps_la_SOURCES = dummy.cpp
 libbmp4apps_la_LIBADD = bm_apps/libbmapps.la
+endif
 
 libbmall_la_SOURCES =
 # Dummy C++ source to cause C++ linking.

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -62,6 +62,7 @@ simple_pre_lag.cpp \
 tables.cpp \
 target_parser.cpp \
 transport.cpp \
+transport_nn.cpp \
 utils.h \
 version.cpp \
 version.h \

--- a/src/bm_sim/debugger.cpp
+++ b/src/bm_sim/debugger.cpp
@@ -19,6 +19,8 @@
  */
 
 #include <bm/bm_sim/debugger.h>
+
+#ifdef BMDEBUG_ON
 #include <bm/bm_sim/nn.h>
 
 // temporary deps?
@@ -38,6 +40,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <vector>
+#endif  // BMDEBUG_ON
 
 namespace bm {
 
@@ -86,6 +89,8 @@ class DebuggerDummy final : public DebuggerIface {
     return "";
   }
 };
+
+#ifdef BMDEBUG_ON
 
 class DebuggerNN final : public DebuggerIface {
  public:
@@ -906,7 +911,8 @@ DebuggerNN::request_in() {
   }
 }
 
-// TODO(antonin): check if allowed by Google style guidelines
+#endif  // BMDEBUG_ON
+
 DebuggerIface *Debugger::debugger = new DebuggerDummy();
 
 bool Debugger::is_init = false;
@@ -915,12 +921,16 @@ void
 Debugger::init_debugger(const std::string &addr) {
   if (is_init) return;
   is_init = true;
+#ifdef BMDEBUG_ON
   DebuggerDummy *dummy = dynamic_cast<DebuggerDummy *>(debugger);
   assert(dummy);
   delete dummy;
   DebuggerNN *debugger_nn = new DebuggerNN(addr);
   debugger_nn->open();
   debugger = debugger_nn;
+#else
+  (void) addr;
+#endif
 }
 
 std::string

--- a/src/bm_sim/dev_mgr_packet_in.cpp
+++ b/src/bm_sim/dev_mgr_packet_in.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#ifdef BMNANOMSG_ON
+
 #include <bm/bm_sim/dev_mgr.h>
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/nn.h>
@@ -323,3 +325,5 @@ DevMgr::set_dev_mgr_packet_in(
 }
 
 }  // namespace bm
+
+#endif  // BMNANOMSG_ON

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -93,9 +93,11 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp) {
        "(interface X corresponds to two files X_in.pcap and X_out.pcap).  "
        "Argument is the time to wait (in seconds) before starting to process "
        "the packet files.")
+#ifdef BMNANOMSG_ON
       ("packet-in", po::value<std::string>(),
        "Enable receiving packet on this (nanomsg) socket. "
        "The --interface options will be ignored.")
+#endif
 #ifdef BMTHRIFT_ON
       ("thrift-port", po::value<int>(),
        "TCP port on which to run the Thrift runtime server")
@@ -114,10 +116,12 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp) {
        "'trace', 'debug', 'info', 'warn', 'error', off'; default is 'trace'")
       ("log-flush", "If used with '--log-file', the logger will flush to disk "
        "after every log message")
+#ifdef BMNANOMSG_ON
       ("notifications-addr", po::value<std::string>(),
        "Specify the nanomsg address to use for notifications "
        "(e.g. learning, ageing, ...); "
        "default is ipc:///tmp/bmv2-<device-id>-notifications.ipc")
+#endif
 #ifdef BMDEBUG_ON
       ("debugger", "Activate debugger")
       ("debugger-addr", po::value<std::string>(),
@@ -220,12 +224,14 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp) {
     device_id = vm["device-id"].as<int>();
   }
 
+#ifdef BMNANOMSG_ON
   if (vm.count("notifications-addr")) {
     notifications_addr = vm["notifications-addr"].as<std::string>();
   } else {
     notifications_addr = std::string("ipc:///tmp/bmv2-")
         + std::to_string(device_id) + std::string("-notifications.ipc");
   }
+#endif
 
   if (vm.count("nanolog")) {
 #ifndef BMELOG_ON
@@ -321,12 +327,14 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp) {
       wait_time = 0;
   }
 
+#ifdef BMNANOMSG_ON
   if (vm.count("packet-in")) {
     packet_in = true;
     packet_in_addr = vm["packet-in"].as<std::string>();
     // very important to clear interface list
     ifaces.clear();
   }
+#endif
 
   if (use_files && packet_in) {
     std::cout << "Error: --use-files and --packet-in are exclusive\n";

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -190,9 +190,14 @@ SwitchWContexts::init_from_command_line_options(
 
   auto transport = my_transport;
   if (transport == nullptr) {
+#ifdef BMNANOMSG_ON
     notifications_addr = parser.notifications_addr;
     transport = std::shared_ptr<TransportIface>(
         TransportIface::make_nanomsg(notifications_addr));
+#else
+    notifications_addr = "";
+    transport = std::shared_ptr<TransportIface>(TransportIface::make_dummy());
+#endif
   }
   // won't hurt if transport has already been opened
   transport->open();
@@ -226,8 +231,10 @@ SwitchWContexts::init_from_command_line_options(
     set_dev_mgr(std::move(my_dev_mgr));
   else if (parser.use_files)
     set_dev_mgr_files(parser.wait_time);
+#ifdef BMNANOMSG_ON
   else if (parser.packet_in)
     set_dev_mgr_packet_in(device_id, parser.packet_in_addr, transport);
+#endif
   else
     set_dev_mgr_bmi(device_id, transport);
 
@@ -404,7 +411,9 @@ SwitchWContexts::do_swap() {
       phv_source->set_phv_factory(cxt_id, &cxt.get_phv_factory());
     rc &= swap_done;
   }
+#ifdef BMDEBUG_ON
   Debugger::get()->config_change();
+#endif
   BMELOG(config_change);
   return rc;
 }

--- a/src/bm_sim/transport.cpp
+++ b/src/bm_sim/transport.cpp
@@ -19,100 +19,12 @@
  */
 
 #include <bm/bm_sim/transport.h>
-#include <bm/bm_sim/nn.h>
-
-#include <nanomsg/pubsub.h>
 
 #include <iostream>
 #include <memory>
 #include <string>
 
 namespace bm {
-
-class TransportNanomsg : public TransportIface {
- public:
-  explicit TransportNanomsg(const std::string &addr)
-      : addr(addr), s(AF_SP, NN_PUB) { }
-
- private:
-  int open_() override {
-    try {
-      s.bind(addr.c_str());
-    } catch (const nn::exception &e) {
-      std::cerr << "Nanomsg returned a exception when trying to bind to "
-                << "address '" << addr << "'.\n"
-                << "The exception is: " << e.what() << "\n"
-                << "This may happen if\n"
-                << "1) the address provided is invalid,\n"
-                << "2) another instance of bmv2 is running and using the same "
-                << "address, or\n"
-                << "3) you have insufficent permissions (e.g. you are using an "
-                << "IPC socket on Unix, the file already exists and you don't "
-                << "have permission to access it)\n";
-      std::exit(1);
-    }
-    // TODO(antonin): review if linger is actually needed
-    int linger = 0;
-    s.setsockopt(NN_SOL_SOCKET, NN_LINGER, &linger, sizeof (linger));
-    return 0;
-  }
-
-  int send_(const std::string &msg) const override {
-    s.send(msg.data(), msg.size(), 0);
-    return 0;
-  }
-
-  int send_(const char *msg, int len) const override {
-    s.send(msg, len, 0);
-    return 0;
-  }
-
-  // do not use this function, I think I should just remove it...
-  int send_msgs_(const std::initializer_list<std::string> &msgs)
-      const override {
-    size_t num_msgs = msgs.size();
-    if (num_msgs == 0) return 0;
-    struct nn_msghdr msghdr;
-    std::memset(&msghdr, 0, sizeof(msghdr));
-    struct nn_iovec iov[num_msgs];
-    int i = 0;
-    for (const auto &msg : msgs) {
-      // wish I could write this, but string.data() return const char *
-      // iov[i].iov_base = msg.data();
-      std::unique_ptr<char[]> data(new char[msg.size()]);
-      msg.copy(data.get(), msg.size());
-      iov[i].iov_base = data.get();
-      iov[i].iov_len = msg.size();
-      i++;
-    }
-    msghdr.msg_iov = iov;
-    msghdr.msg_iovlen = num_msgs;
-    s.sendmsg(&msghdr, 0);
-    return 0;
-  }
-
-  int send_msgs_(const std::initializer_list<MsgBuf> &msgs) const override {
-    size_t num_msgs = msgs.size();
-    if (num_msgs == 0) return 0;
-    struct nn_msghdr msghdr;
-    std::memset(&msghdr, 0, sizeof(msghdr));
-    struct nn_iovec iov[num_msgs];
-    int i = 0;
-    for (const auto &msg : msgs) {
-      iov[i].iov_base = msg.buf;
-      iov[i].iov_len = msg.len;
-      i++;
-    }
-    msghdr.msg_iov = iov;
-    msghdr.msg_iovlen = num_msgs;
-    s.sendmsg(&msghdr, 0);
-    return 0;
-  }
-
- private:
-  std::string addr;
-  nn::socket s;
-};
 
 // TODO(antonin): remove this?
 class TransportStdout : public TransportIface {
@@ -183,11 +95,6 @@ class TransportDummy : public TransportIface {
     return 0;
   }
 };
-
-std::unique_ptr<TransportIface>
-TransportIface::make_nanomsg(const std::string &addr) {
-  return std::unique_ptr<TransportIface>(new TransportNanomsg(addr));
-}
 
 std::unique_ptr<TransportIface>
 TransportIface::make_dummy() {

--- a/src/bm_sim/transport_nn.cpp
+++ b/src/bm_sim/transport_nn.cpp
@@ -1,0 +1,125 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifdef BMNANOMSG_ON
+
+#include <bm/bm_sim/transport.h>
+#include <bm/bm_sim/nn.h>
+
+#include <nanomsg/pubsub.h>
+
+#include <iostream>
+#include <string>
+
+namespace bm {
+
+class TransportNanomsg : public TransportIface {
+ public:
+  explicit TransportNanomsg(const std::string &addr)
+      : addr(addr), s(AF_SP, NN_PUB) { }
+
+ private:
+  int open_() override {
+    try {
+      s.bind(addr.c_str());
+    } catch (const nn::exception &e) {
+      std::cerr << "Nanomsg returned a exception when trying to bind to "
+                << "address '" << addr << "'.\n"
+                << "The exception is: " << e.what() << "\n"
+                << "This may happen if\n"
+                << "1) the address provided is invalid,\n"
+                << "2) another instance of bmv2 is running and using the same "
+                << "address, or\n"
+                << "3) you have insufficent permissions (e.g. you are using an "
+                << "IPC socket on Unix, the file already exists and you don't "
+                << "have permission to access it)\n";
+      std::exit(1);
+    }
+    // TODO(antonin): review if linger is actually needed
+    int linger = 0;
+    s.setsockopt(NN_SOL_SOCKET, NN_LINGER, &linger, sizeof (linger));
+    return 0;
+  }
+
+  int send_(const std::string &msg) const override {
+    s.send(msg.data(), msg.size(), 0);
+    return 0;
+  }
+
+  int send_(const char *msg, int len) const override {
+    s.send(msg, len, 0);
+    return 0;
+  }
+
+  // do not use this function, I think I should just remove it...
+  int send_msgs_(const std::initializer_list<std::string> &msgs)
+      const override {
+    size_t num_msgs = msgs.size();
+    if (num_msgs == 0) return 0;
+    struct nn_msghdr msghdr;
+    std::memset(&msghdr, 0, sizeof(msghdr));
+    struct nn_iovec iov[num_msgs];
+    int i = 0;
+    for (const auto &msg : msgs) {
+      // wish I could write this, but string.data() return const char *
+      // iov[i].iov_base = msg.data();
+      std::unique_ptr<char[]> data(new char[msg.size()]);
+      msg.copy(data.get(), msg.size());
+      iov[i].iov_base = data.get();
+      iov[i].iov_len = msg.size();
+      i++;
+    }
+    msghdr.msg_iov = iov;
+    msghdr.msg_iovlen = num_msgs;
+    s.sendmsg(&msghdr, 0);
+    return 0;
+  }
+
+  int send_msgs_(const std::initializer_list<MsgBuf> &msgs) const override {
+    size_t num_msgs = msgs.size();
+    if (num_msgs == 0) return 0;
+    struct nn_msghdr msghdr;
+    std::memset(&msghdr, 0, sizeof(msghdr));
+    struct nn_iovec iov[num_msgs];
+    int i = 0;
+    for (const auto &msg : msgs) {
+      iov[i].iov_base = msg.buf;
+      iov[i].iov_len = msg.len;
+      i++;
+    }
+    msghdr.msg_iov = iov;
+    msghdr.msg_iovlen = num_msgs;
+    s.sendmsg(&msghdr, 0);
+    return 0;
+  }
+
+ private:
+  std::string addr;
+  nn::socket s;
+};
+
+std::unique_ptr<TransportIface>
+TransportIface::make_nanomsg(const std::string &addr) {
+  return std::unique_ptr<TransportIface>(new TransportNanomsg(addr));
+}
+
+}  // namespace bm
+
+#endif  // BMNANOMSG_ON

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -1,4 +1,8 @@
-SUBDIRS = . tests
+if COND_NANOMSG
+MAYBE_TESTS = tests
+endif
+
+SUBDIRS = . $(MAYBE_TESTS)
 
 THRIFT_IDL = $(srcdir)/thrift/simple_switch.thrift
 

--- a/targets/simple_switch/tests/test_packet_redirect.cpp
+++ b/targets/simple_switch/tests/test_packet_redirect.cpp
@@ -63,9 +63,11 @@ class SimpleSwitch_PacketRedirectP4 : public ::testing::Test {
   // the simple_switch target detaches threads
   static void SetUpTestCase() {
     // bm::Logger::set_logger_console();
+#ifdef BMELOG_ON
     auto event_transport = bm::TransportIface::make_nanomsg(event_logger_addr);
     event_transport->open();
     bm::EventLogger::init(std::move(event_transport));
+#endif
 
     test_switch = new SimpleSwitch(8);  // 8 ports
 

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -69,11 +69,13 @@ main(int argc, char* argv[]) {
 
   simple_switch->start_and_return();
 
+#ifdef PI_INTERNAL_RPC
   char *opt_rpc_addr = NULL;
   char *opt_notifications_addr = NULL;
   pi_remote_addr_t remote_addr = {opt_rpc_addr, opt_notifications_addr};
   std::thread pi_CLI_thread(
       [&remote_addr] { pi_rpc_server_run(&remote_addr); });
+#endif
 
   PIGrpcServerWait();
   PIGrpcServerCleanup();

--- a/tests/test_bm_apps.cpp
+++ b/tests/test_bm_apps.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#ifdef BMNANOMSG_ON
+
 #include <gtest/gtest.h>
 
 #include <bm/bm_sim/ageing.h>
@@ -203,3 +205,5 @@ TEST_F(NotificationsTest, PortEvent) {
   test(1, PortStatus::PORT_DOWN, true, PortEvent::PORT_DOWN);
   test(1, PortStatus::PORT_UP, true, PortEvent::PORT_UP);
 }
+
+#endif  // BMNANOMSG_ON

--- a/tests/test_devmgr.cpp
+++ b/tests/test_devmgr.cpp
@@ -255,6 +255,8 @@ class PacketInReceiver {
   mutable std::condition_variable can_read{};
 };
 
+#ifdef BMNANOMSG_ON
+
 // is here because DevMgr has a protected destructor
 class PacketInSwitch : public DevMgr { };
 
@@ -442,6 +444,8 @@ TEST_F(PacketInDevMgrPortStatusTest, Status) {
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   check_and_reset_counts(0u, 1u, 0u, 0u);
 }
+
+#endif  // BMNANOMSG_ON
 
 struct PMActive { };
 struct PMPassive { };

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -9,6 +9,7 @@ veth_setup.sh \
 veth_teardown.sh
 
 if COND_THRIFT
+if COND_NANOMSG
 
 python_PYTHON = \
 p4dbg.py \
@@ -44,4 +45,5 @@ bm_nanomsg_events.in
 
 CLEANFILES = $(bin_SCRIPTS)
 
+endif  # COND_NANOMSG
 endif  # COND_THRIFT


### PR DESCRIPTION
Made dependency on nanomsg conditional

This greatly limits the number of supported features, both core features such as learning and ageing, and tooling such as the event logger and the debugger. However other packet forwardind capabilities should be unaffected.

A new configure flag has been introduced, '--without-nanomsg', to build without nanomsg.