### PR TITLE
Fix simple_switch_grpc build after PI update

### DIFF
--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -30,7 +30,7 @@ test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp
 LDADD = \
 $(top_builddir)/libsimple_switch_grpc.la \
 $(top_builddir)/../simple_switch/libsimpleswitch.la \
--lpiproto \
+-lpiprotogrpc -lpiprotobuf \
 $(PROTOBUF_LIBS) $(GRPC_LIBS) \
 $(top_builddir)/../../third_party/gtest/libgtest.la
 


### PR DESCRIPTION
lpiproto doesn't exist anymore, it has been replaced with lpiprotogrpc
which does not include protobuf symbols to avoid clashes with
lpiprotobuf