### PR TITLE
Fix issue in entry lookup for ternary match tables

### DIFF
--- a/src/bm_sim/lookup_structures.cpp
+++ b/src/bm_sim/lookup_structures.cpp
@@ -361,9 +361,7 @@ class EntryList {
   static constexpr size_t cache_activation_min_entries = 16;
 
   internal_handle_t handle_from_entry(const Entry *entry) const {
-    // a bit sad that this cast is needed, almost makes me want to do the
-    // pointer arithmetic by hand
-    return std::distance(static_cast<const Entry *>(head), entry);
+    return std::distance(&entries[0], entry);
   }
 
   const Entry *find_entry(const K &key) const {


### PR DESCRIPTION
When adding 2 entries to the table, then removing the first added; we
would observe an error when sending a packet matching the second entry
added only (bmv2 would report a table hit instead of a miss, with a
corrupt entry handle).

This was caused by some incorrect code to compute an entry handle based
on the location of the entry in the table "array".