### PR TITLE
Removed statements with side effects from asserts

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -18,6 +18,7 @@ bm/bm_runtime/bm_runtime.h
 endif
 
 nobase_include_HEADERS += \
+bm/bm_sim/_assert.h \
 bm/bm_sim/action_entry.h \
 bm/bm_sim/action_profile.h \
 bm/bm_sim/actions.h \

--- a/include/bm/bm_sim/_assert.h
+++ b/include/bm/bm_sim/_assert.h
@@ -1,0 +1,39 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef BM_BM_SIM__ASSERT_H_
+#define BM_BM_SIM__ASSERT_H_
+
+// An assert that cannot be removed with NDEBUG
+
+namespace bm {
+
+[[ noreturn ]] void _assert(const char* expr, const char* file, int line);
+
+}  // namespace bm
+
+#define _BM_ASSERT(expr) \
+  ((expr) ? (void)0 : bm::_assert(#expr, __FILE__, __LINE__))
+
+#define _BM_UNREACHABLE(msg) bm::_assert(msg, __FILE__, __LINE__)
+
+#define _BM_UNUSED(x) ((void)x)
+
+#endif  // BM_BM_SIM__ASSERT_H_

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -84,6 +84,7 @@
 #include "named_p4object.h"
 #include "expressions.h"
 #include "stateful.h"
+#include "_assert.h"
 
 namespace bm {
 
@@ -278,7 +279,7 @@ Data &ActionParam::to<Data &>(ActionEngineState *state) const {
       return state->phv.get_header_stack(stack_field.header_stack).get_last()
           .get_field(stack_field.field_offset);
     default:
-      assert(0);
+      _BM_UNREACHABLE("Default switch case should not be reachable");
   }
 }
 
@@ -314,7 +315,7 @@ const Data &ActionParam::to<const Data &>(ActionEngineState *state) const {
       return state->phv.get_header_stack(stack_field.header_stack).get_last()
           .get_field(stack_field.field_offset);
     default:
-      assert(0);
+      _BM_UNREACHABLE("Default switch case should not be reachable");
   }
 }
 
@@ -363,7 +364,7 @@ StackIface &ActionParam::to<StackIface &>(ActionEngineState *state) const {
     case HEADER_UNION_STACK:
       return state->phv.get_header_union_stack(header_union_stack);
     default:
-      assert(0);
+      _BM_UNREACHABLE("Default switch case should not be reachable");
   }
 }
 

--- a/include/bm/bm_sim/nn.h
+++ b/include/bm/bm_sim/nn.h
@@ -95,6 +95,7 @@ namespace nn
       inline ~socket ()
       {
 	int rc = nn_close (s);
+        (void) rc;
 	assert (rc == 0);
       }
 

--- a/src/bf_lpm_trie/bf_lpm_trie.c
+++ b/src/bf_lpm_trie/bf_lpm_trie.c
@@ -32,6 +32,8 @@ typedef unsigned char byte_t;
 
 typedef unsigned long value_t;
 
