### PR TITLE
Read JSON source_info line and column values as 32-bit unsigned ints

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -233,10 +233,10 @@ std::unique_ptr<SourceInfo> object_source_info(const Json::Value &cfg_object) {
     filename = cfg_source_info["filename"].asString();
   }
   if (!cfg_source_info["line"].isNull()) {
-    line = cfg_source_info["line"].asInt();
+    line = cfg_source_info["line"].asUInt();
   }
   if (!cfg_source_info["column"].isNull()) {
-    column = cfg_source_info["column"].asInt();
+    column = cfg_source_info["column"].asUInt();
   }
   if (!cfg_source_info["source_fragment"].isNull()) {
     source_fragment = cfg_source_info["source_fragment"].asString();


### PR DESCRIPTION
They were being interpreted as 32-bit signed ints, which causes an out
of range error if the line number is in range 2^31 through 2^32-1.
Due to a bug in p4c-bm2-ss right now, 2^32-1 is possible, which is how
I discovered this issue.