### PR TITLE
Add bm_register_read_all to Thrift interface

### DIFF
--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -363,6 +363,9 @@ class Context final {
   register_read(const std::string &register_name,
                 const size_t idx, Data *value);
 
+  std::vector<Data>
+  register_read_all(const std::string &register_name);
+
   RegisterErrorCode
   register_write(const std::string &register_name,
                  const size_t idx, Data value);

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -334,6 +334,9 @@ class RuntimeInterface {
                 const std::string &register_name,
                 const size_t idx, Data *value) = 0;
 
+  virtual std::vector<Data>
+  register_read_all(size_t cxt_id, const std::string &register_name) = 0;
+
   virtual RegisterErrorCode
   register_write(size_t cxt_id,
                  const std::string &register_name,

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -719,6 +719,11 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).register_read(register_name, idx, value);
   }
 
+  std::vector<Data>
+  register_read_all(size_t cxt_id, const std::string &register_name) override {
+    return contexts.at(cxt_id).register_read_all(register_name);
+  }
+
   RegisterErrorCode
   register_write(size_t cxt_id,
                  const std::string &register_name,

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -969,6 +969,18 @@ public:
     return value.get<int64_t>();
   }
 
+  void bm_register_read_all(std::vector<BmRegisterValue> & _return, const int32_t cxt_id, const std::string& register_array_name) {
+    Logger::get()->trace("bm_register_read_all");
+    auto entries = switch_->register_read_all(cxt_id, register_array_name);
+    if (entries.empty()) {
+      InvalidRegisterOperation iro;
+      iro.code = RegisterOperationErrorCode::INVALID_REGISTER_NAME;
+      throw iro;
+    }
+    for (const auto &entry : entries)
+      _return.push_back(entry.get<BmRegisterValue>());
+  }
+
   void bm_register_write(const int32_t cxt_id, const std::string& register_array_name, const int32_t index, const BmRegisterValue value) {
     Logger::get()->trace("bm_register_write");
     Register::RegisterErrorCode error_code = switch_->register_write(

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -574,6 +574,18 @@ Context::register_read(const std::string &register_name,
   return Register::SUCCESS;
 }
 
+std::vector<Data>
+Context::register_read_all(const std::string &register_name) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  auto register_array = p4objects_rt->get_register_array_rt(register_name);
+  if (!register_array) return {};
+  auto register_lock = register_array->unique_lock();
+  std::vector<Data> entries;
+  entries.reserve(register_array->size());
+  for (const auto &reg : *register_array) entries.push_back(reg);
+  return entries;
+}
+
 Context::RegisterErrorCode
 Context::register_write(const std::string &register_name,
                         const size_t idx, Data value) {

--- a/targets/simple_switch/tests/CLI_tests/testdata/indirect_res.out
+++ b/targets/simple_switch/tests/CLI_tests/testdata/indirect_res.out
@@ -11,7 +11,7 @@ Invalid meter operation (INVALID_INFO_RATE_VALUE)
 0: info rate = 1.0, burst size = 1
 1: info rate = 2.0, burst size = 1
 ????
-my_register[0]=  0
+my_register[0]= 0
 ????
 Invalid register operation (INVALID_INDEX)
 ????

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -620,6 +620,11 @@ service Standard {
     3:i32 idx
   ) throws (1:InvalidRegisterOperation ouch)
 
+  list<BmRegisterValue> bm_register_read_all(
+    1:i32 cxt_id,
+    2:string register_array_name
+  ) throws (1:InvalidRegisterOperation ouch)
+
   void bm_register_write(
     1:i32 cxt_id,
     2:string register_array_name,

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1826,18 +1826,25 @@ class RuntimeAPI(cmd.Cmd):
 
     @handle_bad_input
     def do_register_read(self, line):
-        "Read register value: register_read <name> <index>"
+        "Read register value: register_read <name> [index]"
         args = line.split()
-        self.exactly_n_args(args, 2)
+        self.at_least_n_args(args, 1)
         register_name = args[0]
         register = self.get_res("register", register_name, REGISTER_ARRAYS)
-        index = args[1]
-        try:
-            index = int(index)
-        except:
-            raise UIn_Error("Bad format for index")
-        value = self.client.bm_register_read(0, register_name, index)
-        print "%s[%d]= " % (register_name, index), value
+        if len(args) > 1:
+            self.exactly_n_args(args, 2)
+            index = args[1]
+            try:
+                index = int(index)
+            except:
+                raise UIn_Error("Bad format for index")
+            value = self.client.bm_register_read(0, register_name, index)
+            print "{}[{}]=".format(register_name, index), value
+        else:
+            sys.stderr.write("register index omitted, reading entire array\n")
+            entries = self.client.bm_register_read_all(0, register_name)
+            print "{}=".format(register_name), ", ".join(
+                [str(e) for e in entries])
 
     def complete_register_read(self, text, line, start_index, end_index):
         return self._complete_registers(text)


### PR DESCRIPTION
To read all register cells in one row. Also, modified the register_read
runtime CLI command to make the index optional. If the index is omitted,
the entire register array will be read and displayed in stdout.