### PR TITLE
Extra logging when evaluating conditions, with source info

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -76,6 +76,7 @@ bm/bm_sim/stateful.h \
 bm/bm_sim/switch.h \
 bm/bm_sim/simple_pre.h \
 bm/bm_sim/simple_pre_lag.h \
+bm/bm_sim/source_info.h \
 bm/bm_sim/stacks.h \
 bm/bm_sim/tables.h \
 bm/bm_sim/target_parser.h \

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -605,6 +605,10 @@ class ActionFn :  public NamedP4Object {
  public:
   ActionFn(const std::string &name, p4object_id_t id, size_t num_params)
       : NamedP4Object(name, id), num_params(num_params) { }
+    ActionFn(const std::string &name, p4object_id_t id, size_t num_params,
+             std::unique_ptr<SourceInfo> source_info)
+        : NamedP4Object(name, id, std::move(source_info)),
+          num_params(num_params) { }
 
   // these parameter_push_back_* methods are not very well named. They are used
   // to push arguments to the primitives; and are independent of the actual

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -607,8 +607,8 @@ class ActionFn :  public NamedP4Object {
       : NamedP4Object(name, id), num_params(num_params) { }
     ActionFn(const std::string &name, p4object_id_t id, size_t num_params,
              std::unique_ptr<SourceInfo> source_info)
-        : NamedP4Object(name, id, std::move(source_info)),
-          num_params(num_params) { }
+      : NamedP4Object(name, id, std::move(source_info)),
+        num_params(num_params) { }
 
   // these parameter_push_back_* methods are not very well named. They are used
   // to push arguments to the primitives; and are independent of the actual

--- a/include/bm/bm_sim/conditionals.h
+++ b/include/bm/bm_sim/conditionals.h
@@ -34,7 +34,9 @@ class Conditional
  public:
   Conditional(const std::string &name, p4object_id_t id)
     : ControlFlowNode(name, id) {}
-  Conditional(const std::string &name, p4object_id_t id, const std::string &filename, unsigned line, unsigned column, const std::string &source_fragment)
+  Conditional(const std::string &name, p4object_id_t id,
+              const std::string &filename, unsigned line,
+              unsigned column, const std::string &source_fragment)
     : ControlFlowNode(name, id, filename, line, column, source_fragment) {}
 
   bool eval(const PHV &phv) const {

--- a/include/bm/bm_sim/conditionals.h
+++ b/include/bm/bm_sim/conditionals.h
@@ -34,6 +34,8 @@ class Conditional
  public:
   Conditional(const std::string &name, p4object_id_t id)
     : ControlFlowNode(name, id) {}
+  Conditional(const std::string &name, p4object_id_t id, const std::string &filename, unsigned line, unsigned column, const std::string &source_fragment)
+    : ControlFlowNode(name, id, filename, line, column, source_fragment) {}
 
   bool eval(const PHV &phv) const {
     return eval_bool(phv);

--- a/include/bm/bm_sim/conditionals.h
+++ b/include/bm/bm_sim/conditionals.h
@@ -35,8 +35,8 @@ class Conditional
   Conditional(const std::string &name, p4object_id_t id)
     : ControlFlowNode(name, id) {}
   Conditional(const std::string &name, p4object_id_t id,
-              const SourceInfo *source_info)
-    : ControlFlowNode(name, id, source_info) {}
+              std::unique_ptr<SourceInfo> source_info)
+    : ControlFlowNode(name, id, std::move(source_info)) {}
 
   bool eval(const PHV &phv) const {
     return eval_bool(phv);

--- a/include/bm/bm_sim/conditionals.h
+++ b/include/bm/bm_sim/conditionals.h
@@ -35,9 +35,8 @@ class Conditional
   Conditional(const std::string &name, p4object_id_t id)
     : ControlFlowNode(name, id) {}
   Conditional(const std::string &name, p4object_id_t id,
-              const std::string &filename, unsigned line,
-              unsigned column, const std::string &source_fragment)
-    : ControlFlowNode(name, id, filename, line, column, source_fragment) {}
+              const SourceInfo *source_info)
+    : ControlFlowNode(name, id, source_info) {}
 
   bool eval(const PHV &phv) const {
     return eval_bool(phv);

--- a/include/bm/bm_sim/control_flow.h
+++ b/include/bm/bm_sim/control_flow.h
@@ -34,8 +34,8 @@ class ControlFlowNode : public NamedP4Object {
   ControlFlowNode(const std::string &name, p4object_id_t id)
       : NamedP4Object(name, id) { }
   ControlFlowNode(const std::string &name, p4object_id_t id,
-                  const SourceInfo *source_info)
-    : NamedP4Object(name, id, source_info) {}
+                  std::unique_ptr<SourceInfo> source_info)
+      : NamedP4Object(name, id, std::move(source_info)) {}
   virtual ~ControlFlowNode() { }
   virtual const ControlFlowNode *operator()(Packet *pkt) const = 0;
 };

--- a/include/bm/bm_sim/control_flow.h
+++ b/include/bm/bm_sim/control_flow.h
@@ -34,9 +34,8 @@ class ControlFlowNode : public NamedP4Object {
   ControlFlowNode(const std::string &name, p4object_id_t id)
       : NamedP4Object(name, id) { }
   ControlFlowNode(const std::string &name, p4object_id_t id,
-                  const std::string &filename, unsigned line,
-                  unsigned column, const std::string &source_fragment)
-    : NamedP4Object(name, id, filename, line, column, source_fragment) {}
+                  const SourceInfo *source_info)
+    : NamedP4Object(name, id, source_info) {}
   virtual ~ControlFlowNode() { }
   virtual const ControlFlowNode *operator()(Packet *pkt) const = 0;
 };

--- a/include/bm/bm_sim/control_flow.h
+++ b/include/bm/bm_sim/control_flow.h
@@ -33,7 +33,9 @@ class ControlFlowNode : public NamedP4Object {
  public:
   ControlFlowNode(const std::string &name, p4object_id_t id)
       : NamedP4Object(name, id) { }
-  ControlFlowNode(const std::string &name, p4object_id_t id, const std::string &filename, unsigned line, unsigned column, const std::string &source_fragment)
+  ControlFlowNode(const std::string &name, p4object_id_t id,
+                  const std::string &filename, unsigned line,
+                  unsigned column, const std::string &source_fragment)
     : NamedP4Object(name, id, filename, line, column, source_fragment) {}
   virtual ~ControlFlowNode() { }
   virtual const ControlFlowNode *operator()(Packet *pkt) const = 0;

--- a/include/bm/bm_sim/control_flow.h
+++ b/include/bm/bm_sim/control_flow.h
@@ -33,6 +33,8 @@ class ControlFlowNode : public NamedP4Object {
  public:
   ControlFlowNode(const std::string &name, p4object_id_t id)
       : NamedP4Object(name, id) { }
+  ControlFlowNode(const std::string &name, p4object_id_t id, const std::string &filename, unsigned line, unsigned column, const std::string &source_fragment)
+    : NamedP4Object(name, id, filename, line, column, source_fragment) {}
   virtual ~ControlFlowNode() { }
   virtual const ControlFlowNode *operator()(Packet *pkt) const = 0;
 };

--- a/include/bm/bm_sim/logger.h
+++ b/include/bm/bm_sim/logger.h
@@ -134,6 +134,13 @@ class Logger {
 #define BMLOG_TRACE_PKT(pkt, s, ...)                     \
   BMLOG_TRACE("[{}] [cxt {}] " s, (pkt).get_unique_id(), \
               (pkt).get_context(), ##__VA_ARGS__)
+//! Same as BMLOG_TRACE_PKT except it takes a pointer to a SourceInfo
+//! object, and if non-NULL, include its data in the output.
+#define BMLOG_TRACE_SI_PKT(pkt, source_info, s, ...)                   \
+  BMLOG_TRACE("[{}] [cxt {}] {}" s, (pkt).get_unique_id(),             \
+              (pkt).get_context(),                                     \
+              (source_info == nullptr) ? "" : (source_info->toString() + " "), \
+              ##__VA_ARGS__)
 
 #define BMLOG_ERROR(...) bm::Logger::get()->error(__VA_ARGS__)
 

--- a/include/bm/bm_sim/logger.h
+++ b/include/bm/bm_sim/logger.h
@@ -136,10 +136,11 @@ class Logger {
               (pkt).get_context(), ##__VA_ARGS__)
 //! Same as BMLOG_TRACE_PKT except it takes a pointer to a SourceInfo
 //! object, and if non-NULL, include its data in the output.
-#define BMLOG_TRACE_SI_PKT(pkt, source_info, s, ...)                   \
-  BMLOG_TRACE("[{}] [cxt {}] {}" s, (pkt).get_unique_id(),             \
-              (pkt).get_context(),                                     \
-              (source_info == nullptr) ? "" : (source_info->toString() + " "), \
+#define BMLOG_TRACE_SI_PKT(pkt, source_info, s, ...)       \
+  BMLOG_TRACE("[{}] [cxt {}] {}" s, (pkt).get_unique_id(), \
+              (pkt).get_context(),                         \
+              (source_info == nullptr) ? ""                \
+                : (source_info->to_string() + " "),        \
               ##__VA_ARGS__)
 
 #define BMLOG_ERROR(...) bm::Logger::get()->error(__VA_ARGS__)

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -25,6 +25,7 @@
 
 #include <bm/bm_sim/source_info.h>
 #include <string>
+#include <memory>
 
 namespace bm {
 
@@ -37,10 +38,10 @@ using p4object_id_t = int;
 class NamedP4Object {
  public:
   NamedP4Object(const std::string &name, p4object_id_t id)
-    : name(name), id(id), source_info(nullptr) {}
+    : name(name), id(id) {}
   NamedP4Object(const std::string &name, p4object_id_t id,
-                const SourceInfo *source_info)
-    : name(name), id(id), source_info(source_info) {}
+                std::unique_ptr<SourceInfo> source_info)
+    : name(name), id(id), source_info(std::move(source_info)) {}
 
   virtual ~NamedP4Object() { }
 
@@ -65,12 +66,12 @@ class NamedP4Object {
   unsigned get_column() const { return column; }
   const std::string &get_source_fragment() const { return source_fragment; }
   bool has_source_info() const { return (source_info != nullptr); }
-  const SourceInfo *get_source_info() const { return source_info; }
+  const SourceInfo *get_source_info() const { return source_info.get(); }
 
  protected:
   const std::string name;
   p4object_id_t id;
-  const SourceInfo *source_info;
+  std::unique_ptr<SourceInfo> source_info;
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -37,8 +37,12 @@ class NamedP4Object {
  public:
   NamedP4Object(const std::string &name, p4object_id_t id)
       : name(name), id(id), has_source_info(false) {}
-  NamedP4Object(const std::string &name, p4object_id_t id, const std::string &filename, unsigned line, unsigned column, const std::string &source_fragment)
-      : name(name), id(id), has_source_info(true), filename(filename), line(line), column(column), source_fragment(source_fragment) {}
+  NamedP4Object(const std::string &name, p4object_id_t id,
+                const std::string &filename, unsigned line,
+                unsigned column, const std::string &source_fragment)
+      : name(name), id(id), has_source_info(true),
+        filename(filename), line(line),
+        column(column), source_fragment(source_fragment) {}
 
   virtual ~NamedP4Object() { }
 

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -43,11 +43,6 @@ class NamedP4Object {
                 std::unique_ptr<SourceInfo> source_info)
     : name(name), id(id), source_info(std::move(source_info)) {}
 
-  NamedP4Object(const NamedP4Object& rhs)
-      : name(rhs.name), id(rhs.id),
-        source_info(rhs.source_info ? new SourceInfo(*rhs.source_info)
-                    : nullptr) { }
-
   virtual ~NamedP4Object() { }
 
   //! Get the name of the P4 instance

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -24,6 +24,8 @@
 #define BM_BM_SIM_NAMED_P4OBJECT_H_
 
 #include <string>
+#include <sstream>
+#include <bm/bm_sim/source_info.h>
 
 namespace bm {
 
@@ -36,13 +38,10 @@ using p4object_id_t = int;
 class NamedP4Object {
  public:
   NamedP4Object(const std::string &name, p4object_id_t id)
-      : name(name), id(id), has_source_info(false) {}
+    : name(name), id(id), source_info(nullptr) {}
   NamedP4Object(const std::string &name, p4object_id_t id,
-                const std::string &filename, unsigned line,
-                unsigned column, const std::string &source_fragment)
-      : name(name), id(id), has_source_info(true),
-        filename(filename), line(line),
-        column(column), source_fragment(source_fragment) {}
+                const SourceInfo *source_info)
+    : name(name), id(id), source_info(source_info) {}
 
   virtual ~NamedP4Object() { }
 
@@ -66,15 +65,13 @@ class NamedP4Object {
   unsigned get_line() const { return line; }
   unsigned get_column() const { return column; }
   const std::string &get_source_fragment() const { return source_fragment; }
+  bool has_source_info() const { return (source_info != nullptr); }
+  const SourceInfo *get_source_info() const { return source_info; }
 
  protected:
   const std::string name;
   p4object_id_t id;
-  bool has_source_info;
-  const std::string filename;
-  unsigned line;
-  unsigned column;
-  const std::string source_fragment;
+  const SourceInfo *source_info;
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -61,11 +61,6 @@ class NamedP4Object {
   //! Default assignment operator
   NamedP4Object &operator=(NamedP4Object &&other) = default;
 
-  const std::string &get_filename() const { return filename; }
-  unsigned get_line() const { return line; }
-  unsigned get_column() const { return column; }
-  const std::string &get_source_fragment() const { return source_fragment; }
-  bool has_source_info() const { return (source_info != nullptr); }
   const SourceInfo *get_source_info() const { return source_info.get(); }
 
  protected:

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -23,9 +23,8 @@
 #ifndef BM_BM_SIM_NAMED_P4OBJECT_H_
 #define BM_BM_SIM_NAMED_P4OBJECT_H_
 
-#include <string>
-#include <sstream>
 #include <bm/bm_sim/source_info.h>
+#include <string>
 
 namespace bm {
 

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -43,6 +43,11 @@ class NamedP4Object {
                 std::unique_ptr<SourceInfo> source_info)
     : name(name), id(id), source_info(std::move(source_info)) {}
 
+  NamedP4Object(const NamedP4Object& rhs)
+      : name(rhs.name), id(rhs.id),
+        source_info(rhs.source_info ? new SourceInfo(*rhs.source_info)
+                    : nullptr) { }
+
   virtual ~NamedP4Object() { }
 
   //! Get the name of the P4 instance

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -36,7 +36,9 @@ using p4object_id_t = int;
 class NamedP4Object {
  public:
   NamedP4Object(const std::string &name, p4object_id_t id)
-    : name(name), id(id) {}
+      : name(name), id(id), has_source_info(false) {}
+  NamedP4Object(const std::string &name, p4object_id_t id, const std::string &filename, unsigned line, unsigned column, const std::string &source_fragment)
+      : name(name), id(id), has_source_info(true), filename(filename), line(line), column(column), source_fragment(source_fragment) {}
 
   virtual ~NamedP4Object() { }
 
@@ -56,9 +58,19 @@ class NamedP4Object {
   //! Default assignment operator
   NamedP4Object &operator=(NamedP4Object &&other) = default;
 
+  const std::string &get_filename() const { return filename; }
+  unsigned get_line() const { return line; }
+  unsigned get_column() const { return column; }
+  const std::string &get_source_fragment() const { return source_fragment; }
+
  protected:
   const std::string name;
   p4object_id_t id;
+  bool has_source_info;
+  const std::string filename;
+  unsigned line;
+  unsigned column;
+  const std::string source_fragment;
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/source_info.h
+++ b/include/bm/bm_sim/source_info.h
@@ -43,14 +43,14 @@ class SourceInfo {
   }
 
   std::string get_source_fragment() const { return source_fragment; }
-  std::string toString() const { return to_string; }
+  std::string to_string() const { return string_representation; }
 
  private:
   std::string filename;
   unsigned int line;
   unsigned int column;
   std::string source_fragment;
-  std::string to_string;
+  std::string string_representation;
 
   void init_to_string();
 };

--- a/include/bm/bm_sim/source_info.h
+++ b/include/bm/bm_sim/source_info.h
@@ -26,7 +26,7 @@
 //! the JSON file produced by the compiler.
 
 #include <string>
-#include "jsoncpp/json.h"
+#include <sstream>
 
 namespace bm {
 
@@ -34,36 +34,12 @@ class SourceInfo {
  public:
   SourceInfo()
     : filename(""), line(0), column(0), source_fragment("") { }
-  SourceInfo(std::string filename, unsigned line, unsigned column,
+  SourceInfo(std::string filename, unsigned int line, unsigned int column,
              std::string source_fragment)
     : filename(filename),
       line(line),
       column(column),
       source_fragment(source_fragment) { }
-
-  static SourceInfo *newFromJson(const Json::Value &cfg_source_info) {
-    std::string filename = "";
-    unsigned line = 0;
-    unsigned column = 0;
-    std::string source_fragment = "";
-
-    if (cfg_source_info.isNull()) {
-      return nullptr;
-    }
-    if (!cfg_source_info["filename"].isNull()) {
-      filename = cfg_source_info["filename"].asString();
-    }
-    if (!cfg_source_info["line"].isNull()) {
-      line = cfg_source_info["line"].asInt();
-    }
-    if (!cfg_source_info["column"].isNull()) {
-      column = cfg_source_info["column"].asInt();
-    }
-    if (!cfg_source_info["source_fragment"].isNull()) {
-      source_fragment = cfg_source_info["source_fragment"].asString();
-    }
-    return new SourceInfo(filename, line, column, source_fragment);
-  }
 
   std::string toString() const {
     std::stringstream result;
@@ -75,8 +51,8 @@ class SourceInfo {
 
  private:
   std::string filename;
-  unsigned line;
-  unsigned column;
+  unsigned int line;
+  unsigned int column;
   std::string source_fragment;
 };
 

--- a/include/bm/bm_sim/source_info.h
+++ b/include/bm/bm_sim/source_info.h
@@ -33,13 +33,14 @@ class SourceInfo {
  public:
   SourceInfo(std::string filename, unsigned int line, unsigned int column,
              std::string source_fragment)
-    : filename(filename),
-      line(line),
-      column(column),
+    : filename(filename), line(line), column(column),
       source_fragment(source_fragment) {
     init_to_string();
   }
 
+  std::string get_filename() const { return filename; }
+  unsigned int get_line() const { return line; }
+  unsigned int get_column() const { return column; }
   std::string get_source_fragment() const { return source_fragment; }
   std::string to_string() const { return string_representation; }
 

--- a/include/bm/bm_sim/source_info.h
+++ b/include/bm/bm_sim/source_info.h
@@ -26,7 +26,6 @@
 //! the JSON file produced by the compiler.
 
 #include <string>
-#include <sstream>
 
 namespace bm {
 
@@ -39,21 +38,21 @@ class SourceInfo {
     : filename(filename),
       line(line),
       column(column),
-      source_fragment(source_fragment) { }
-
-  std::string toString() const {
-    std::stringstream result;
-    result << filename << "(" << line << ":" << column << ")";
-    return result.str();
+      source_fragment(source_fragment) {
+    init_to_string();
   }
 
   std::string get_source_fragment() const { return source_fragment; }
+  std::string toString() const { return to_string; }
 
  private:
   std::string filename;
   unsigned int line;
   unsigned int column;
   std::string source_fragment;
+  std::string to_string;
+
+  void init_to_string();
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/source_info.h
+++ b/include/bm/bm_sim/source_info.h
@@ -1,0 +1,85 @@
+/* Copyright 2017 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Andy Fingerhut (jafinger@cisco.com)
+ *
+ */
+
+#ifndef BM_BM_SIM_SOURCE_INFO_H_
+#define BM_BM_SIM_SOURCE_INFO_H_
+
+//! @file source_info.h
+//! Stores source location information about some objects, as read from
+//! the JSON file produced by the compiler.
+
+#include <string>
+#include "jsoncpp/json.h"
+
+namespace bm {
+
+class SourceInfo {
+ public:
+  SourceInfo()
+    : filename(""), line(0), column(0), source_fragment("") { }
+  SourceInfo(std::string filename, unsigned line, unsigned column,
+             std::string source_fragment)
+    : filename(filename),
+      line(line),
+      column(column),
+      source_fragment(source_fragment) { }
+
+  static SourceInfo *newFromJson(const Json::Value &cfg_source_info) {
+    std::string filename = "";
+    unsigned line = 0;
+    unsigned column = 0;
+    std::string source_fragment = "";
+
+    if (cfg_source_info.isNull()) {
+      return nullptr;
+    }
+    if (!cfg_source_info["filename"].isNull()) {
+      filename = cfg_source_info["filename"].asString();
+    }
+    if (!cfg_source_info["line"].isNull()) {
+      line = cfg_source_info["line"].asInt();
+    }
+    if (!cfg_source_info["column"].isNull()) {
+      column = cfg_source_info["column"].asInt();
+    }
+    if (!cfg_source_info["source_fragment"].isNull()) {
+      source_fragment = cfg_source_info["source_fragment"].asString();
+    }
+    return new SourceInfo(filename, line, column, source_fragment);
+  }
+
+  std::string toString() const {
+    std::stringstream result;
+    result << filename << "(" << line << ":" << column << ")";
+    return result.str();
+  }
+
+  std::string get_source_fragment() const { return source_fragment; }
+
+ private:
+  std::string filename;
+  unsigned line;
+  unsigned column;
+  std::string source_fragment;
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_SOURCE_INFO_H_

--- a/include/bm/bm_sim/source_info.h
+++ b/include/bm/bm_sim/source_info.h
@@ -31,8 +31,6 @@ namespace bm {
 
 class SourceInfo {
  public:
-  SourceInfo()
-    : filename(""), line(0), column(0), source_fragment("") { }
   SourceInfo(std::string filename, unsigned int line, unsigned int column,
              std::string source_fragment)
     : filename(filename),

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -60,6 +60,7 @@ stateful.cpp \
 switch.cpp \
 simple_pre.cpp \
 simple_pre_lag.cpp \
+source_info.cpp \
 stacks.cpp \
 tables.cpp \
 target_parser.cpp \

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1518,10 +1518,8 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       p4object_id_t conditional_id = cfg_conditional["id"].asInt();
       const Json::Value &cfg_source_info = cfg_conditional["source_info"];
       Conditional *conditional =
-          new Conditional(conditional_name,
-                          conditional_id,
+          new Conditional(conditional_name, conditional_id,
                           SourceInfo::newFromJson(cfg_source_info));
-
       const Json::Value &cfg_expression = cfg_conditional["expression"];
       build_expression(cfg_expression, conditional);
       conditional->build();

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1521,10 +1521,12 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       if (cfg_conditional["source_info"].isNull()) {
           conditional = new Conditional(conditional_name, conditional_id);
       } else {
-          const string filename = cfg_conditional["source_info"]["filename"].asString();
+          const string filename =
+              cfg_conditional["source_info"]["filename"].asString();
           unsigned line = cfg_conditional["source_info"]["line"].asInt();
           unsigned column = cfg_conditional["source_info"]["column"].asInt();
-          const string source_fragment = cfg_conditional["source_info"]["source_fragment"].asString();
+          const string source_fragment =
+              cfg_conditional["source_info"]["source_fragment"].asString();
           conditional = new Conditional(conditional_name, conditional_id,
                                         filename, line, column,
                                         source_fragment);

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1516,21 +1516,11 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
     for (const auto &cfg_conditional : cfg_conditionals) {
       const string conditional_name = cfg_conditional["name"].asString();
       p4object_id_t conditional_id = cfg_conditional["id"].asInt();
-      Conditional *conditional = new Conditional(conditional_name,
-                                                 conditional_id);
-      if (cfg_conditional["source_info"].isNull()) {
-          conditional = new Conditional(conditional_name, conditional_id);
-      } else {
-          const string filename =
-              cfg_conditional["source_info"]["filename"].asString();
-          unsigned line = cfg_conditional["source_info"]["line"].asInt();
-          unsigned column = cfg_conditional["source_info"]["column"].asInt();
-          const string source_fragment =
-              cfg_conditional["source_info"]["source_fragment"].asString();
-          conditional = new Conditional(conditional_name, conditional_id,
-                                        filename, line, column,
-                                        source_fragment);
-      }
+      const Json::Value &cfg_source_info = cfg_conditional["source_info"];
+      Conditional *conditional =
+          new Conditional(conditional_name,
+                          conditional_id,
+                          SourceInfo::newFromJson(cfg_source_info));
 
       const Json::Value &cfg_expression = cfg_conditional["expression"];
       build_expression(cfg_expression, conditional);

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1518,6 +1518,17 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       p4object_id_t conditional_id = cfg_conditional["id"].asInt();
       Conditional *conditional = new Conditional(conditional_name,
                                                  conditional_id);
+      if (cfg_conditional["source_info"].isNull()) {
+          conditional = new Conditional(conditional_name, conditional_id);
+      } else {
+          const string filename = cfg_conditional["source_info"]["filename"].asString();
+          unsigned line = cfg_conditional["source_info"]["line"].asInt();
+          unsigned column = cfg_conditional["source_info"]["column"].asInt();
+          const string source_fragment = cfg_conditional["source_info"]["source_fragment"].asString();
+          conditional = new Conditional(conditional_name, conditional_id,
+                                        filename, line, column,
+                                        source_fragment);
+      }
 
       const Json::Value &cfg_expression = cfg_conditional["expression"];
       build_expression(cfg_expression, conditional);

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1344,6 +1344,30 @@ std::vector<MatchKeyParam> parse_match_key(
   return match_key;
 }
 
+SourceInfo *new_from_json(const Json::Value &cfg_source_info) {
+  std::string filename = "";
+  unsigned int line = 0;
+  unsigned int column = 0;
+  std::string source_fragment = "";
+
+  if (cfg_source_info.isNull()) {
+    return nullptr;
+  }
+  if (!cfg_source_info["filename"].isNull()) {
+    filename = cfg_source_info["filename"].asString();
+  }
+  if (!cfg_source_info["line"].isNull()) {
+    line = cfg_source_info["line"].asInt();
+  }
+  if (!cfg_source_info["column"].isNull()) {
+    column = cfg_source_info["column"].asInt();
+  }
+  if (!cfg_source_info["source_fragment"].isNull()) {
+    source_fragment = cfg_source_info["source_fragment"].asString();
+  }
+  return new SourceInfo(filename, line, column, source_fragment);
+}
+
 }  // namespace
 
 void
@@ -1517,9 +1541,8 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       const string conditional_name = cfg_conditional["name"].asString();
       p4object_id_t conditional_id = cfg_conditional["id"].asInt();
       const Json::Value &cfg_source_info = cfg_conditional["source_info"];
-      Conditional *conditional =
-          new Conditional(conditional_name, conditional_id,
-                          SourceInfo::newFromJson(cfg_source_info));
+      auto conditional = new Conditional(
+        conditional_name, conditional_id, new_from_json(cfg_source_info));
       const Json::Value &cfg_expression = cfg_conditional["expression"];
       build_expression(cfg_expression, conditional);
       conditional->build();

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -219,11 +219,12 @@ ExprType get_opcode_type(ExprOpcode opcode) {
   return ExprType::UNKNOWN;
 }
 
-std::unique_ptr<SourceInfo> new_from_json(const Json::Value &cfg_source_info) {
+std::unique_ptr<SourceInfo> object_source_info(const Json::Value &cfg_object) {
   std::string filename = "";
   unsigned int line = 0;
   unsigned int column = 0;
   std::string source_fragment = "";
+  auto cfg_source_info = cfg_object["source_info"];
 
   if (cfg_source_info.isNull()) {
     return nullptr;
@@ -243,8 +244,6 @@ std::unique_ptr<SourceInfo> new_from_json(const Json::Value &cfg_source_info) {
   auto source_info =
       std::unique_ptr<SourceInfo>{new SourceInfo(filename, line, column,
                                                  source_fragment)};
-  // std::unique_ptr<SourceInfo> source_info(filename, line, column,
-  //                                        source_fragment);
   return source_info;
 }
 
@@ -1242,10 +1241,9 @@ P4Objects::init_actions(const Json::Value &cfg_root) {
   for (const auto &cfg_action : cfg_actions) {
     const string action_name = cfg_action["name"].asString();
     p4object_id_t action_id = cfg_action["id"].asInt();
-    const Json::Value &cfg_source_info = cfg_action["source_info"];
     std::unique_ptr<ActionFn> action_fn(new ActionFn(
-      action_name, action_id, cfg_action["runtime_data"].size(),
-      new_from_json(cfg_source_info)));
+        action_name, action_id, cfg_action["runtime_data"].size(),
+        object_source_info(cfg_action)));
 
     const auto &cfg_primitive_calls = cfg_action["primitives"];
     for (const auto &cfg_primitive_call : cfg_primitive_calls)
@@ -1547,9 +1545,8 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
     for (const auto &cfg_conditional : cfg_conditionals) {
       const string conditional_name = cfg_conditional["name"].asString();
       p4object_id_t conditional_id = cfg_conditional["id"].asInt();
-      const Json::Value &cfg_source_info = cfg_conditional["source_info"];
       auto conditional = new Conditional(
-        conditional_name, conditional_id, new_from_json(cfg_source_info));
+        conditional_name, conditional_id, object_source_info(cfg_conditional));
       const Json::Value &cfg_expression = cfg_conditional["expression"];
       build_expression(cfg_expression, conditional);
       conditional->build();

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1344,7 +1344,7 @@ std::vector<MatchKeyParam> parse_match_key(
   return match_key;
 }
 
-SourceInfo *new_from_json(const Json::Value &cfg_source_info) {
+std::unique_ptr<SourceInfo> new_from_json(const Json::Value &cfg_source_info) {
   std::string filename = "";
   unsigned int line = 0;
   unsigned int column = 0;
@@ -1365,7 +1365,12 @@ SourceInfo *new_from_json(const Json::Value &cfg_source_info) {
   if (!cfg_source_info["source_fragment"].isNull()) {
     source_fragment = cfg_source_info["source_fragment"].asString();
   }
-  return new SourceInfo(filename, line, column, source_fragment);
+  auto source_info =
+      std::unique_ptr<SourceInfo>{new SourceInfo(filename, line, column,
+                                                 source_fragment)};
+  // std::unique_ptr<SourceInfo> source_info(filename, line, column,
+  //                                        source_fragment);
+  return source_info;
 }
 
 }  // namespace

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -23,6 +23,7 @@
 #include <bm/bm_sim/event_logger.h>
 #include <bm/bm_sim/P4Objects.h>
 #include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/logger.h>
 
 #include <iostream>
 #include <string>
@@ -289,6 +290,8 @@ ActionFnEntry::execute(Packet *pkt) const {
   auto &primitives = action_fn->primitives;
   size_t param_offset = 0;
   // primitives is a vector of pointers
+  const SourceInfo *si = action_fn->get_source_info();
+  BMLOG_TRACE_SI_PKT(*pkt, si, "Executing action {}", action_fn->get_name());
   for (auto primitive : primitives) {
     primitive->execute(&state, &(action_fn->params[param_offset]));
     param_offset += primitive->get_num_params();

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -290,8 +290,8 @@ ActionFnEntry::execute(Packet *pkt) const {
   auto &primitives = action_fn->primitives;
   size_t param_offset = 0;
   // primitives is a vector of pointers
-  const SourceInfo *si = action_fn->get_source_info();
-  BMLOG_TRACE_SI_PKT(*pkt, si, "Executing action {}", action_fn->get_name());
+  BMLOG_TRACE_SI_PKT(*pkt, action_fn->get_source_info(),
+                     "Executing action {}", action_fn->get_name());
   for (auto primitive : primitives) {
     primitive->execute(&state, &(action_fn->params[param_offset]));
     param_offset += primitive->get_num_params();

--- a/src/bm_sim/conditionals.cpp
+++ b/src/bm_sim/conditionals.cpp
@@ -57,4 +57,3 @@ Conditional::operator()(Packet *pkt) const {
 }
 
 }  // namespace bm
-

--- a/src/bm_sim/conditionals.cpp
+++ b/src/bm_sim/conditionals.cpp
@@ -43,11 +43,10 @@ Conditional::operator()(Packet *pkt) const {
   // + The full expression even if it spans multiple lines.
   // + The current values of all variables involved in evaluating the
   //   expression.
-  BMLOG_TRACE_SI_PKT(*pkt, get_source_info(), "Condition is {}", result);
-  //SourceInfo source_info = get_source_info();
-  //BMLOG_TRACE_PKT(*pkt, "{}: Condition \"{}\" is {}",
-  //                source_info.toString(), source_info.get_source_fragment(),
-  //                result);
+  const SourceInfo *si = get_source_info();
+  BMLOG_TRACE_SI_PKT(*pkt, si, "Condition \"{}\" is {}",
+                     (si == nullptr) ? get_name() : si->get_source_fragment(),
+                     result);
   DEBUGGER_NOTIFY_UPDATE_V(
       Debugger::PacketId::make(pkt->get_packet_id(), pkt->get_copy_id()),
       Debugger::FIELD_COND, result);
@@ -58,3 +57,4 @@ Conditional::operator()(Packet *pkt) const {
 }
 
 }  // namespace bm
+

--- a/src/bm_sim/conditionals.cpp
+++ b/src/bm_sim/conditionals.cpp
@@ -21,6 +21,7 @@
 #include <bm/bm_sim/conditionals.h>
 #include <bm/bm_sim/event_logger.h>
 #include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/logger.h>
 
 #include <cassert>
 
@@ -36,6 +37,20 @@ Conditional::operator()(Packet *pkt) const {
   PHV *phv = pkt->get_phv();
   bool result = eval(*phv);
   BMELOG(condition_eval, *pkt, *this, result);
+
+  // It would be nicer to see the following additional info in the log:
+  //
+  // + The full expression even if it spans multiple lines.
+  // + The current values of all variables involved in evaluating the
+  //   expression.
+  if (get_has_source_info()) {
+      BMLOG_TRACE_PKT(*pkt, "{}({}): Condition \"{}\" is {}",
+                      get_filename(), get_line(), get_source_fragment(),
+                      result);
+  } else {
+      BMLOG_TRACE_PKT(*pkt, "Condition {} is {}",
+                      get_name(), result);
+  }
   DEBUGGER_NOTIFY_UPDATE_V(
       Debugger::PacketId::make(pkt->get_packet_id(), pkt->get_copy_id()),
       Debugger::FIELD_COND, result);

--- a/src/bm_sim/conditionals.cpp
+++ b/src/bm_sim/conditionals.cpp
@@ -43,14 +43,11 @@ Conditional::operator()(Packet *pkt) const {
   // + The full expression even if it spans multiple lines.
   // + The current values of all variables involved in evaluating the
   //   expression.
-  if (get_has_source_info()) {
-      BMLOG_TRACE_PKT(*pkt, "{}({}): Condition \"{}\" is {}",
-                      get_filename(), get_line(), get_source_fragment(),
-                      result);
-  } else {
-      BMLOG_TRACE_PKT(*pkt, "Condition {} is {}",
-                      get_name(), result);
-  }
+  BMLOG_TRACE_SI_PKT(*pkt, get_source_info(), "Condition is {}", result);
+  //SourceInfo source_info = get_source_info();
+  //BMLOG_TRACE_PKT(*pkt, "{}: Condition \"{}\" is {}",
+  //                source_info.toString(), source_info.get_source_fragment(),
+  //                result);
   DEBUGGER_NOTIFY_UPDATE_V(
       Debugger::PacketId::make(pkt->get_packet_id(), pkt->get_copy_id()),
       Debugger::FIELD_COND, result);

--- a/src/bm_sim/conditionals.cpp
+++ b/src/bm_sim/conditionals.cpp
@@ -43,9 +43,9 @@ Conditional::operator()(Packet *pkt) const {
   // + The full expression even if it spans multiple lines.
   // + The current values of all variables involved in evaluating the
   //   expression.
-  const SourceInfo *si = get_source_info();
-  BMLOG_TRACE_SI_PKT(*pkt, si, "Condition \"{}\" is {}",
-                     (si == nullptr) ? get_name() : si->get_source_fragment(),
+  BMLOG_TRACE_SI_PKT(*pkt, get_source_info(), "Condition \"{}\" is {}",
+                     (get_source_info() == nullptr) ? get_name() :
+                     get_source_info()->get_source_fragment(),
                      result);
   DEBUGGER_NOTIFY_UPDATE_V(
       Debugger::PacketId::make(pkt->get_packet_id(), pkt->get_copy_id()),

--- a/src/bm_sim/source_info.cpp
+++ b/src/bm_sim/source_info.cpp
@@ -1,0 +1,32 @@
+/* Copyright 2017 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Andy Fingerhut (jafinger@cisco.com)
+ *
+ */
+
+#include <bm/bm_sim/source_info.h>
+#include <sstream>
+
+namespace bm {
+
+void SourceInfo::init_to_string() {
+  std::stringstream result;
+  result << filename << "(" << line << ")";
+  to_string = result.str();
+}
+
+}  // namespace bm

--- a/src/bm_sim/source_info.cpp
+++ b/src/bm_sim/source_info.cpp
@@ -26,7 +26,7 @@ namespace bm {
 void SourceInfo::init_to_string() {
   std::stringstream result;
   result << filename << "(" << line << ")";
-  to_string = result.str();
+  string_representation = result.str();
 }
 
 }  // namespace bm

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -517,6 +517,12 @@ class JsonBuilder {
     Json::Value cond(Json::objectValue);
     cond["name"] = name;
     cond["id"] = 0;
+    Json::Value source_info(Json::objectValue);
+    source_info["filename"] = "foo.p4";
+    source_info["line"] = 42;
+    source_info["column"] = 18;
+    source_info["source_fragment"] = "hdr.ethernet.dstAddr == 0";
+    cond["source_info"] = source_info;
     Json::Value expression(Json::objectValue);
     expression["type"] = "expression";
     expression["value"] = expr.get_json();


### PR DESCRIPTION
@antoninbas This is probably not in a form that you would like to merge, but I was hoping to get your thoughts on what approach you would like to see when using the new source_info added with the latest p4c commit earlier today.  The changes in this PR only use this information to add extra debug tracing when evaluating conditions, but of course this information could be used in many other places, too.

Here is a sample of a new log output line when evaluating a condition:

    [18:56:44.690] [bmv2] [T] [thread 8299] [0.0] [cxt 0] temp.p4(134): Condition "hdr.ethernet.dstAddr == 0xFFFFFFFFFFFF" is false
