### PR TITLE
Support for injecting / receiving pkts with gRPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ VERSION-build
 
 # dist archives
 *.tar.gz
+
+core
+vgcore*

--- a/PI/src/pi_imp.cpp
+++ b/PI/src/pi_imp.cpp
@@ -57,16 +57,23 @@ pi_status_t _pi_update_device_start(pi_dev_id_t dev_id,
                                     const pi_p4info_t *p4info,
                                     const char *device_data,
                                     size_t device_data_size) {
-  (void) dev_id;
-  (void) p4info;
-  (void) device_data;
-  (void) device_data_size;
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_id);
+  assert(d_info->assigned);
+  auto error_code = pibmv2::switch_->load_new_config(
+      std::string(device_data, device_data_size));
+  if (error_code != bm::RuntimeInterface::ErrorCode::SUCCESS)
+    return PI_STATUS_TARGET_ERROR;
+  d_info->p4info = p4info;
+  return PI_STATUS_SUCCESS;
 }
 
 pi_status_t _pi_update_device_end(pi_dev_id_t dev_id) {
-  (void) dev_id;
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  pibmv2::device_info_t *d_info = pibmv2::get_device_info(dev_id);
+  assert(d_info->assigned);
+  auto error_code = pibmv2::switch_->swap_configs();
+  if (error_code != bm::RuntimeInterface::ErrorCode::SUCCESS)
+    return PI_STATUS_TARGET_ERROR;
+  return PI_STATUS_SUCCESS;
 }
 
 pi_status_t _pi_remove_device(pi_dev_id_t dev_id) {

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -23,6 +23,7 @@
 #ifndef BM_BM_SIM_OPTIONS_PARSE_H_
 #define BM_BM_SIM_OPTIONS_PARSE_H_
 
+#include <iosfwd>
 #include <string>
 #include <map>
 
@@ -53,12 +54,11 @@ class InterfaceList {
 };
 
 class OptionsParser {
-  friend class SwitchWContexts;
-
  public:
-  void parse(int argc, char *argv[], TargetParserIface *tp);
+  void parse(int argc, char *argv[], TargetParserIface *tp,
+             // NOLINTNEXTLINE(runtime/references)
+             std::ostream &outstream = std::cout);
 
- private:
   std::string config_file_path{};
   bool no_p4{false};
   InterfaceList ifaces{};

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -89,6 +89,7 @@
 
 namespace bm {
 
+class OptionsParser;
 class Packet;
 
 // multiple inheritance in accordance with Google C++ guidelines:
@@ -221,6 +222,20 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   int init_from_command_line_options(
       int argc, char *argv[],
       TargetParserIface *tp = nullptr,
+      std::shared_ptr<TransportIface> my_transport = nullptr,
+      std::unique_ptr<DevMgrIface> my_dev_mgr = nullptr);
+
+  //! Initialize the switch using an bm::OptionsParser instance. This is similar
+  //! to init_from_command_line_options() but the target is responsible for
+  //! parsing the command-line options itself. In other words, the target needs
+  //! to instantiate a bm::OptionsParser object, invoke
+  //! bm::OptionsParser::parse() on it and pass the object to this method as \p
+  //! parser. This is useful if the target needs to access some of the
+  //! command-line options before initializing the switch. For example, the
+  //! target may want to use a custom bm::DevMgrIface implementation and may
+  //! need some information from the command-line to instantiate it.
+  int init_from_options_parser(
+      const OptionsParser &parser,
       std::shared_ptr<TransportIface> my_transport = nullptr,
       std::unique_ptr<DevMgrIface> my_dev_mgr = nullptr);
 

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -185,9 +185,17 @@ SwitchWContexts::init_from_command_line_options(
     int argc, char *argv[], TargetParserIface *tp,
     std::shared_ptr<TransportIface> my_transport,
     std::unique_ptr<DevMgrIface> my_dev_mgr) {
-  int status = 0;
   OptionsParser parser;
   parser.parse(argc, argv, tp);
+  return init_from_options_parser(parser, my_transport, std::move(my_dev_mgr));
+}
+
+int
+SwitchWContexts::init_from_options_parser(
+    const OptionsParser &parser,
+    std::shared_ptr<TransportIface> my_transport,
+    std::unique_ptr<DevMgrIface> my_dev_mgr) {
+  int status = 0;
 
   auto transport = my_transport;
   if (transport == nullptr) {

--- a/targets/simple_switch_grpc/.gitignore
+++ b/targets/simple_switch_grpc/.gitignore
@@ -9,3 +9,8 @@ tests/test
 tests/test.run
 tests/test_packet_io
 tests/test_packet_io.run
+tests/test_grpc_dp
+
+cpp_out
+grpc_out
+py_out

--- a/targets/simple_switch_grpc/CPPLINT.cfg
+++ b/targets/simple_switch_grpc/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# in case the src dir is used as the build dir
+exclude_files=cpp_out|grpc_out|config.h

--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -12,11 +12,102 @@ bin_PROGRAMS = simple_switch_grpc
 simple_switch_grpc_SOURCES = main.cpp
 
 simple_switch_grpc_LDADD = \
-$(builddir)/../simple_switch/libsimpleswitch.la \
-$(builddir)/../../PI/libbmpi.la \
--lpifeproto -lpigrpcserver -lpi
+libsimple_switch_grpc.la
 
 # We follow this tutorial to link with grpc++_reflection:
 # https://github.com/grpc/grpc/blob/master/doc/server_reflection_tutorial.md
 simple_switch_grpc_LDFLAGS = \
 -Wl,--no-as-needed,-lgrpc++_reflection,--as-needed
+
+lib_LTLIBRARIES = libbm_grpc_dataplane.la
+noinst_LTLIBRARIES = libsimple_switch_grpc.la
+
+libsimple_switch_grpc_la_SOURCES = \
+switch_runner.cpp switch_runner.h
+
+libsimple_switch_grpc_la_LIBADD = \
+$(builddir)/../simple_switch/libsimpleswitch.la \
+$(builddir)/../../PI/libbmpi.la \
+libbm_grpc_dataplane.la \
+-lpifeproto -lpigrpcserver -lpi \
+$(GRPC_LIBS) $(PROTOBUF_LIBS)
+
+
+# dataplane_interface.proto
+
+EXTRA_DIST = p4/bm/dataplane_interface.proto
+
+proto = $(abs_srcdir)/p4/bm/dataplane_interface.proto
+
+PROTOFLAGS = -I$(abs_srcdir)
+
+proto_cpp_files = \
+cpp_out/p4/bm/dataplane_interface.pb.cc \
+cpp_out/p4/bm/dataplane_interface.pb.h
+
+proto_grpc_files = \
+grpc_out/p4/bm/dataplane_interface.grpc.pb.cc \
+grpc_out/p4/bm/dataplane_interface.grpc.pb.h
+
+includep4bmdir = $(includep4bmdir)/p4/bm/
+nodist_includep4bm_HEADERS = \
+cpp_out/p4/bm/dataplane_interface.pb.h \
+grpc_out/p4/bm/dataplane_interface.grpc.pb.h
+
+BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
+
+if HAVE_GRPC_PY_PLUGIN
+p4bmpydir = $(pythondir)/p4/bm
+nodist_p4bmpy_PYTHON = \
+py_out/p4/bm/dataplane_interface_pb2.py \
+py_out/p4/bm/__init__.py
+
+BUILT_SOURCES += \
+$(nodist_p4bmpy_PYTHON)
+endif
+
+# See http://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
+
+proto_files.ts: $(proto)
+	@rm -f proto_files.tmp
+	@touch proto_files.tmp
+	@mkdir -p $(builddir)/cpp_out
+	@mkdir -p $(builddir)/grpc_out
+	$(PROTOC) $^ --cpp_out $(builddir)/cpp_out $(PROTOFLAGS)
+	$(PROTOC) $^ --grpc_out $(builddir)/grpc_out --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN) $(PROTOFLAGS)
+if HAVE_GRPC_PY_PLUGIN
+	@mkdir -p $(builddir)/py_out
+# With the Python plugin, it seems that I need to use a single command for proto
+# + grpc and that the output directory needs to be the same (because the grpc
+# plugin inserts code into the proto-generated files). But maybe I am just using
+# an old version of the Python plugin.
+	$(PROTOC) $^ --python_out $(builddir)/py_out $(PROTOFLAGS) --grpc_out $(builddir)/py_out --plugin=protoc-gen-grpc=$(GRPC_PY_PLUGIN)
+	@touch $(builddir)/py_out/p4/bm/__init__.py
+endif
+	@mv -f proto_files.tmp $@
+
+$(BUILT_SOURCES): proto_files.ts
+## Recover from the removal of $@
+	@if test -f $@; then :; else \
+	  trap 'rm -rf proto_files.lock proto_files.ts' 1 2 13 15; \
+## mkdir is a portable test-and-set
+	if mkdir proto_files.lock 2>/dev/null; then \
+## This code is being executed by the first process.
+	  rm -f proto_files.ts; \
+	  $(MAKE) $(AM_MAKEFLAGS) proto_files.ts; \
+	  result=$$?; rm -rf proto_files.lock; exit $$result; \
+	else \
+## This code is being executed by the follower processes.
+## Wait until the first process is done.
+	  while test -d proto_files.lock; do sleep 1; done; \
+## Succeed if and only if the first process succeeded.
+	    test -f proto_files.ts; \
+	  fi; \
+	fi
+
+AM_CPPFLAGS += -Icpp_out -Igrpc_out \
+-I$(builddir)/cpp_out -I$(builddir)/grpc_out
+
+nodist_libbm_grpc_dataplane_la_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
+
+CLEANFILES = $(BUILT_SOURCES) proto_files.ts

--- a/targets/simple_switch_grpc/configure.ac
+++ b/targets/simple_switch_grpc/configure.ac
@@ -41,6 +41,21 @@ PKG_CHECK_MODULES([GRPC], [grpc++ >= 1.3.0 grpc >= 3.0.0])
 AC_SUBST([GRPC_CFLAGS])
 AC_SUBST([GRPC_LIBS])
 
+AC_PATH_PROG([PROTOC], [protoc], [])
+AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found])])
+
+AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
+AS_IF([test "x$GRPC_CPP_PLUGIN" = x], [
+    AC_MSG_ERROR([grpc_cpp_plugin not found])
+])
+AS_IF([test "$PYTHON" != :], [
+    AC_PATH_PROG([GRPC_PY_PLUGIN], [grpc_python_plugin])
+    AS_IF([test "x$GRPC_PY_PLUGIN" = x], [
+        AC_MSG_WARN([grpc_python_plugin not found, Python code won't be generated])
+    ])
+])
+AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
+
 # Generate makefiles
 AC_CONFIG_FILES([Makefile
                  tests/Makefile])

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -18,63 +18,53 @@
  *
  */
 
-/* Switch instance */
-
-#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/target_parser.h>
 
-#include <bm/PI/pi.h>
+#include <string>
 
-#include <PI/frontends/proto/device_mgr.h>
-
-#include <PI/proto/pi_server.h>
-
-#include <PI/pi.h>
-#include <PI/target/pi_imp.h>
-
-#include "simple_switch.h"
-
-namespace {
-SimpleSwitch *simple_switch;
-bm::TargetParserBasic *simple_switch_parser;
-}  // namespace
-
-// We use the PI native RPC server (built on top of nanomsg) as a debugging
-// tool, since we do not have a CLI using p4runtime.proto yet.
-extern "C" {
-
-extern pi_status_t pi_rpc_server_run(const pi_remote_addr_t *remote_addr);
-
-}
+#include "switch_runner.h"
 
 int
 main(int argc, char* argv[]) {
-  simple_switch = new SimpleSwitch();
-  simple_switch_parser = new bm::TargetParserBasic();
-  simple_switch_parser->add_flag_option("enable-swap",
-                                        "enable JSON swapping at runtime");
-  simple_switch_parser->add_string_option(
+  bm::TargetParserBasic simple_switch_parser;
+  simple_switch_parser.add_flag_option(
+      "enable-swap",
+      "enable JSON swapping at runtime");
+  simple_switch_parser.add_string_option(
       "grpc-server-addr",
       "bind gRPC server to given address [default is 0.0.0.0:50051]");
-  simple_switch_parser->add_int_option(
+  simple_switch_parser.add_int_option(
       "cpu-port",
       "set CPU port, will be used for packet-in / packet-out; "
       "do not add an interface with this port number");
-  int status = simple_switch->init_from_command_line_options(
-      argc, argv, simple_switch_parser);
-  if (status != 0) std::exit(status);
+  simple_switch_parser.add_string_option(
+      "dp-grpc-server-addr",
+      "use a gRPC channel to inject and receive dataplane packets; "
+      "bind this gRPC server to given address, e.g. 0.0.0.0:50052");
+
+  bm::OptionsParser parser;
+  parser.parse(argc, argv, &simple_switch_parser);
+
+  std::string dp_grpc_server_addr;
+  {
+    auto rc = simple_switch_parser.get_string_option(
+        "dp-grpc-server-addr", &dp_grpc_server_addr);
+    if (rc != bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED &&
+        rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
 
   bool enable_swap_flag = false;
   {
-    auto rc = simple_switch_parser->get_flag_option(
+    auto rc = simple_switch_parser.get_flag_option(
         "enable-swap", &enable_swap_flag);
     if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) std::exit(1);
   }
-  if (enable_swap_flag) simple_switch->enable_config_swap();
 
   std::string grpc_server_addr;
   {
-    auto rc = simple_switch_parser->get_string_option(
+    auto rc = simple_switch_parser.get_string_option(
         "grpc-server-addr", &grpc_server_addr);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       grpc_server_addr = "0.0.0.0:50051";
@@ -84,57 +74,18 @@ main(int argc, char* argv[]) {
 
   int cpu_port = -1;
   {
-    auto rc = simple_switch_parser->get_int_option("cpu-port", &cpu_port);
+    auto rc = simple_switch_parser.get_int_option("cpu-port", &cpu_port);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       cpu_port = -1;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port < 0)
       std::exit(1);
   }
 
-  // check if CPU port number is also used by --interface
-  // TODO(antonin): ports added dynamically?
-  if (cpu_port >= 0) {
-    auto port_info = simple_switch->get_port_info();
-    if (port_info.find(cpu_port) != port_info.end()) {
-      bm::Logger::get()->error("Cpu port {} is used as a data port", cpu_port);
-      std::exit(1);
-    }
-  }
+  auto &runner = sswitch_grpc::SimpleSwitchGrpcRunner::get_instance(
+      512, enable_swap_flag, grpc_server_addr, cpu_port, dp_grpc_server_addr);
+  int status = runner.init_and_start(parser);
+  if (status != 0) std::exit(status);
 
-  if (cpu_port >= 0) {
-    auto transmit_fn = [cpu_port](int port_num, const char *buf, int len) {
-      if (port_num == cpu_port) {
-        BMLOG_DEBUG("Transmitting packet-in");
-        auto status = pi_packetin_receive(
-            simple_switch->get_device_id(), buf, static_cast<size_t>(len));
-        if (status != PI_STATUS_SUCCESS)
-          bm::Logger::get()->error("Error when transmitting packet-in");
-      } else {
-        simple_switch->transmit_fn(port_num, buf, len);
-      }
-    };
-    simple_switch->set_transmit_fn(transmit_fn);
-  }
-
-  bm::pi::register_switch(simple_switch, cpu_port);
-
-  using pi::fe::proto::DeviceMgr;
-  DeviceMgr::init(256);
-  PIGrpcServerRunAddr(grpc_server_addr.c_str());
-
-  simple_switch->start_and_return();
-
-#ifdef PI_INTERNAL_RPC
-  char *opt_rpc_addr = NULL;
-  char *opt_notifications_addr = NULL;
-  pi_remote_addr_t remote_addr = {opt_rpc_addr, opt_notifications_addr};
-  std::thread pi_CLI_thread(
-      [&remote_addr] { pi_rpc_server_run(&remote_addr); });
-#endif
-
-  PIGrpcServerWait();
-  PIGrpcServerCleanup();
-  DeviceMgr::destroy();
-
+  runner.wait();
   return 0;
 }

--- a/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
+++ b/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
@@ -1,0 +1,37 @@
+// Copyright 2013-present Barefoot Networks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// This package and its contents are a work-in-progress.
+
+package p4.bm;
+
+service DataplaneInterface {
+  rpc PacketStream(stream PacketStreamRequest)
+      returns (stream PacketStreamResponse) {
+  }
+}
+
+message PacketStreamRequest {
+  uint64 device_id = 1;
+  uint32 port = 2;
+  bytes packet = 3;
+}
+
+message PacketStreamResponse {
+  uint64 device_id = 1;
+  uint32 port = 2;
+  bytes packet = 3;
+}

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -1,0 +1,233 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/options_parse.h>
+
+#include <bm/PI/pi.h>
+
+#include <PI/frontends/proto/device_mgr.h>
+
+#include <PI/proto/pi_server.h>
+
+#include <PI/pi.h>
+#include <PI/target/pi_imp.h>
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+
+#include <map>
+#include <mutex>
+#include <string>
+
+#include "simple_switch.h"
+
+#include "switch_runner.h"
+
+namespace sswitch_grpc {
+
+namespace {
+
+using grpc::ServerContext;
+using grpc::Status;
+using grpc::StatusCode;
+
+using ServerReaderWriter = grpc::ServerReaderWriter<
+  p4::bm::PacketStreamResponse, p4::bm::PacketStreamRequest>;
+
+class DataplaneInterfaceServiceImpl
+    : public p4::bm::DataplaneInterface::Service,
+      public bm::DevMgrIface {
+ public:
+  explicit DataplaneInterfaceServiceImpl(int device_id)
+      : device_id(device_id) {
+    p_monitor = bm::PortMonitorIface::make_dummy();
+  }
+
+ private:
+  using Lock = std::lock_guard<std::mutex>;
+
+  Status PacketStream(ServerContext *context,
+                      ServerReaderWriter *stream) override {
+    {
+      Lock lock(mutex);
+      if (!started)
+        return Status(StatusCode::UNAVAILABLE, "not ready");
+      if (active) {
+        return Status(StatusCode::RESOURCE_EXHAUSTED,
+                      "only one client authorized at a time");
+      }
+      active = true;
+      this->context = context;
+      this->stream = stream;
+    }
+    p4::bm::PacketStreamRequest request;
+    while (this->stream->Read(&request)) {
+      if (request.device_id() != device_id) {
+        continue;
+      }
+      const auto &packet = request.packet();
+      if (packet.empty()) continue;
+      if (!pkt_handler) continue;
+      pkt_handler(request.port(), packet.data(), packet.size(), pkt_cookie);
+    }
+    Lock lock(mutex);
+    active = false;
+    return Status::OK;
+  }
+
+  ReturnCode port_add_(const std::string &iface_name, port_t port_num,
+                       const char *in_pcap, const char *out_pcap) override {
+    _BM_UNUSED(iface_name);
+    _BM_UNUSED(port_num);
+    _BM_UNUSED(in_pcap);
+    _BM_UNUSED(out_pcap);
+    return ReturnCode::UNSUPPORTED;
+  }
+
+  ReturnCode port_remove_(port_t port_num) override {
+    _BM_UNUSED(port_num);
+    return ReturnCode::UNSUPPORTED;
+  }
+
+  void transmit_fn_(int port_num, const char *buffer, int len) override {
+    p4::bm::PacketStreamResponse response;
+    response.set_device_id(device_id);
+    response.set_port(port_num);
+    response.set_packet(buffer, len);
+    Lock lock(mutex);
+    if (active) stream->Write(response);
+  }
+
+  void start_() override {
+    Lock lock(mutex);
+    started = true;
+  }
+
+  ReturnCode set_packet_handler_(const PacketHandler &handler, void *cookie)
+      override {
+    pkt_handler = handler;
+    pkt_cookie = cookie;
+    return ReturnCode::SUCCESS;
+  }
+
+  bool port_is_up_(port_t port) const override {
+    _BM_UNUSED(port);
+    return true;
+  }
+
+  std::map<port_t, PortInfo> get_port_info_() const override {
+    return {};
+  }
+
+  int device_id;
+  // protects the shared state (active) and prevents concurrent Write calls by
+  // different threads
+  std::mutex mutex{};
+  bool started{false};
+  bool active{false};
+  ServerContext *context{nullptr};
+  ServerReaderWriter *stream{nullptr};
+  PacketHandler pkt_handler{};
+  void *pkt_cookie{nullptr};
+};
+
+}  // namespace
+
+SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(int max_port, bool enable_swap,
+                                               std::string grpc_server_addr,
+                                               int cpu_port,
+                                               std::string dp_grpc_server_addr)
+    : simple_switch(new SimpleSwitch(max_port, enable_swap)),
+      grpc_server_addr(grpc_server_addr), cpu_port(cpu_port),
+      dp_grpc_server_addr(dp_grpc_server_addr),
+      dp_grpc_server{nullptr} { }
+
+int
+SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
+  std::unique_ptr<bm::DevMgrIface> my_dev_mgr = nullptr;
+  if (!dp_grpc_server_addr.empty()) {
+    auto service = new DataplaneInterfaceServiceImpl(parser.device_id);
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(dp_grpc_server_addr,
+                             grpc::InsecureServerCredentials());
+    builder.RegisterService(service);
+    dp_grpc_server = builder.BuildAndStart();
+    my_dev_mgr.reset(service);
+  }
+
+  int status = simple_switch->init_from_options_parser(
+      parser, nullptr, std::move(my_dev_mgr));
+  if (status != 0) return status;
+
+  // check if CPU port number is also used by --interface
+  // TODO(antonin): ports added dynamically?
+  if (cpu_port >= 0) {
+    auto port_info = simple_switch->get_port_info();
+    if (port_info.find(cpu_port) != port_info.end()) {
+      bm::Logger::get()->error("Cpu port {} is used as a data port", cpu_port);
+      return 1;
+    }
+  }
+
+  if (cpu_port >= 0) {
+    auto transmit_fn = [this](int port_num, const char *buf, int len) {
+      if (port_num == cpu_port) {
+        BMLOG_DEBUG("Transmitting packet-in");
+        auto status = pi_packetin_receive(
+            simple_switch->get_device_id(), buf, static_cast<size_t>(len));
+        if (status != PI_STATUS_SUCCESS)
+          bm::Logger::get()->error("Error when transmitting packet-in");
+      } else {
+        simple_switch->transmit_fn(port_num, buf, len);
+      }
+    };
+    simple_switch->set_transmit_fn(transmit_fn);
+  }
+
+  bm::pi::register_switch(simple_switch.get(), cpu_port);
+
+  using pi::fe::proto::DeviceMgr;
+  DeviceMgr::init(256);
+  PIGrpcServerRunAddr(grpc_server_addr.c_str());
+
+  simple_switch->start_and_return();
+
+  return 0;
+}
+
+void
+SimpleSwitchGrpcRunner::wait() {
+  PIGrpcServerWait();
+}
+
+void
+SimpleSwitchGrpcRunner::shutdown() {
+  PIGrpcServerShutdown();
+  dp_grpc_server->Shutdown();
+}
+
+SimpleSwitchGrpcRunner::~SimpleSwitchGrpcRunner() {
+  PIGrpcServerCleanup();
+}
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -1,0 +1,77 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_
+#define SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_
+
+#include <memory>
+#include <string>
+
+class SimpleSwitch;
+
+namespace grpc {
+
+class Server;
+
+}  // namespace grpc
+
+namespace bm {
+
+class OptionsParser;
+
+}  // namespace bm
+
+namespace sswitch_grpc {
+
+class SimpleSwitchGrpcRunner {
+ public:
+  // there is no real need for a singleton here, except for the case that we use
+  // PIGrpcServerRunAddr, ... which uses static state
+  static SimpleSwitchGrpcRunner &get_instance(
+      int max_port = 512, bool enable_swap = false,
+      std::string grpc_server_addr = "0.0.0.0:50051",
+      int cpu_port = -1,
+      std::string dp_grpc_server_addr = "") {
+    static SimpleSwitchGrpcRunner instance(
+        max_port, enable_swap, grpc_server_addr, cpu_port, dp_grpc_server_addr);
+    return instance;
+  }
+
+  int init_and_start(const bm::OptionsParser &parser);
+  void wait();
+  void shutdown();
+
+ private:
+  SimpleSwitchGrpcRunner(int max_port = 512, bool enable_swap = false,
+                         std::string grpc_server_addr = "0.0.0.0:50051",
+                         int cpu_port = -1,
+                         std::string dp_grpc_server_addr = "");
+  ~SimpleSwitchGrpcRunner();
+
+  std::unique_ptr<SimpleSwitch> simple_switch;
+  std::string grpc_server_addr;
+  int cpu_port;
+  std::string dp_grpc_server_addr;
+  std::unique_ptr<grpc::Server> dp_grpc_server;
+};
+
+}  // namespace sswitch_grpc
+
+#endif  // SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -1,17 +1,30 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 AM_CPPFLAGS += \
+-isystem $(top_srcdir)/../../third_party/gtest/include \
+-I$(top_srcdir) \
+-I$(top_srcdir)/../../include \
+-I$(top_builddir)/cpp_out -I$(top_builddir)/grpc_out \
 -DTESTDATADIR=\"$(abs_srcdir)/testdata\"
 
-TESTS = test.run test_packet_io.run
+TESTS = test.run test_packet_io.run test_grpc_dp
 
-check_PROGRAMS = test test_packet_io
+check_PROGRAMS = test test_packet_io test_grpc_dp
 
-common_source = utils.h utils.cpp
+common_source = utils.h utils.cpp base_test.h base_test.cpp
 
 test_SOURCES = test.cpp $(common_source)
 test_packet_io_SOURCES = test_packet_io.cpp $(common_source)
+test_grpc_dp_SOURCES = test_grpc_dp.cpp $(common_source) main.cpp
 
 LDADD = \
+$(top_builddir)/libsimple_switch_grpc.la \
+$(top_builddir)/../simple_switch/libsimpleswitch.la \
 -lpiproto \
-$(PROTOBUF_LIBS) $(GRPC_LIBS)
+$(PROTOBUF_LIBS) $(GRPC_LIBS) \
+$(top_builddir)/../../third_party/gtest/libgtest.la
+
+EXTRA_DIST = \
+simple_router.json simple_router.proto.txt \
+packet_io.p4 packet_io.json packet_io.proto.txt \
+loopback.p4 loopback.json loopback.proto.txt

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -1,0 +1,72 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <p4/tmp/p4config.grpc.pb.h>
+
+#include <fstream>
+#include <streambuf>
+
+#include "base_test.h"
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+constexpr char SimpleSwitchGrpcBaseTest::grpc_server_addr[];
+constexpr char SimpleSwitchGrpcBaseTest::dp_grpc_server_addr[];
+constexpr int SimpleSwitchGrpcBaseTest::cpu_port;
+constexpr int SimpleSwitchGrpcBaseTest::device_id;
+
+SimpleSwitchGrpcBaseTest::SimpleSwitchGrpcBaseTest(
+    const char *p4info_proto_txt_path)
+    : p4runtime_channel(grpc::CreateChannel(
+          grpc_server_addr, grpc::InsecureChannelCredentials())),
+      p4runtime_stub(p4::P4Runtime::NewStub(p4runtime_channel)) {
+  p4info = parse_p4info(p4info_proto_txt_path);
+}
+
+void
+SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
+  p4::SetForwardingPipelineConfigRequest request;
+  request.set_action(
+      p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+  auto config = request.add_configs();
+  config->set_device_id(device_id);
+  p4::tmp::P4DeviceConfig device_config;
+  std::ifstream istream(json_path);
+  device_config.mutable_device_data()->assign(
+      (std::istreambuf_iterator<char>(istream)),
+       std::istreambuf_iterator<char>());
+  device_config.SerializeToString(config->mutable_p4_device_config());
+
+  p4::SetForwardingPipelineConfigResponse rep;
+  ClientContext context;
+  config->set_allocated_p4info(&p4info);
+  auto status = p4runtime_stub->SetForwardingPipelineConfig(
+      &context, request, &rep);
+  config->release_p4info();
+  ASSERT_TRUE(status.ok());
+}
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -1,0 +1,67 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_
+#define SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_
+
+#include <p4/config/p4info.grpc.pb.h>
+#include <p4/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "utils.h"
+
+namespace grpc {
+
+class Channel;
+
+}  // namespace grpc
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+using grpc::ClientContext;
+using grpc::Status;
+
+class SimpleSwitchGrpcBaseTest : public ::testing::Test {
+ public:
+  static constexpr char grpc_server_addr[] = "0.0.0.0:50056";
+  static constexpr char dp_grpc_server_addr[] = "0.0.0.0:50057";
+  static constexpr int cpu_port = 64;
+  static constexpr int device_id = 3;
+
+ protected:
+  explicit SimpleSwitchGrpcBaseTest(const char *p4info_proto_txt_path);
+
+  void update_json(const char *json_path);
+
+  std::shared_ptr<grpc::Channel> p4runtime_channel;
+  std::unique_ptr<p4::P4Runtime::Stub> p4runtime_stub;
+  p4::config::P4Info p4info{};
+};
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc
+
+#endif  // SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -1,0 +1,68 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/options_parse.h>
+
+#include <gtest/gtest.h>
+
+#include "base_test.h"
+#include "switch_runner.h"
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+constexpr char start_json[] = TESTDATADIR "/loopback.json";
+
+class SimpleSwitchGrpcEnv : public ::testing::Environment {
+ public:
+  // We make the switch a shared resource for all tests. This is mainly because
+  // simple_switch detaches threads.
+  void SetUp() override {
+    auto &runner = SimpleSwitchGrpcRunner::get_instance(
+        256, true, SimpleSwitchGrpcBaseTest::grpc_server_addr,
+        SimpleSwitchGrpcBaseTest::cpu_port,
+        SimpleSwitchGrpcBaseTest::dp_grpc_server_addr);
+    bm::OptionsParser parser;
+    const char *argv[] = {"test", "--device-id", "3", start_json};
+    auto argc = static_cast<int>(sizeof(argv) / sizeof(char *));
+    parser.parse(argc, const_cast<char **>(argv), nullptr);
+    ASSERT_EQ(0, runner.init_and_start(parser));
+  }
+
+  void TearDown() override {
+    SimpleSwitchGrpcRunner::get_instance().shutdown();
+  }
+};
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(
+       new sswitch_grpc::testing::SimpleSwitchGrpcEnv);
+  return RUN_ALL_TESTS();
+}

--- a/targets/simple_switch_grpc/tests/test.cpp
+++ b/targets/simple_switch_grpc/tests/test.cpp
@@ -25,21 +25,22 @@
 #include <google/protobuf/util/message_differencer.h>
 
 #include <memory>
+#include <string>
 
 #include "utils.h"
 
+namespace sswitch_grpc {
+
 namespace testing {
+
+namespace {
 
 using grpc::ClientContext;
 using grpc::Status;
 
 using google::protobuf::util::MessageDifferencer;
 
-namespace {
-
-const char *test_proto_txt = TESTDATADIR "/simple_router.proto.txt";
-
-}  // namespace
+constexpr char test_proto_txt[] = TESTDATADIR "/simple_router.proto.txt";
 
 int
 test() {
@@ -156,9 +157,13 @@ test() {
   return 0;
 }
 
+}  // namespace
+
 }  // namespace testing
+
+}  // namespace sswitch_grpc
 
 int
 main() {
-  return testing::test();
+  return sswitch_grpc::testing::test();
 }

--- a/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
@@ -1,0 +1,98 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "base_test.h"
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+constexpr char loopback_json[] = TESTDATADIR "/loopback.json";
+constexpr char loopback_proto[] = TESTDATADIR "/loopback.proto.txt";
+
+class SimpleSwitchGrpcTest_GrpcDataplane : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_GrpcDataplane()
+      : SimpleSwitchGrpcBaseTest(loopback_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    update_json(loopback_json);
+  }
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+};
+
+TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, SendAndReceive) {
+  p4::bm::PacketStreamRequest request;
+  request.set_device_id(device_id);
+  request.set_port(9);
+  request.set_packet(std::string(10, '\xab'));
+  ClientContext context;
+  auto stream = dataplane_stub->PacketStream(&context);
+  stream->Write(request);
+  p4::bm::PacketStreamResponse response;
+  stream->Read(&response);
+  EXPECT_EQ(request.device_id(), response.device_id());
+  EXPECT_EQ(request.port(), response.port());
+  EXPECT_EQ(request.packet(), response.packet());
+  stream->WritesDone();
+  auto status = stream->Finish();
+  EXPECT_TRUE(status.ok());
+}
+
+// This tests ensure that an error status is returned if we try to have multiple
+// connections to the gRPC DataplaneInterface service
+TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, MultipleClients) {
+  ClientContext context1;
+  auto stream1 = dataplane_stub->PacketStream(&context1);
+  ClientContext context2;
+  auto stream2 = dataplane_stub->PacketStream(&context2);
+  p4::bm::PacketStreamResponse response;
+  while (stream2->Read(&response)) { }
+  EXPECT_TRUE(stream1->WritesDone());
+  EXPECT_TRUE(stream2->WritesDone());
+  auto status1 = stream1->Finish();
+  auto status2 = stream2->Finish();
+  EXPECT_TRUE(status1.ok());
+  EXPECT_EQ(status2.error_code(), grpc::StatusCode::RESOURCE_EXHAUSTED);
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/test_packet_io.cpp
+++ b/targets/simple_switch_grpc/tests/test_packet_io.cpp
@@ -25,22 +25,21 @@
 #include <google/protobuf/util/message_differencer.h>
 
 #include <memory>
+#include <string>
 
 #include "utils.h"
 
+namespace sswitch_grpc {
+
 namespace testing {
+
+namespace {
 
 using grpc::ClientContext;
 using grpc::ClientReaderWriter;
 using grpc::Status;
 
-using google::protobuf::util::MessageDifferencer;
-
-namespace {
-
-const char *test_proto_txt = TESTDATADIR "/packet_io.proto.txt";
-
-}  // namespace
+constexpr char test_proto_txt[] = TESTDATADIR "/packet_io.proto.txt";
 
 int
 test() {
@@ -97,9 +96,13 @@ test() {
   return 0;
 }
 
+}  // namespace
+
 }  // namespace testing
+
+}  // namespace sswitch_grpc
 
 int
 main() {
-  return testing::test();
+  return sswitch_grpc::testing::test();
 }

--- a/targets/simple_switch_grpc/tests/testdata/loopback.json
+++ b/targets/simple_switch_grpc/tests/testdata/loopback.json
@@ -1,0 +1,203 @@
+{
+    "__meta__": {
+        "version": [
+            2,
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
+    },
+    "header_types": [
+        {
+            "name": "standard_metadata_t",
+            "id": 0,
+            "fields": [
+                [
+                    "ingress_port",
+                    9
+                ],
+                [
+                    "packet_length",
+                    32
+                ],
+                [
+                    "egress_spec",
+                    9
+                ],
+                [
+                    "egress_port",
+                    9
+                ],
+                [
+                    "egress_instance",
+                    32
+                ],
+                [
+                    "instance_type",
+                    32
+                ],
+                [
+                    "clone_spec",
+                    32
+                ],
+                [
+                    "_padding",
+                    5
+                ]
+            ],
+            "length_exp": null,
+            "max_length": null
+        }
+    ],
+    "headers": [
+        {
+            "name": "standard_metadata",
+            "id": 0,
+            "header_type": "standard_metadata_t",
+            "metadata": true
+        }
+    ],
+    "header_stacks": [],
+    "parsers": [
+        {
+            "name": "parser",
+            "id": 0,
+            "init_state": "start",
+            "parse_states": [
+                {
+                    "name": "start",
+                    "id": 0,
+                    "parser_ops": [],
+                    "transition_key": [],
+                    "transitions": [
+                        {
+                            "type": "default",
+                            "value": null,
+                            "mask": null,
+                            "next_state": null
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "parse_vsets": [],
+    "deparsers": [
+        {
+            "name": "deparser",
+            "id": 0,
+            "order": []
+        }
+    ],
+    "meter_arrays": [],
+    "actions": [
+        {
+            "name": "redirect",
+            "id": 0,
+            "runtime_data": [],
+            "primitives": [
+                {
+                    "op": "modify_field",
+                    "parameters": [
+                        {
+                            "type": "field",
+                            "value": [
+                                "standard_metadata",
+                                "egress_spec"
+                            ]
+                        },
+                        {
+                            "type": "field",
+                            "value": [
+                                "standard_metadata",
+                                "ingress_port"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "pipelines": [
+        {
+            "name": "ingress",
+            "id": 0,
+            "init_table": "t_redirect",
+            "tables": [
+                {
+                    "name": "t_redirect",
+                    "id": 0,
+                    "match_type": "exact",
+                    "type": "simple",
+                    "max_size": 16384,
+                    "with_counters": false,
+                    "direct_meters": null,
+                    "support_timeout": false,
+                    "key": [],
+                    "actions": [
+                        "redirect"
+                    ],
+                    "next_tables": {
+                        "redirect": null
+                    },
+                    "default_entry": {
+                        "action_id": 0,
+                        "action_const": true,
+                        "action_data": [],
+                        "action_entry_const": false
+                    },
+                    "base_default_next": null
+                }
+            ],
+            "action_profiles": [],
+            "conditionals": []
+        },
+        {
+            "name": "egress",
+            "id": 1,
+            "init_table": null,
+            "tables": [],
+            "action_profiles": [],
+            "conditionals": []
+        }
+    ],
+    "calculations": [],
+    "checksums": [],
+    "learn_lists": [],
+    "field_lists": [],
+    "counter_arrays": [],
+    "register_arrays": [],
+    "force_arith": [
+        [
+            "standard_metadata",
+            "ingress_port"
+        ],
+        [
+            "standard_metadata",
+            "packet_length"
+        ],
+        [
+            "standard_metadata",
+            "egress_spec"
+        ],
+        [
+            "standard_metadata",
+            "egress_port"
+        ],
+        [
+            "standard_metadata",
+            "egress_instance"
+        ],
+        [
+            "standard_metadata",
+            "instance_type"
+        ],
+        [
+            "standard_metadata",
+            "clone_spec"
+        ],
+        [
+            "standard_metadata",
+            "_padding"
+        ]
+    ]
+}

--- a/targets/simple_switch_grpc/tests/testdata/loopback.p4
+++ b/targets/simple_switch_grpc/tests/testdata/loopback.p4
@@ -1,0 +1,33 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+parser start {
+    return ingress;
+}
+
+action redirect() {
+    modify_field(standard_metadata.egress_spec, standard_metadata.ingress_port);
+}
+
+table t_redirect {
+    actions { redirect; }
+    default_action: redirect();
+}
+
+control ingress {
+    apply(t_redirect);
+}
+
+control egress { }

--- a/targets/simple_switch_grpc/tests/testdata/loopback.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/loopback.proto.txt
@@ -1,0 +1,18 @@
+tables {
+  preamble {
+    id: 33591959
+    name: "t_redirect"
+    alias: "t_redirect"
+  }
+  action_refs {
+    id: 16794474
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16794474
+    name: "redirect"
+    alias: "redirect"
+  }
+}

--- a/targets/simple_switch_grpc/tests/utils.cpp
+++ b/targets/simple_switch_grpc/tests/utils.cpp
@@ -25,6 +25,9 @@
 
 #include <fstream>
 #include <streambuf>
+#include <string>
+
+namespace sswitch_grpc {
 
 namespace testing {
 
@@ -78,3 +81,5 @@ p4::config::P4Info parse_p4info(const char *path) {
 }
 
 }  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -18,10 +18,14 @@
  *
  */
 
-#ifndef SIMPLE_SWITCH_GRPC_UTILS_H_
-#define SIMPLE_SWITCH_GRPC_UTILS_H_
+#ifndef SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_
+#define SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_
 
 #include <p4/config/p4info.grpc.pb.h>
+
+#include <string>
+
+namespace sswitch_grpc {
 
 namespace testing {
 
@@ -39,4 +43,6 @@ p4::config::P4Info parse_p4info(const char *path);
 
 }  // namespace testing
 
-#endif  // SIMPLE_SWITCH_GRPC_UTILS_H_
+}  // namespace sswitch_grpc
+
+#endif  // SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -20,6 +20,7 @@ run_cpplint $ROOT_DIR/include/bm/bm_apps include
 run_cpplint $ROOT_DIR/targets/simple_switch targets
 run_cpplint $ROOT_DIR/targets/l2_switch targets
 run_cpplint $ROOT_DIR/targets/simple_router targets
+run_cpplint $ROOT_DIR/targets/simple_switch_grpc targets
 
 run_cpplint $ROOT_DIR/tests .
 


### PR DESCRIPTION
We define a new `p4::bm::DataplaneInterface` gRPC service which can be used to inject and receive packets. We add a `DevMgrIface` implementation to simple_switch_grpc which handles this gRPC service. simple_switch_grpc users can choose to use this `DevMgrIface` implementation by providing a gRPC server address with the new `--dp-grpc-server-addr` command-line option.

In this PR, we also start using GTest for unit-testing simple_switch_grpc. For now we only have tests for the new gRPC packet injection / reception feature. The legacy tests will be converted to GTest in a future pull request.