### PR TITLE
Verify checksums at the end of parsing

### DIFF
--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -44,6 +44,8 @@ class BoolExpression;
 class ArithExpression;
 class ActionFn;
 
+class Checksum;
+
 struct field_t {
   header_id_t header;
   int offset;
@@ -306,6 +308,8 @@ class Parser : public NamedP4Object {
 
   void set_init_state(const ParseState *state);
 
+  void add_checksum(const Checksum *checksum);
+
   //! Extracts Packet headers as specified by the parse graph. When the parser
   //! extracts a header to the PHV, the header is marked as valid. After parsing
   //! a packet, you can send it to the appropriate match-action Pipeline for
@@ -324,9 +328,12 @@ class Parser : public NamedP4Object {
   Parser &operator=(Parser &&other) /*noexcept*/ = default;
 
  private:
+  void verify_checksums(const Packet &pkt) const;
+
   const ParseState *init_state;
   const ErrorCodeMap *error_codes;
   const ErrorCode no_error;
+  std::vector<const Checksum *> checksums{};
 };
 
 }  // namespace bm

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1840,6 +1840,10 @@ P4Objects::init_checksums(const Json::Value &cfg_root) {
     for (auto it = deparsers.begin(); it != deparsers.end(); ++it) {
       it->second->add_checksum(checksum);
     }
+
+    for (auto it = parsers.begin(); it != parsers.end(); ++it) {
+      it->second->add_checksum(checksum);
+    }
   }
 }
 


### PR DESCRIPTION
And log an error message if the checksum is not correct (but do not take
any further action, like dropping the packet).