+#define _unused(x) ((void)(x))
+
 typedef struct node_s {
   Pvoid_t PJLarray_branches;
   Pvoid_t PJLarray_prefixes;
@@ -270,14 +272,18 @@ bool bf_lpm_trie_delete(bf_lpm_trie_t *trie, const char *prefix,
   pdata = get_prefix_ptr(current_node, prefix_key);
   if(!pdata) return false;
 
+  int success;
+  _unused(success);
   if(trie->release_memory) {
-    assert(delete_prefix(current_node, prefix_key) == 1);
+    success = delete_prefix(current_node, prefix_key);
+    assert(success == 1);
     current_node->pref_num--;
     while(current_node->pref_num == 0 && current_node->branch_num == 0) {
       node_t *tmp = current_node;
       current_node = current_node->parent;
       if(!current_node) break;
-      assert(delete_branch(current_node, tmp->child_id) == 1);
+      success = delete_branch(current_node, tmp->child_id);
+      assert(success == 1);
       free(tmp);
       current_node->branch_num--;
     }
@@ -286,4 +292,4 @@ bool bf_lpm_trie_delete(bf_lpm_trie_t *trie, const char *prefix,
   return true;
 }
 
-
+#undef _unused

--- a/src/bm_apps/nn.h
+++ b/src/bm_apps/nn.h
@@ -95,6 +95,7 @@ namespace nn
       inline ~socket ()
       {
 	int rc = nn_close (s);
+        (void) rc;
 	assert (rc == 0);
       }
 

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -20,8 +20,9 @@
 
 #include <bm/Standard.h>
 
-#include <bm/bm_sim/switch.h>
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/switch.h>
 
 #include <functional>
 
@@ -94,7 +95,7 @@ public:
       case MatchErrorCode::ERROR:
         return TableOperationErrorCode::ERROR;
       default:
-        assert(0 && "invalid error code");
+        _BM_UNREACHABLE("Default switch case should not be reachable");
     }
   }
 

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -14,6 +14,7 @@ AM_CFLAGS += $(COVERAGE_FLAGS)
 noinst_LTLIBRARIES = libbmsim.la
 
 libbmsim_la_SOURCES = \
+_assert.cpp \
 action_profile.cpp \
 actions.cpp \
 ageing.cpp \

--- a/src/bm_sim/_assert.cpp
+++ b/src/bm_sim/_assert.cpp
@@ -1,0 +1,34 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/_assert.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace bm {
+
+void _assert(const char* expr, const char* file, int line) {
+  std::cerr << "Assertion '" << expr << "' failed, file '" << file
+            << "' line '" << line << "'.\n";
+  std::abort();
+}
+
+}  // namespace bm

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/action_profile.h>
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/packet.h>
@@ -243,7 +244,9 @@ ActionProfile::delete_member(mbr_hdl_t mbr) {
     } else if (index_ref_count.get(IndirectIndex::make_mbr_index(mbr)) > 0) {
       rc = MatchErrorCode::MBR_STILL_USED;
     } else {
-      assert(!mbr_handles.release_handle(mbr));
+      int error = mbr_handles.release_handle(mbr);
+      _BM_UNUSED(error);
+      assert(!error);
       num_members--;
     }
   }
@@ -338,7 +341,9 @@ ActionProfile::delete_group(grp_hdl_t grp) {
       for (auto mbr : group_info)
         index_ref_count.decrease(IndirectIndex::make_mbr_index(mbr));
 
-      assert(!grp_handles.release_handle(grp));
+      int error = grp_handles.release_handle(grp);
+      _BM_UNUSED(error);
+      assert(!error);
 
       num_groups--;
     }
