### PR TITLE
Support for saturating fields

### DIFF
--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -49,7 +49,8 @@ class Field : public Data {
   // indirection in Header (for the field vector), so I am sticking to this for
   // now.
   explicit Field(int nbits, Header *parent_hdr, bool arith_flag = true,
-                 bool is_signed = false, bool hidden = false, bool VL = false);
+                 bool is_signed = false, bool hidden = false, bool VL = false,
+                 bool is_saturating = false);
 
   // to avoid dynamic resizing of the Bytecontainer, which would invalide field
   // references
@@ -99,6 +100,11 @@ class Field : public Data {
 
   void export_bytes() override {
     std::fill(bytes.begin(), bytes.end(), 0);  // very important !
+
+    if (is_saturating) {
+      if (value < min) value = min;
+      else if (value > max) value = max;
+    }
 
     if (!is_signed) {
       // is this efficient enough?
@@ -178,6 +184,7 @@ class Field : public Data {
   bool is_signed{false};
   bool hidden{false};
   bool VL{false};
+  bool is_saturating{false};
   bool written_to{false};  // used to keep track of whether a field was modified
   Bignum mask{1};
   Bignum max{1};

--- a/include/bm/bm_sim/headers.h
+++ b/include/bm/bm_sim/headers.h
@@ -52,6 +52,7 @@ class HeaderType : public NamedP4Object {
     std::string name;
     int bitwidth;
     bool is_signed;
+    bool is_saturating;
     bool is_VL;
     bool is_hidden;
   };
@@ -64,7 +65,8 @@ class HeaderType : public NamedP4Object {
 
   // returns field offset
   int push_back_field(const std::string &field_name, int field_bit_width,
-                      bool is_signed = false, bool is_VL = false);
+                      bool is_signed = false, bool is_saturating = false,
+                      bool is_VL = false);
 
   // if field_length_expr is nullptr it means that the length will have to be
   // provided to extract
@@ -72,7 +74,8 @@ class HeaderType : public NamedP4Object {
       const std::string &field_name,
       int max_header_bytes,
       std::unique_ptr<VLHeaderExpression> field_length_expr,
-      bool is_signed = false);
+      bool is_signed = false,
+      bool is_saturating = false);
 
   const FInfo &get_finfo(int field_offset) const {
     return fields_info.at(field_offset);

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -660,6 +660,9 @@ P4Objects::init_header_types(const Json::Value &cfg_root) {
       bool is_signed = false;
       if (cfg_field.size() > 2)
         is_signed = cfg_field[2].asBool();
+      bool is_saturating = false;
+      if (cfg_field.size() > 3)
+        is_saturating = cfg_field[3].asBool();
       if (cfg_field[1].asString() == "*") {  // VL field
         std::unique_ptr<VLHeaderExpression> VL_expr(nullptr);
         if (cfg_header_type.isMember("length_exp")) {
@@ -673,10 +676,12 @@ P4Objects::init_header_types(const Json::Value &cfg_root) {
         if (cfg_header_type.isMember("max_length"))
           max_header_bytes = cfg_header_type["max_length"].asInt();
         header_type->push_back_VL_field(
-            field_name, max_header_bytes, std::move(VL_expr), is_signed);
+            field_name, max_header_bytes, std::move(VL_expr),
+            is_signed, is_saturating);
       } else {
         int field_bit_width = cfg_field[1].asInt();
-        header_type->push_back_field(field_name, field_bit_width, is_signed);
+        header_type->push_back_field(
+            field_name, field_bit_width, is_signed, is_saturating);
       }
     }
 


### PR DESCRIPTION
Tentative support for saturating fields, i.e. fields which do not
overflow. This is an experimental feature and is not documented yet in
the JSON format doc.