### PR TITLE
Fix to make bmv compile in google3

### DIFF
--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -485,6 +485,7 @@ void set_direct_resources(const pi_p4info_t *p4info, pi_dev_id_t dev_id,
         break;
       default:  // TODO(antonin): what to do?
         assert(0);
+        return;
     }
     if (error_code != bm::MatchErrorCode::SUCCESS)
       throw bm_exception(error_code);

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -178,7 +178,7 @@ class Data {
   //! Convert the value of Data to any inegral type
   template<typename T,
            typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-  typename std::remove_const<T>::type get() const {
+  T get() const {
     assert(arith);
     return value.convert_to<typename std::remove_const<T>::type>();
   }

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -178,29 +178,26 @@ class Data {
   //! Convert the value of Data to any inegral type
   template<typename T,
            typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-  T get() const {
+  typename std::remove_const<T>::type get() const {
     assert(arith);
-    return value.convert_to<T>();
+    return value.convert_to<typename std::remove_const<T>::type>();
   }
 
   //! Get the value of Data has an unsigned integer
   unsigned int get_uint() const {
     assert(arith);
-    // Bad ?
     return value.convert_to<unsigned int>();
   }
 
   //! Get the value of Data has a `uint64_t`
   uint64_t get_uint64() const {
     assert(arith);
-    // Bad ?
     return value.convert_to<uint64_t>();
   }
 
   //! get the value of Data has an integer
   int get_int() const {
     assert(arith);
-    // Bad ?
     return value.convert_to<int>();
   }
 

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -180,28 +180,28 @@ class Data {
            typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
   T get() const {
     assert(arith);
-    return static_cast<T>(value);
+    return value.convert_to<T>();
   }
 
   //! Get the value of Data has an unsigned integer
   unsigned int get_uint() const {
     assert(arith);
     // Bad ?
-    return static_cast<unsigned int>(value);
+    return value.convert_to<unsigned int>();
   }
 
   //! Get the value of Data has a `uint64_t`
   uint64_t get_uint64() const {
     assert(arith);
     // Bad ?
-    return static_cast<uint64_t>(value);
+    return value.convert_to<uint64_t>();
   }
 
   //! get the value of Data has an integer
   int get_int() const {
     assert(arith);
     // Bad ?
-    return static_cast<int>(value);
+    return value.convert_to<int>();
   }
 
   //! get the binary representation of Data has a string. There is no sign


### PR DESCRIPTION
Fix the way bm_sim/data.h uses boost, and add return in pi_tables_imp.cpp to make gcc happy.