### PR TITLE
Change ByteContainer::to_hex for clang debug mode

### DIFF
--- a/src/bm_sim/bytecontainer.cpp
+++ b/src/bm_sim/bytecontainer.cpp
@@ -32,7 +32,10 @@ ByteContainer::to_hex(size_t start, size_t s, bool upper_case) const {
   assert(start + s <= size());
 
   std::ostringstream ret;
-  utils::dump_hexstring(ret, &bytes[start], &bytes[start + s], upper_case);
+  // in debug mode, some compilers perform bound-checking even for operator[]
+  // utils::dump_hexstring(ret, &bytes[start], &bytes[start + s], upper_case);
+  auto first = bytes.begin() + start;
+  utils::dump_hexstring(ret, first, first + s, upper_case);
   return ret.str();
 }
 


### PR DESCRIPTION
In clang debug mode (_GLIBCXX_DEBUG), the operator[] for std::vector
performs some bound checking, which caused ByteContainer::to_hex to
segfault.