@@ -448,6 +453,7 @@ ActionProfile::get_members() const {
   size_t idx = 0;
   for (const auto h : mbr_handles) {
     MatchErrorCode rc = get_member_(h, &members[idx++]);
+    _BM_UNUSED(rc);
     assert(rc == MatchErrorCode::SUCCESS);
   }
   return members;
@@ -478,6 +484,7 @@ ActionProfile::get_groups() const {
   size_t idx = 0;
   for (const auto h : grp_handles) {
     MatchErrorCode rc = get_group_(h, &groups[idx++]);
+    _BM_UNUSED(rc);
     assert(rc == MatchErrorCode::SUCCESS);
   }
   return groups;
@@ -540,14 +547,18 @@ ActionProfile::deserialize(std::istream *in, const P4Objects &objs) {
   (*in) >> num_members;
   for (size_t i = 0; i < num_members; i++) {
     mbr_hdl_t mbr_hdl; (*in) >> mbr_hdl;
-    assert(!mbr_handles.set_handle(mbr_hdl));
+    int error = mbr_handles.set_handle(mbr_hdl);
+    _BM_UNUSED(error);
+    assert(!error);
     action_entries.at(mbr_hdl).deserialize(in, objs);
   }
   index_ref_count.deserialize(in);
   (*in) >> num_groups;
   for (size_t i = 0; i < num_groups; i++) {
     grp_hdl_t grp_hdl; (*in) >> grp_hdl;
-    assert(!grp_handles.set_handle(grp_hdl));
+    int error = grp_handles.set_handle(grp_hdl);
+    _BM_UNUSED(error);
+    assert(!error);
     grp_mgr.insert_group(grp_hdl);
     grp_mgr.at(grp_hdl).deserialize(in);
     for (const auto mbr : grp_mgr.at(grp_hdl))

--- a/src/bm_sim/debugger.cpp
+++ b/src/bm_sim/debugger.cpp
@@ -375,13 +375,11 @@ DebuggerNN::packet_in_(const PacketId &packet_id, int port) {
       wait_for_resume_packet_in(lock);
   }
 
-  auto it = packet_registers_map.find(packet_id);
-  assert(it == packet_registers_map.end());
+  assert(packet_registers_map.find(packet_id) == packet_registers_map.end());
   packet_registers_map.emplace_hint(packet_registers_map.end(),
                                     packet_id, PacketRegisters());
 
-  auto it2 = packet_ctr_stacks.find(packet_id);
-  assert(it2 == packet_ctr_stacks.end());
+  assert(packet_ctr_stacks.find(packet_id) == packet_ctr_stacks.end());
   packet_ctr_stacks.emplace_hint(packet_ctr_stacks.end(),
                                  packet_id, std::vector<uint32_t>());
 

--- a/src/bm_sim/lookup_structures.cpp
+++ b/src/bm_sim/lookup_structures.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/lookup_structures.h>
 #include <bm/bm_sim/match_key_types.h>
 
@@ -172,7 +173,9 @@ class TernaryCache {
     if (it != cache.end()) return false;
     if (cache.size() == S) {  // cache is full
       auto evict = entries.back();
-      assert(cache.erase(evict.key) == 1);
+      int success = cache.erase(evict.key);
+      _BM_UNUSED(success);
+      assert(success == 1);
       entries.pop_back();
     }
     entries.emplace_front(handle, key_data);

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/match_tables.h>
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/event_logger.h>
@@ -529,6 +530,7 @@ MatchTable::get_entries() const {
   for (auto it = match_unit->handles_begin(); it != match_unit->handles_end();
        it++) {
     MatchErrorCode rc = get_entry_(*it, &entries[idx++]);
+    _BM_UNUSED(rc);
     assert(rc == MatchErrorCode::SUCCESS);
   }
 
@@ -574,6 +576,7 @@ MatchTable::set_default_entry(const ActionFn *action_fn,
                               ActionData action_data, bool is_const) {
   assert(!const_default_entry);
   auto rc = set_default_action(action_fn, std::move(action_data));
+  _BM_UNUSED(rc);
   assert(rc == MatchErrorCode::SUCCESS);
   const_default_entry = is_const;
 }
@@ -824,6 +827,7 @@ MatchTableIndirect::get_entries() const {
   for (auto it = match_unit->handles_begin(); it != match_unit->handles_end();
        it++) {
     MatchErrorCode rc = get_entry_(*it, &entries[idx++]);
+    _BM_UNUSED(rc);
     assert(rc == MatchErrorCode::SUCCESS);
   }
 
@@ -1044,6 +1048,7 @@ MatchTableIndirectWS::get_entries() const {
   for (auto it = match_unit->handles_begin(); it != match_unit->handles_end();
        it++) {
     MatchErrorCode rc = get_entry_(*it, &entries[idx++]);
+    _BM_UNUSED(rc);
     assert(rc == MatchErrorCode::SUCCESS);
   }
 

--- a/src/bm_sim/match_units.cpp
+++ b/src/bm_sim/match_units.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/action_entry.h>
 #include <bm/bm_sim/action_profile.h>
 #include <bm/bm_sim/match_units.h>
@@ -1143,7 +1144,9 @@ MatchUnitGeneric<K, V>::deserialize_(std::istream *in, const P4Objects &objs) {
   for (size_t i = 0; i < this->num_entries; i++) {
     Entry entry;
     internal_handle_t handle_; (*in) >> handle_;
-    assert(!this->handles.set_handle(handle_));
+    int error = this->handles.set_handle(handle_);
+    _BM_UNUSED(error);
+    assert(!error);
     uint32_t version; (*in) >> version;
     std::string key_hex; (*in) >> key_hex;
     entry.key.data = ByteContainer(key_hex);

--- a/src/bm_sim/parser_error.cpp
+++ b/src/bm_sim/parser_error.cpp
@@ -60,7 +60,7 @@ ErrorCodeMap::add_core() {
                           Core::StackOutOfBounds, Core::HeaderTooShort,
                           Core::ParserTimeout}) {
     auto name = core_to_name(core);
-    if (!exists(name)) assert(add(name, max_v++));
+    if (!exists(name)) add(name, max_v++);
   }
 }
 

--- a/src/bm_sim/simple_pre.cpp
+++ b/src/bm_sim/simple_pre.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/simple_pre.h>
 #include <bm/bm_sim/logger.h>
 
@@ -153,9 +154,13 @@ McSimplePre::mc_node_destroy(const l1_hdl_t l1_hdl) {
   }
   rid = l1_entry.rid;
   l2_entries.erase(l1_entry.l2_hdl);
-  assert(!l2_handles.release_handle(l1_entry.l2_hdl));
+  int error;
+  _BM_UNUSED(error);
+  error = l2_handles.release_handle(l1_entry.l2_hdl);
+  assert(!error);
   l1_entries.erase(l1_hdl);
-  assert(!l1_handles.release_handle(l1_hdl));
+  error = l1_handles.release_handle(l1_hdl);
+  assert(!error);
   Logger::get()->debug("node destroyed for rid {}", rid);
   return SUCCESS;
 }

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/P4Objects.h>
 #include <bm/bm_sim/options_parse.h>
@@ -317,7 +318,9 @@ SwitchWContexts::swap_configs() {
   {
     std::unique_lock<std::mutex> config_lock(config_mutex);
     if (!config_loaded) config_loaded = true;
-    assert(do_swap() == 0);
+    int error = do_swap();
+    _BM_UNUSED(error);
+    assert(!error);
   }
   config_loaded_cv.notify_one();
   return ErrorCode::SUCCESS;

--- a/tests/stress_tests/stress_utils.h
+++ b/tests/stress_tests/stress_utils.h
@@ -21,6 +21,7 @@
 #ifndef TESTS_STRESS_TESTS_STRESS_UTILS_H_
 #define TESTS_STRESS_TESTS_STRESS_UTILS_H_
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/switch.h>
 
 #include <chrono>

--- a/tests/stress_tests/test_LPM_match_1.cpp
+++ b/tests/stress_tests/test_LPM_match_1.cpp
@@ -95,9 +95,10 @@ bm::MatchErrorCode add_entry_3(SwitchTest *sw, const ethernet_t &hdr) {
                           &handle);
 }
 
-bool check_rc(bm::MatchErrorCode rc) {
-  return (rc == bm::MatchErrorCode::SUCCESS ||
-          rc == bm::MatchErrorCode::DUPLICATE_ENTRY);
+void check_rc(bm::MatchErrorCode rc) {
+  _BM_UNUSED(rc);
+  assert(rc == bm::MatchErrorCode::SUCCESS ||
+         rc == bm::MatchErrorCode::DUPLICATE_ENTRY);
 }
 
 }  // namespace
@@ -121,9 +122,9 @@ int main(int argc, char* argv[]) {
   for (const auto &pkt : packets) {
     ethernet_t *hdr = reinterpret_cast<ethernet_t *>(pkt->data());
     assert(ntohs(hdr->etherType) == 0x0800);  // check for IPv4 ethertype
-    assert(check_rc(add_entry_1(&sw, *hdr)));
-    assert(check_rc(add_entry_2(&sw, *hdr)));
-    assert(check_rc(add_entry_3(&sw, *hdr)));
+    check_rc(add_entry_1(&sw, *hdr));
+    check_rc(add_entry_2(&sw, *hdr));
+    check_rc(add_entry_3(&sw, *hdr));
   }
 
   auto parser = sw.get_parser("parser");

--- a/tests/stress_tests/test_exact_match_1.cpp
+++ b/tests/stress_tests/test_exact_match_1.cpp
@@ -76,9 +76,10 @@ bm::MatchErrorCode add_entry_3(SwitchTest *sw, const ethernet_t &hdr) {
                           &handle);
 }
 
-bool check_rc(bm::MatchErrorCode rc) {
-  return (rc == bm::MatchErrorCode::SUCCESS ||
-          rc == bm::MatchErrorCode::DUPLICATE_ENTRY);
+void check_rc(bm::MatchErrorCode rc) {
+  _BM_UNUSED(rc);
+  assert(rc == bm::MatchErrorCode::SUCCESS ||
+         rc == bm::MatchErrorCode::DUPLICATE_ENTRY);
 }
 
 }  // namespace
@@ -101,9 +102,9 @@ int main(int argc, char* argv[]) {
   for (const auto &pkt : packets) {
     ethernet_t *hdr = reinterpret_cast<ethernet_t *>(pkt->data());
     assert(ntohs(hdr->etherType) == 0x0800);  // check for IPv4 ethertype
-    if (rgen.get_bool(p_add)) assert(check_rc(add_entry_1(&sw, *hdr)));
-    if (rgen.get_bool(p_add)) assert(check_rc(add_entry_2(&sw, *hdr)));
-    if (rgen.get_bool(p_add)) assert(check_rc(add_entry_3(&sw, *hdr)));
+    if (rgen.get_bool(p_add)) check_rc(add_entry_1(&sw, *hdr));
+    if (rgen.get_bool(p_add)) check_rc(add_entry_2(&sw, *hdr));
+    if (rgen.get_bool(p_add)) check_rc(add_entry_3(&sw, *hdr));
   }
 
   auto parser = sw.get_parser("parser");

--- a/tests/stress_tests/test_ternary_match_1.cpp
+++ b/tests/stress_tests/test_ternary_match_1.cpp
@@ -90,9 +90,10 @@ bm::MatchErrorCode add_entry_3(SwitchTest *sw, const ethernet_t &hdr) {
                           &handle);
 }
 
-bool check_rc(bm::MatchErrorCode rc) {
-  return (rc == bm::MatchErrorCode::SUCCESS ||
-          rc == bm::MatchErrorCode::DUPLICATE_ENTRY);
+void check_rc(bm::MatchErrorCode rc) {
+  _BM_UNUSED(rc);
+  assert(rc == bm::MatchErrorCode::SUCCESS ||
+         rc == bm::MatchErrorCode::DUPLICATE_ENTRY);
 }
 
 }  // namespace
@@ -116,9 +117,9 @@ int main(int argc, char* argv[]) {
   for (const auto &pkt : packets) {
     ethernet_t *hdr = reinterpret_cast<ethernet_t *>(pkt->data());
     assert(ntohs(hdr->etherType) == 0x0800);  // check for IPv4 ethertype
-    if (rgen.get_bool(p_add)) assert(check_rc(add_entry_1(&sw, *hdr)));
-    if (rgen.get_bool(p_add)) assert(check_rc(add_entry_2(&sw, *hdr)));
-    if (rgen.get_bool(p_add)) assert(check_rc(add_entry_3(&sw, *hdr)));
+    if (rgen.get_bool(p_add)) check_rc(add_entry_1(&sw, *hdr));
+    if (rgen.get_bool(p_add)) check_rc(add_entry_2(&sw, *hdr));
+    if (rgen.get_bool(p_add)) check_rc(add_entry_3(&sw, *hdr));
   }
 
   auto parser = sw.get_parser("parser");

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -347,10 +347,13 @@ TEST(P4Objects, HeaderStackArith) {
   ASSERT_NO_THROW(h1_f1.get_int());
   ASSERT_NO_THROW(h0_f1.get_int());
 
+  (void) h0_f2; (void) h1_f2;
+#ifndef NDEBUG
   if (!WITH_VALGRIND) {
     ASSERT_DEATH(h0_f2.get_int(), "Assertion .*failed");
     ASSERT_DEATH(h1_f2.get_int(), "Assertion .*failed");
   }
+#endif
 }
 
 TEST(P4Objects, Errors) {

--- a/tests/test_runtime_iface.cpp
+++ b/tests/test_runtime_iface.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/switch.h>
 
 #include <string>
@@ -50,7 +51,7 @@ class RuntimeIfaceTest : public ::testing::Test {
   virtual void SetUp() {
     // load JSON
     fs::path json_path = fs::path(testdata_dir) / fs::path(test_json);
-    assert(sw.init_objects(json_path.string()) == 0);
+    _BM_ASSERT(sw.init_objects(json_path.string()) == 0);
   }
 
   // virtual void TearDown() { }

--- a/tests/test_switch.cpp
+++ b/tests/test_switch.cpp
@@ -83,7 +83,7 @@ TEST(Switch, GetConfig) {
     std::ifstream fs(md5_path.string());
     for (size_t i = 0; i < md5.size(); i++) {
       char c1, c2;
-      assert(fs.get(c1)); assert(fs.get(c2));
+      ASSERT_TRUE(fs.get(c1)); ASSERT_TRUE(fs.get(c2));
       md5[i] = (char2digit(c1) << 4) | char2digit(c2);
     }
   }

--- a/tests/utils.cpp.in
+++ b/tests/utils.cpp.in
@@ -23,6 +23,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <bm/bm_sim/_assert.h>
+
 #include <string>
 
 #include <cstdio>
@@ -52,7 +54,7 @@ class CLIWrapperImp {
   }
 
   ~CLIWrapperImp() {
-    assert(pclose(CLI_f) == 0);
+    _BM_ASSERT(pclose(CLI_f) == 0);
   }
 
   void send_cmd(const std::string &cmd) {


### PR DESCRIPTION
In release builds, it is common to define NDEBUG to ignore
asserts. Which means it is a bad idea to call methods with necessary
side-effects inside asserts...