### PR TITLE
Dissociate checksum verification and update

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -10,7 +10,7 @@ on each attribute.
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.13*.
+The version described in this document is *2.14*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -654,10 +654,14 @@ the following attributes:
 - `target`: the field where the checksum result is written
 - `type`: always set to `generic`
 - `calculation`: the name of the calculation to use to compute the checksum
-- `if_cond`: null if the checksum needs to be updated unconditionally, otherwise
-a boolean expression, which will determine whether or not the checksum gets
-updated. See [here](#the-type-value-object) for more information on expressions
-format.
+- `update`: an optional boolean value, which defaults to `true`; indicates
+whether the checksum needs to be updated in deparsers.
+- `verify`: an optional boolean value, which defaults to `true`; indicates
+whether the checksum needs to be verified in parsers.
+- `if_cond`: null if the checksum needs to be verified and / or updated
+unconditionally, otherwise a boolean expression, which will determine whether or
+not the checksum gets verified and / or updated. See
+[here](#the-type-value-object) for more information on expressions format.
 
 ### `learn_lists`
 

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1877,6 +1877,10 @@ P4Objects::init_checksums(const Json::Value &cfg_root) {
                                        header_id, field_offset, calculation);
     }
 
+    const Json::Value true_value(true);
+    const auto do_update = cfg_checksum.get("update", true_value).asBool();
+    const auto do_verify = cfg_checksum.get("verify", true_value).asBool();
+
     if (cfg_checksum.isMember("if_cond") && !cfg_checksum["if_cond"].isNull()) {
       auto cksum_condition = std::unique_ptr<Expression>(new Expression());
       build_expression(cfg_checksum["if_cond"], cksum_condition.get());
@@ -1886,12 +1890,16 @@ P4Objects::init_checksums(const Json::Value &cfg_root) {
 
     checksums.push_back(unique_ptr<Checksum>(checksum));
 
-    for (auto it = deparsers.begin(); it != deparsers.end(); ++it) {
-      it->second->add_checksum(checksum);
+    if (do_update) {
+      for (auto it = deparsers.begin(); it != deparsers.end(); ++it) {
+        it->second->add_checksum(checksum);
+      }
     }
 
-    for (auto it = parsers.begin(); it != parsers.end(); ++it) {
-      it->second->add_checksum(checksum);
+    if (do_verify) {
+      for (auto it = parsers.begin(); it != parsers.end(); ++it) {
+        it->second->add_checksum(checksum);
+      }
     }
   }
 }


### PR DESCRIPTION
One can now have checksums that are just verified (in all parsers),
checksums that are just updated (in all deparsers) and checksums that
are both verified and updated. This can be specified in the JSON using
the new 'update' and 'verify' attributes for checksums.

This change is backward-compatible.

The JSON documentation was updated to reflect this change, and the
version number was bumped up to 2.14.