### PR TITLE
For sswitch with pri, do not crash if no pri field

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -243,8 +243,8 @@ SimpleSwitch::enqueue(int egress_port, std::unique_ptr<Packet> &&packet) {
     }
 
 #ifdef SSWITCH_PRIORITY_QUEUEING_ON
-    size_t priority =
-        phv->get_field(SSWITCH_PRIORITY_QUEUEING_SRC).get<size_t>();
+    size_t priority = phv->has_field(SSWITCH_PRIORITY_QUEUEING_SRC) ?
+        phv->get_field(SSWITCH_PRIORITY_QUEUEING_SRC).get<size_t>() : 0u;
     if (priority >= SSWITCH_PRIORITY_QUEUEING_NB_QUEUES) {
       bm::Logger::get()->error("Priority out of range, dropping packet");
       return;


### PR DESCRIPTION
If the priority field does not exist, we use 0 as the priority, instead
of crashing.