### PR TITLE
Give error for duplicate ports or LAGs in simple_switch_CLI commands

### DIFF
--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1510,6 +1510,9 @@ class RuntimeAPI(cmd.Cmd):
             except:
                 raise UIn_Error("'%s' is not a valid %s number"
                                 "" % (port_num_str, description))
+            if port_num < 0:
+                raise UIn_Error("'%s' is not a valid %s number"
+                                "" % (port_num_str, description))
             ports_int.append(port_num)
         ports_int.sort()
         for port_num in ports_int:

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1500,7 +1500,7 @@ class RuntimeAPI(cmd.Cmd):
         print "Destroying multicast group", mgrp
         self.mc_client.bm_mc_mgrp_destroy(0, mgrp)
 
-    def ports_to_port_map_str(self, ports):
+    def ports_to_port_map_str(self, ports, description="port"):
         last_port_num = 0
         port_map_str = ""
         ports_int = []
@@ -1508,10 +1508,14 @@ class RuntimeAPI(cmd.Cmd):
             try:
                 port_num = int(port_num_str)
             except:
-                raise UIn_Error("'%s' is not a valid port number" % port_num_str)
+                raise UIn_Error("'%s' is not a valid %s number"
+                                "" % (port_num_str, description))
             ports_int.append(port_num)
         ports_int.sort()
         for port_num in ports_int:
+            if port_num == (last_port_num - 1):
+                raise UIn_Error("Found duplicate %s number '%s'"
+                                "" % (description, port_num))
             port_map_str += "0" * (port_num - last_port_num) + "1"
             last_port_num = port_num + 1
         return port_map_str[::-1]
@@ -1526,7 +1530,7 @@ class RuntimeAPI(cmd.Cmd):
         if self.pre_type == PreType.SimplePreLAG:
             i += 1
             lags = [] if i == len(args) else args[i:]
-            lag_map_str = self.ports_to_port_map_str(lags)
+            lag_map_str = self.ports_to_port_map_str(lags, description="lag")
         else:
             lag_map_str = None
         return port_map_str, lag_map_str
@@ -1618,7 +1622,7 @@ class RuntimeAPI(cmd.Cmd):
             lag_index = int(args[0])
         except:
             raise UIn_Error("Bad format for lag index")
-        port_map_str = self.ports_to_port_map_str(args[1:])
+        port_map_str = self.ports_to_port_map_str(args[1:], description="lag")
         print "Setting lag membership:", lag_index, "<-", port_map_str
         self.mc_client.bm_mc_set_lag_membership(0, lag_index, port_map_str)
 


### PR DESCRIPTION
Also make error message say 'lag' instead of 'port' if that is what
the error message is about.

Before this change, if you give duplicate port numbers or lags, the "bit vector string" created and passed to simple_switch process is incorrect.