### PR TITLE
Fix mc_dump CLI command for SimplePre type

### DIFF
--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1616,9 +1616,12 @@ class RuntimeAPI(cmd.Cmd):
 
         print "=========="
         print "LAGS"
-        for lag in mc_json["lags"]:
-            print "lag({})".format(lag["id"]),
-            print "-> ports=[{}]".format(", ".join([str(p) for p in ports]))
+        if "lags" in mc_json:
+            for lag in mc_json["lags"]:
+                print "lag({})".format(lag["id"]),
+                print "-> ports=[{}]".format(", ".join([str(p) for p in ports]))
+        else:
+            print "None for this PRE type"
         print "=========="
 
     @handle_bad_input


### PR DESCRIPTION
The command implementation was correct for SimplePreLAG but not for
SimplePre, as it assumed the existence of LAG entries in the JSON
returned by the switch.

This addresses issue #342.