### PR TITLE
Cleanup in the PRE code

### DIFF
--- a/include/bm/bm_sim/simple_pre.h
+++ b/include/bm/bm_sim/simple_pre.h
@@ -63,7 +63,6 @@ class McSimplePre {
     TABLE_FULL,
     INVALID_MGID,
     INVALID_L1_HANDLE,
-    INVALID_L2_HANDLE,
     ERROR
   };
 
@@ -96,7 +95,6 @@ class McSimplePre {
                               l1_hdl_t *l1_hdl);
   McReturnCode mc_node_associate(const mgrp_hdl_t, const l1_hdl_t);
   McReturnCode mc_node_dissociate(const mgrp_hdl_t, const l1_hdl_t);
-  McReturnCode mc_node_disassociate(const mgrp_hdl_t, const l1_hdl_t);
   McReturnCode mc_node_destroy(const l1_hdl_t);
   McReturnCode mc_node_update(const l1_hdl_t l1_hdl,
                               const PortMap &port_map);
@@ -149,16 +147,19 @@ class McSimplePre {
     std::vector<l1_hdl_t> l1_list{};
 
     MgidEntry() {}
-    explicit MgidEntry(mgrp_t mgid) : mgid(mgid) {}
+    explicit MgidEntry(mgrp_t mgid)
+        : mgid(mgid) {}
   };
 
   struct L1Entry {
     mgrp_hdl_t mgrp_hdl{};
     rid_t rid{};
     l2_hdl_t l2_hdl{};
+    bool is_associated{false};
 
     L1Entry() {}
-    explicit L1Entry(rid_t rid) : rid(rid) {}
+    explicit L1Entry(rid_t rid)
+        : rid(rid) {}
   };
 
   struct L2Entry {
@@ -167,17 +168,11 @@ class McSimplePre {
     LagMap lag_map{};
 
     L2Entry() {}
-    L2Entry(l1_hdl_t l1_hdl,
-            const PortMap &port_map) :
-            l1_hdl(l1_hdl),
-            port_map(port_map) {}
+    L2Entry(l1_hdl_t l1_hdl, const PortMap &port_map)
+        : l1_hdl(l1_hdl), port_map(port_map) {}
 
-    L2Entry(l1_hdl_t l1_hdl,
-            const PortMap &port_map,
-            const LagMap &lag_map) :
-            l1_hdl(l1_hdl),
-            port_map(port_map),
-            lag_map(lag_map) {}
+    L2Entry(l1_hdl_t l1_hdl, const PortMap &port_map, const LagMap &lag_map)
+        : l1_hdl(l1_hdl), port_map(port_map), lag_map(lag_map) {}
   };
 
   // internal version, which does not acquire the lock
@@ -185,6 +180,9 @@ class McSimplePre {
 
   // does not acquire lock
   void get_entries_common(Json::Value *root) const;
+
+  // does not acquire lock
+  void node_dissociate(MgidEntry *mgid_entry, l1_hdl_t l1_hdl);
 
   std::unordered_map<mgrp_hdl_t, MgidEntry> mgid_entries{};
   std::unordered_map<l1_hdl_t, L1Entry> l1_entries{};

--- a/include/bm/bm_sim/simple_pre_lag.h
+++ b/include/bm/bm_sim/simple_pre_lag.h
@@ -53,7 +53,6 @@ class McSimplePreLAG : public McSimplePre {
 
   void reset_state();
 
-  //! TODO(unknown)
   std::vector<McOut> replicate(const McIn) const;
 
  private:
@@ -62,10 +61,8 @@ class McSimplePreLAG : public McSimplePre {
     PortMap port_map{};
 
     LagEntry() {}
-    LagEntry(uint16_t member_count,
-            const PortMap &port_map) :
-            member_count(member_count),
-            port_map(port_map) {}
+    LagEntry(uint16_t member_count, const PortMap &port_map)
+        : member_count(member_count), port_map(port_map) {}
   };
 
   std::unordered_map<lag_id_t, LagEntry> lag_entries{};

--- a/src/bm_sim/simple_pre_lag.cpp
+++ b/src/bm_sim/simple_pre_lag.cpp
@@ -55,7 +55,7 @@ McSimplePreLAG::mc_node_create(const rid_t rid,
     return ERROR;
   }
   l1_entries.insert(std::make_pair(*l1_hdl, L1Entry(rid)));
-  L1Entry &l1_entry = l1_entries[*l1_hdl];
+  auto &l1_entry = l1_entries.at(*l1_hdl);
   l1_entry.l2_hdl = l2_hdl;
   l2_entries.insert(
     std::make_pair(l2_hdl, L2Entry(*l1_hdl, port_map, lag_map)));
@@ -72,9 +72,9 @@ McSimplePreLAG::mc_node_update(const l1_hdl_t l1_hdl,
     Logger::get()->error("node update failed, invalid l1 handle");
     return INVALID_L1_HANDLE;
   }
-  L1Entry &l1_entry = l1_entries[l1_hdl];
-  l2_hdl_t l2_hdl = l1_entry.l2_hdl;
-  L2Entry &l2_entry = l2_entries[l2_hdl];
+  auto &l1_entry = l1_entries.at(l1_hdl);
+  auto l2_hdl = l1_entry.l2_hdl;
+  auto &l2_entry = l2_entries.at(l2_hdl);
   l2_entry.port_map = port_map;
   l2_entry.lag_map = lag_map;
   Logger::get()->debug("node updated for rid {}", l1_entry.rid);
@@ -95,7 +95,7 @@ McSimplePreLAG::mc_set_lag_membership(const lag_id_t lag_index,
       member_count++;
     }
   }
-  LagEntry &lag_entry = lag_entries[lag_index];
+  auto &lag_entry = lag_entries[lag_index];
   lag_entry.member_count = member_count;
   lag_entry.port_map = port_map;
   Logger::get()->debug("lag membership set for lag index {}", lag_index);
@@ -158,12 +158,12 @@ McSimplePreLAG::replicate(const McSimplePre::McIn ingress_info) const {
                         "to the PRE", ingress_info.mgid);
     return {};
   }
-  const MgidEntry &mgid_entry = mgid_it->second;
+  const auto &mgid_entry = mgid_it->second;
   for (const l1_hdl_t l1_hdl : mgid_entry.l1_list) {
-    const L1Entry &l1_entry = l1_entries.at(l1_hdl);
+    const auto &l1_entry = l1_entries.at(l1_hdl);
     egress_info.rid = l1_entry.rid;
     // Port replication
-    const L2Entry &l2_entry = l2_entries.at(l1_entry.l2_hdl);
+    const auto &l2_entry = l2_entries.at(l1_entry.l2_hdl);
     for (port_id = 0; port_id < l2_entry.port_map.size(); port_id++) {
       if (l2_entry.port_map[port_id]) {
         egress_info.egress_port = port_id;

--- a/tests/test_pre.cpp
+++ b/tests/test_pre.cpp
@@ -138,6 +138,31 @@ TEST(McSimplePre, Replicate) {
   ASSERT_EQ(rc, McSimplePre::SUCCESS);
 }
 
+TEST(McSimplePre, DestroyWithoutDissociate) {
+  McSimplePre pre;
+  McSimplePre::mgrp_t mgid = 0x400;
+  McSimplePre::mgrp_hdl_t mgrp_hdl;
+  McSimplePre::l1_hdl_t l1_hdl;
+  McSimplePre::rid_t rid = 0x200;
+  McSimplePre::egress_port_t port = 9;
+  McSimplePre::PortMap port_map;
+  port_map[port] = 1;
+  McSimplePre::McIn ingress_info = {mgid};
+
+  EXPECT_EQ(McSimplePre::SUCCESS, pre.mc_mgrp_create(mgid, &mgrp_hdl));
+  EXPECT_EQ(McSimplePre::SUCCESS, pre.mc_node_create(rid, port_map, &l1_hdl));
+  EXPECT_EQ(McSimplePre::SUCCESS, pre.mc_node_associate(mgid, l1_hdl));
+
+  const auto egress_info_1 = pre.replicate(ingress_info);
+  EXPECT_EQ(1u, egress_info_1.size());
+  EXPECT_EQ(rid, egress_info_1.at(0).rid);
+  EXPECT_EQ(port, egress_info_1.at(0).egress_port);
+
+  EXPECT_EQ(McSimplePre::SUCCESS, pre.mc_node_destroy(l1_hdl));
+  const auto egress_info_2 = pre.replicate(ingress_info);
+  EXPECT_TRUE(egress_info_2.empty());
+}
+
 
 TEST(McSimplePreLAG, Replicate) {
   McSimplePreLAG pre;


### PR DESCRIPTION
Additional sanity-checking; dissociate L1 nodes from their multicast
group before destroying them.