### PR TITLE
Fix --no-p4 mode

### DIFF
--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -70,8 +70,13 @@ void
 SwitchWContexts::start_and_return() {
   {
     std::unique_lock<std::mutex> config_lock(config_mutex);
+    if (!config_loaded && !enable_swap) {
+      Logger::get()->error(
+          "The switch was started with no P4 and config swap is disabled");
+    }
     config_loaded_cv.wait(config_lock, [this]() { return config_loaded; });
   }
+  start();  // DevMgr::start
   start_and_return_();
 }
 
@@ -283,7 +288,6 @@ SwitchWContexts::init_from_options_parser(
 
   // TODO(unknown): is this the right place to do this?
   set_packet_handler(packet_handler, static_cast<void *>(this));
-  start();
 
   return status;
 }


### PR DESCRIPTION
Moved the call to DevMgr::start from Switch::init to
Switch::start_and_return; otherwise the target may start receiving
packets before a config has been pushed.