### PR TITLE
Ability to pass "extras" KV map when adding port

### DIFF
--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -49,10 +49,15 @@ class DevMgrIface : public PacketDispatcherIface {
   using port_t = PortMonitorIface::port_t;
   using PortStatus = PortMonitorIface::PortStatus;
   using PortStatusCb = PortMonitorIface::PortStatusCb;
+  using PortExtras = std::map<std::string, std::string>;
+
+  static constexpr char kPortExtraInPcap[] = "in_pcap";
+  static constexpr char kPortExtraOutPcap[] = "out_pcap";
 
   struct PortInfo {
-    PortInfo(port_t port_num, const std::string &iface_name)
-        : port_num(port_num), iface_name(iface_name) { }
+    PortInfo(port_t port_num, const std::string &iface_name,
+             const PortExtras &port_extras = {})
+        : port_num(port_num), iface_name(iface_name), extra(port_extras) { }
 
     void set_is_up(bool status) {
       is_up = status;
@@ -65,13 +70,13 @@ class DevMgrIface : public PacketDispatcherIface {
     port_t port_num{};
     std::string iface_name{};
     bool is_up{true};
-    std::map<std::string, std::string> extra{};
+    PortExtras extra{};
   };
 
   virtual ~DevMgrIface();
 
   ReturnCode port_add(const std::string &iface_name, port_t port_num,
-                      const char *in_pcap, const char *out_pcap);
+                      const PortExtras &port_extras);
 
   ReturnCode port_remove(port_t port_num);
 
@@ -99,7 +104,7 @@ class DevMgrIface : public PacketDispatcherIface {
 
  private:
   virtual ReturnCode port_add_(const std::string &iface_name, port_t port_num,
-                               const char *in_pcap, const char *out_pcap) = 0;
+                               const PortExtras &port_extras) = 0;
 
   virtual ReturnCode port_remove_(port_t port_num) = 0;
 
@@ -128,6 +133,7 @@ class DevMgr : public PacketDispatcherIface {
   using PortStatus = PortMonitorIface::PortStatus;
   //! @copydoc PortMonitorIface::PortStatusCb
   using PortStatusCb = PortMonitorIface::PortStatusCb;
+  using PortExtras = DevMgrIface::PortExtras;
 
   DevMgr();
 
@@ -155,7 +161,7 @@ class DevMgr : public PacketDispatcherIface {
 #endif
 
   ReturnCode port_add(const std::string &iface_name, port_t port_num,
-                      const char *in_pcap, const char *out_pcap);
+                      const PortExtras &port_extras);
 
   ReturnCode port_remove(port_t port_num);
 

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -1027,10 +1027,13 @@ public:
 
   void bm_dev_mgr_add_port(const std::string& iface_name, const int32_t port_num, const std::string& pcap_path) {
     Logger::get()->trace("bm_dev_mgr_add_port");
-    const char *pcap = NULL;
-    if(pcap_path != "") pcap = pcap_path.c_str();
+    DevMgrIface::PortExtras port_extras;
+    if (!pcap_path.empty()) {
+      port_extras.emplace(DevMgrIface::kPortExtraInPcap, pcap_path);
+      port_extras.emplace(DevMgrIface::kPortExtraOutPcap, pcap_path);
+    }
     DevMgr::ReturnCode error_code;
-    error_code = switch_->port_add(iface_name, port_num, pcap, pcap);
+    error_code = switch_->port_add(iface_name, port_num, port_extras);
     if(error_code != DevMgr::ReturnCode::SUCCESS) {
       InvalidDevMgrOperation idmo;
       idmo.code = (DevMgrErrorCode::type) 1; // TODO

--- a/src/bm_sim/dev_mgr_bmi.cpp
+++ b/src/bm_sim/dev_mgr_bmi.cpp
@@ -60,14 +60,18 @@ class BmiDevMgrImp : public DevMgrIface {
   }
 
   ReturnCode port_add_(const std::string &iface_name, port_t port_num,
-                       const char *in_pcap, const char *out_pcap) override {
+                       const PortExtras &port_extras) override {
+    auto it_in_pcap = port_extras.find(kPortExtraInPcap);
+    auto it_out_pcap = port_extras.find(kPortExtraOutPcap);
+    const char *in_pcap = (it_in_pcap == port_extras.end()) ?
+        NULL : it_in_pcap->second.c_str();
+    const char *out_pcap = (it_out_pcap == port_extras.end()) ?
+        NULL : it_out_pcap->second.c_str();
     if (bmi_port_interface_add(port_mgr, iface_name.c_str(), port_num, in_pcap,
                                out_pcap))
       return ReturnCode::ERROR;
 
-    PortInfo p_info(port_num, iface_name);
-    if (in_pcap) p_info.add_extra("in_pcap", std::string(in_pcap));
-    if (out_pcap) p_info.add_extra("out_pcap", std::string(out_pcap));
+    PortInfo p_info(port_num, iface_name, port_extras);
 
     Lock lock(mutex);
     port_info.emplace(port_num, std::move(p_info));

--- a/src/bm_sim/dev_mgr_packet_in.cpp
+++ b/src/bm_sim/dev_mgr_packet_in.cpp
@@ -63,12 +63,11 @@ class PacketInDevMgrImp : public DevMgrIface {
   }
 
   ReturnCode port_add_(const std::string &iface_name, port_t port_num,
-                       const char *in_pcap, const char *out_pcap) override {
+                       const PortExtras &port_extras) override {
     // TODO(antonin): do we want to allow this on top of IPC messages?
     (void) iface_name;
     (void) port_num;
-    (void) in_pcap;
-    (void) out_pcap;
+    (void) port_extras;
     Logger::get()->warn("When using packet in, port_add is done "
                         "through IPC messages");
     return ReturnCode::UNSUPPORTED;

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -258,24 +258,22 @@ SwitchWContexts::init_from_options_parser(
               << (parser.use_files ? " (files)" : "")
               << std::endl;
 
-    const char* inFileName = NULL;
-    const char* outFileName = NULL;
-
     std::string inFile;
     std::string outFile;
-
     if (parser.use_files) {
       inFile = iface.second + "_in.pcap";
-      inFileName = inFile.c_str();
       outFile = iface.second + "_out.pcap";
-      outFileName = outFile.c_str();
     } else if (parser.pcap) {
       inFile = iface.second + ".pcap";
-      inFileName = inFile.c_str();
-      outFileName = inFileName;
+      outFile = inFile;
     }
 
-    port_add(iface.second, iface.first, inFileName, outFileName);
+    PortExtras port_extras;
+    if (!inFile.empty())
+      port_extras.emplace(DevMgrIface::kPortExtraInPcap, inFile);
+    if (!outFile.empty())
+      port_extras.emplace(DevMgrIface::kPortExtraOutPcap, outFile);
+    port_add(iface.second, iface.first, port_extras);
   }
   thrift_port = parser.thrift_port;
 

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -96,11 +96,10 @@ class DataplaneInterfaceServiceImpl
   }
 
   ReturnCode port_add_(const std::string &iface_name, port_t port_num,
-                       const char *in_pcap, const char *out_pcap) override {
+                       const PortExtras &port_extras) override {
     _BM_UNUSED(iface_name);
     _BM_UNUSED(port_num);
-    _BM_UNUSED(in_pcap);
-    _BM_UNUSED(out_pcap);
+    _BM_UNUSED(port_extras);
     return ReturnCode::UNSUPPORTED;
   }
 

--- a/tests/test_devmgr.cpp
+++ b/tests/test_devmgr.cpp
@@ -83,10 +83,9 @@ class TestDevMgrImp : public DevMgrIface {
   }
 
   ReturnCode port_add_(const std::string &iface_name, port_t port_num,
-                       const char *in_pcap, const char *out_pcap) override {
+                       const PortExtras &port_extras) override {
     (void) iface_name;
-    (void) in_pcap;
-    (void) out_pcap;
+    (void) port_extras;
     std::lock_guard<std::mutex> lock(status_mutex);
     auto it = port_status.find(port_num);
     if (it != port_status.end()) return ReturnCode::ERROR;
@@ -169,7 +168,7 @@ TEST_F(DevMgrTest, cb_test) {
   register_callback();
 
   for (unsigned int i = 0; i < NPORTS; i++) {
-    g_mgr->port_add("dummyport", i, nullptr, nullptr);
+    g_mgr->port_add("dummyport", i, {});
   }
   std::this_thread::sleep_for(std::chrono::seconds(2));
   ASSERT_EQ(NPORTS, get_count(DevMgrIface::PortStatus::PORT_ADDED))

--- a/tests/test_switch.cpp
+++ b/tests/test_switch.cpp
@@ -78,7 +78,7 @@ class MyDevMgr : public DevMgrIface {
     return {{99, PortInfo(99, "dummy_port")}};
   }
   ReturnCode port_add_(const std::string &, port_t,
-                       const char *, const char *) override {
+                       const PortExtras &) override {
     return ReturnCode::SUCCESS;
   }
   ReturnCode port_remove_(port_t) override { return ReturnCode::SUCCESS; }


### PR DESCRIPTION
Different implementations of DevMgr can rely on different keys being
present when a port is added. "in_pcap" and "out_pcap" are now just
keys in this map.