### PR TITLE
In PI do not call dump_action_data if no data

### DIFF
--- a/PI/src/common.cpp
+++ b/PI/src/common.cpp
@@ -30,6 +30,7 @@ Buffer::Buffer() {
 
 char *
 Buffer::extend(size_t s) {
+  if (s == 0) return nullptr;
   const auto size = data.size();
   data.resize(size + s);
   return &data[size];

--- a/PI/src/pi_act_prof_imp.cpp
+++ b/PI/src/pi_act_prof_imp.cpp
@@ -210,8 +210,10 @@ pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,
       const auto adata_size = pi_p4info_action_data_size(p4info, action_id);
       emit_p4_id(buffer.extend(sizeof(s_pi_p4_id_t)), action_id);
       emit_uint32(buffer.extend(sizeof(uint32_t)), adata_size);
-      pibmv2::dump_action_data(p4info, buffer.extend(adata_size), action_id,
-                               mbr.action_data);
+      if (adata_size > 0) {
+        pibmv2::dump_action_data(p4info, buffer.extend(adata_size), action_id,
+                                 mbr.action_data);
+      }
     }
     res->entries_members_size = buffer.size();
     res->entries_members = buffer.copy();

--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -330,7 +330,7 @@ void get_default_entry(const pi_p4info_t *p4info, const std::string &t_name,
 
 using pibmv2::Buffer;
 
-// The difference with build_action_entry is the putput format.
+// The difference with build_action_entry is the output format.
 template <typename E>
 void build_action_entry_2(const pi_p4info_t *p4info, const E &entry,
                           Buffer *buffer);
@@ -349,8 +349,10 @@ void build_action_entry_2<bm::MatchTable::Entry>(
 
   emit_p4_id(buffer->extend(sizeof(s_pi_p4_id_t)), action_id);
   emit_uint32(buffer->extend(sizeof(uint32_t)), adata_size);
-  pibmv2::dump_action_data(p4info, buffer->extend(adata_size), action_id,
-                           entry.action_data);
+  if (adata_size > 0) {
+    pibmv2::dump_action_data(p4info, buffer->extend(adata_size), action_id,
+                             entry.action_data);
+  }
 }
 
 template <>


### PR DESCRIPTION
According to the standard, the [] operator for std::vector is not
supposed to perform bound-checking, but it seems that with some debug
options in some builds, an out_of_range exception can be returned.