### PR TITLE
Fix implicit conversion warning from clang

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -34,8 +34,8 @@ namespace {
 
 struct hash_ex {
   uint32_t operator()(const char *buf, size_t s) const {
-    const int p = 16777619;
-    int hash = 2166136261;
+    const uint32_t p = 16777619;
+    uint32_t hash = 2166136261;
 
     for (size_t i = 0; i < s; i++)
       hash = (hash ^ buf[i]) * p;


### PR DESCRIPTION
This patches fixes the following warning (which causes compilation to fail due to `-Werror`) on `clang-802.0.38`:

```
simple_switch.cpp:38:16: error: implicit conversion from 'long' to 'int' changes value from
      2166136261 to -2128831035 [-Werror,-Wconstant-conversion]
    int hash = 2166136261;
        ~~~~   ^~~~~~~~~~
```