### PR TITLE
Update the Dockerfile to use third-party:stable and Ubuntu 16.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.git
+**/.gitmodules
+**/.travis.yml
+**/Dockerfile
+**/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM p4lang/third-party:latest
+FROM p4lang/third-party:stable
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
 # Select the type of image we're building. Use `build` for a normal build, which
@@ -19,9 +19,9 @@ ENV BM_DEPS automake \
             libboost-filesystem-dev \
             libboost-thread-dev \
             libtool
-ENV BM_RUNTIME_DEPS libboost-program-options1.54.0 \
-                    libboost-system1.54.0 \
-                    libboost-thread1.54.0 \
+ENV BM_RUNTIME_DEPS libboost-program-options1.58.0 \
+                    libboost-system1.58.0 \
+                    libboost-thread1.58.0 \
                     libgmp10 libjudydebian1 \
                     libpcap0.8 \
                     python


### PR DESCRIPTION
This PR updates the `Dockerfile` to:

- Build from `p4lang/third-party:stable`, instead of `:latest`.
- Build with Ubuntu 16.04, which we're using as the base image in `third-party` now.

It also adds a `.dockerignore` file to reduce the size of the generated image a little. I didn't try to get too aggressive with it, since upcoming Docker features will make this kind of thing much less of an issue.