### PR TITLE
Support 64-bit device id

### DIFF
--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -287,7 +287,7 @@ void build_action_entry<bm::MatchTableIndirectWS::Entry>(
 
 template <typename M,
           bm::MatchErrorCode (bm::RuntimeInterface::*GetFn)(
-              size_t, const std::string &, typename M::Entry *) const>
+              bm::cxt_id_t, const std::string &, typename M::Entry *) const>
 typename M::Entry get_default_entry_common(
     const pi_p4info_t *p4info, const std::string &t_name,
     pi_table_entry_t *table_entry) {
@@ -388,7 +388,7 @@ void build_action_entry_2<bm::MatchTableIndirectWS::Entry>(
 template <
   typename M,
   typename std::vector<typename M::Entry> (bm::RuntimeInterface::*GetFn)(
-      size_t, const std::string &) const>
+      bm::cxt_id_t, const std::string &) const>
 void get_entries_common(const pi_p4info_t *p4info, pi_p4_id_t table_id,
                         pi_table_fetch_res_t *res) {
   std::string t_name(pi_p4info_table_name_from_id(p4info, table_id));
@@ -502,7 +502,7 @@ void set_direct_resources(const pi_p4info_t *p4info, pi_dev_id_t dev_id,
 
 template <typename M,
           bm::MatchErrorCode (bm::RuntimeInterface::*GetFn)(
-              size_t, const std::string &,
+              bm::cxt_id_t, const std::string &,
               const std::vector<bm::MatchKeyParam> &,
               typename M::Entry *, int) const>
 pi_entry_handle_t get_entry_handle_from_key_common(

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -36,6 +36,7 @@ bm/bm_sim/data.h \
 bm/bm_sim/debugger.h \
 bm/bm_sim/deparser.h \
 bm/bm_sim/dev_mgr.h \
+bm/bm_sim/device_id.h \
 bm/bm_sim/entries.h \
 bm/bm_sim/enums.h \
 bm/bm_sim/event_logger.h \

--- a/include/bm/bm_apps/learn.h
+++ b/include/bm/bm_apps/learn.h
@@ -42,8 +42,8 @@ namespace bm_apps {
 class LearnListener {
  public:
   using buffer_id_t = uint64_t;
-  using switch_id_t = int;
-  using cxt_id_t = int;
+  using switch_id_t = uint64_t;
+  using cxt_id_t = uint32_t;
   using list_id_t = int;
 
   struct MsgInfo {

--- a/include/bm/bm_apps/notifications.h
+++ b/include/bm/bm_apps/notifications.h
@@ -37,8 +37,8 @@ class NotificationsListenerImp;
 class NotificationsListener {
  public:
   using buffer_id_t = uint64_t;
-  using switch_id_t = int;
-  using cxt_id_t = int;
+  using switch_id_t = uint64_t;
+  using cxt_id_t = uint32_t;
   using list_id_t = int;
   using table_id_t = int;
 

--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -48,6 +48,7 @@
 #include "extern.h"
 #include "enums.h"
 #include "control_action.h"
+#include "device_id.h"
 
 // forward declaration of Json::Value
 namespace Json {
@@ -102,7 +103,7 @@ class P4Objects {
 
   int init_objects(std::istream *is,
                    LookupStructureFactory *lookup_factory,
-                   int device_id = 0, size_t cxt_id = 0,
+                   device_id_t device_id = 0, cxt_id_t cxt_id = 0,
                    std::shared_ptr<TransportIface> transport = nullptr,
                    const std::set<header_field_pair> &required_fields =
                      std::set<header_field_pair>(),

--- a/include/bm/bm_sim/ageing.h
+++ b/include/bm/bm_sim/ageing.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 
+#include "device_id.h"
 #include "transport.h"
 
 namespace bm {
@@ -31,14 +32,14 @@ class MatchTableAbstract;
 
 class AgeingMonitorIface {
  public:
+  // the header size for notifications is always 32 bytes
   struct msg_hdr_t {
     char sub_topic[4];
-    int switch_id;
-    int cxt_id;
+    s_device_id_t switch_id;
+    s_cxt_id_t cxt_id;
     uint64_t buffer_id;
     int table_id;
     unsigned int num_entries;
-    char _padding[4];  // the header size for notifications is always 32 bytes
   } __attribute__((packed));
 
   virtual ~AgeingMonitorIface() { }
@@ -50,7 +51,8 @@ class AgeingMonitorIface {
   virtual void reset_state() = 0;
 
   static std::unique_ptr<AgeingMonitorIface> make(
-      int device_id, int cxt_id, std::shared_ptr<TransportIface> writer,
+      device_id_t device_id, cxt_id_t cxt_id,
+      std::shared_ptr<TransportIface> writer,
       unsigned int sweep_interval_ms = 1000u);
 };
 

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -62,6 +62,7 @@
 #include "match_tables.h"
 #include "runtime_interface.h"
 #include "lookup_structures.h"
+#include "device_id.h"
 
 namespace bm {
 
@@ -422,9 +423,9 @@ class Context final {
 
   void set_notifications_transport(std::shared_ptr<TransportIface> transport);
 
-  void set_device_id(int device_id);
+  void set_device_id(device_id_t device_id);
 
-  void set_cxt_id(int cxt_id);
+  void set_cxt_id(cxt_id_t cxt_id);
 
   void set_force_arith(bool force_arith);
 
@@ -463,9 +464,9 @@ class Context final {
   ErrorCodeMap get_error_codes() const;
 
  private:  // data members
-  size_t cxt_id{};
+  cxt_id_t cxt_id{};
 
-  int device_id{0};
+  device_id_t device_id{0};
 
   std::shared_ptr<P4Objects> p4objects{nullptr};
   std::shared_ptr<P4Objects> p4objects_rt{nullptr};

--- a/include/bm/bm_sim/debugger.h
+++ b/include/bm/bm_sim/debugger.h
@@ -28,6 +28,9 @@
 
 namespace bm {
 
+using device_id_t = uint64_t;
+using s_device_id_t = device_id_t;
+
 /* This whole code if for a proof of concept and is temporary */
 
 // forward declaration
@@ -70,7 +73,7 @@ class Debugger {
     }
   };
 
-  static void init_debugger(const std::string &addr);
+  static void init_debugger(const std::string &addr, device_id_t device_id);
 
   static DebuggerIface *get() {
     return debugger;

--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -143,7 +143,7 @@ class DevMgr : public PacketDispatcherIface {
   void set_dev_mgr(std::unique_ptr<DevMgrIface> my_pimp);
 
   void set_dev_mgr_bmi(
-      int device_id,
+      device_id_t device_id,
       std::shared_ptr<TransportIface> notifications_transport = nullptr);
 
   // The interface names are instead interpreted as file names.
@@ -155,7 +155,7 @@ class DevMgr : public PacketDispatcherIface {
   // if enforce ports is set to true, packets coming in on un-registered ports
   // are dropped
   void set_dev_mgr_packet_in(
-      int device_id, const std::string &addr,
+      device_id_t device_id, const std::string &addr,
       std::shared_ptr<TransportIface> notifications_transport = nullptr,
       bool enforce_ports = false);
 #endif

--- a/include/bm/bm_sim/device_id.h
+++ b/include/bm/bm_sim/device_id.h
@@ -1,0 +1,34 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef BM_BM_SIM_DEVICE_ID_H_
+#define BM_BM_SIM_DEVICE_ID_H_
+
+namespace bm {
+
+// s_* for serialized value format (e.g. notifications)
+using device_id_t = uint64_t;
+using s_device_id_t = device_id_t;
+using cxt_id_t = uint32_t;
+using s_cxt_id_t = cxt_id_t;
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_DEVICE_ID_H_

--- a/include/bm/bm_sim/event_logger.h
+++ b/include/bm/bm_sim/event_logger.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <memory>
 
+#include "device_id.h"
 #include "phv_forward.h"
 #include "transport.h"
 
@@ -65,7 +66,7 @@ using entry_handle_t = uint32_t;
 class EventLogger {
  public:
   explicit EventLogger(std::unique_ptr<TransportIface> transport,
-                       int device_id = 0)
+                       device_id_t device_id = 0)
       : transport_instance(std::move(transport)), device_id(device_id) { }
 
   // we need the ingress / egress ports, but they are part of the Packet
@@ -104,14 +105,14 @@ class EventLogger {
   }
 
   static void init(std::unique_ptr<TransportIface> transport,
-                   int device_id = 0) {
+                   device_id_t device_id = 0) {
     get()->transport_instance = std::move(transport);
     get()->device_id = device_id;
   }
 
  private:
   std::unique_ptr<TransportIface> transport_instance{nullptr};
-  int device_id{};
+  device_id_t device_id{};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/learning.h
+++ b/include/bm/bm_sim/learning.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <functional>
 
+#include "device_id.h"
 #include "transport.h"
 #include "phv_forward.h"
 
@@ -51,14 +52,14 @@ class LearnEngineIface {
     ERROR
   };
 
+  // the header size for notifications is always 32 bytes
   struct msg_hdr_t {
     char sub_topic[4];
-    int switch_id;
-    int cxt_id;
+    s_device_id_t switch_id;
+    s_cxt_id_t cxt_id;
     int list_id;
     uint64_t buffer_id;
     unsigned int num_samples;
-    char _padding[4];  // the header size for notifications is always 32 bytes
   } __attribute__((packed));
 
   using LearnCb = std::function<void(const msg_hdr_t &, size_t,
@@ -107,8 +108,8 @@ class LearnEngineIface {
 
   virtual void reset_state() = 0;
 
-  static std::unique_ptr<LearnEngineIface> make(int device_id = 0,
-                                                int cxt_id = 0);
+  static std::unique_ptr<LearnEngineIface> make(device_id_t device_id = 0,
+                                                cxt_id_t cxt_id = 0);
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <map>
 
+#include "device_id.h"
 #include "logger.h"
 #include "target_parser.h"
 
@@ -64,7 +65,7 @@ class OptionsParser {
   InterfaceList ifaces{};
   bool pcap{false};
   int thrift_port{0};
-  int device_id{};
+  device_id_t device_id{};
   // if true read/write packets from files instead of interfaces
   bool use_files{false};
   // time to wait (in seconds) before starting packet processing

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -35,6 +35,7 @@
 
 #include <cassert>
 
+#include "device_id.h"
 #include "packet_buffer.h"
 #include "parser_error.h"
 #include "phv_source.h"
@@ -266,10 +267,10 @@ class Packet final {
   //! if `new_cxt == cxt_id`, then this is a no-op,
   //! otherwise, release the old PHV and replace it with a new one, compatible
   //! with the new context
-  void change_context(size_t new_cxt);
+  void change_context(cxt_id_t new_cxt);
 
   //! Returns the id of the Context this packet currently belongs to
-  size_t get_context() const { return cxt_id; }
+  cxt_id_t get_context() const { return cxt_id; }
 
   // the *_ptr function are just here for convenience, the same can be achieved
   // by the client by constructing a unique_ptr
@@ -296,9 +297,9 @@ class Packet final {
   //! Same as clone_no_phv(), but also changes the context id for the clone.
   //! See change_context() for more information on how a Packet instance belongs
   //! to a specific Context
-  Packet clone_choose_context(size_t new_cxt) const;
+  Packet clone_choose_context(cxt_id_t new_cxt) const;
   //! @copydoc clone_choose_context
-  std::unique_ptr<Packet> clone_choose_context_ptr(size_t new_cxt) const;
+  std::unique_ptr<Packet> clone_choose_context_ptr(cxt_id_t new_cxt) const;
 
   //! Deleted copy constructor
   Packet(const Packet &other) = delete;
@@ -317,20 +318,20 @@ class Packet final {
   // NOLINTNEXTLINE(whitespace/operators)
   static Packet make_new(int ingress_length, PacketBuffer &&buffer,
                          PHVSourceIface *phv_source);
-  static Packet make_new(size_t cxt, int ingress_port, packet_id_t id,
+  static Packet make_new(cxt_id_t cxt, int ingress_port, packet_id_t id,
                          copy_id_t copy_id, int ingress_length,
                          // cpplint false positive
                          // NOLINTNEXTLINE(whitespace/operators)
                          PacketBuffer &&buffer, PHVSourceIface *phv_source);
 
  private:
-  Packet(size_t cxt, int ingress_port, packet_id_t id, copy_id_t copy_id,
+  Packet(cxt_id_t cxt, int ingress_port, packet_id_t id, copy_id_t copy_id,
          int ingress_length, PacketBuffer &&buffer, PHVSourceIface *phv_source);
 
   void update_signature(uint64_t seed = 0);
   void set_ingress_ts();
 
-  size_t cxt_id{0};
+  cxt_id_t cxt_id{0};
   int ingress_port{-1};
   int egress_port{-1};
   packet_id_t packet_id{0};

--- a/include/bm/bm_sim/phv_source.h
+++ b/include/bm/bm_sim/phv_source.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 
+#include "device_id.h"
 #include "phv_forward.h"
 
 namespace bm {
@@ -31,24 +32,24 @@ class PHVSourceIface {
  public:
   virtual ~PHVSourceIface() { }
 
-  std::unique_ptr<PHV> get(size_t cxt);
+  std::unique_ptr<PHV> get(cxt_id_t cxt);
 
-  void release(size_t cxt, std::unique_ptr<PHV> phv);
+  void release(cxt_id_t cxt, std::unique_ptr<PHV> phv);
 
-  void set_phv_factory(size_t cxt, const PHVFactory *factory);
+  void set_phv_factory(cxt_id_t cxt, const PHVFactory *factory);
 
-  size_t phvs_in_use(size_t cxt);
+  size_t phvs_in_use(cxt_id_t cxt);
 
   static std::unique_ptr<PHVSourceIface> make_phv_source(size_t size = 1);
 
  private:
-  virtual std::unique_ptr<PHV> get_(size_t cxt) = 0;
+  virtual std::unique_ptr<PHV> get_(cxt_id_t cxt) = 0;
 
-  virtual void release_(size_t cxt, std::unique_ptr<PHV> phv) = 0;
+  virtual void release_(cxt_id_t cxt, std::unique_ptr<PHV> phv) = 0;
 
-  virtual void set_phv_factory_(size_t cxt, const PHVFactory *factory) = 0;
+  virtual void set_phv_factory_(cxt_id_t cxt, const PHVFactory *factory) = 0;
 
-  virtual size_t phvs_in_use_(size_t cxt) = 0;
+  virtual size_t phvs_in_use_(cxt_id_t cxt) = 0;
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/port_monitor.h
+++ b/include/bm/bm_sim/port_monitor.h
@@ -27,6 +27,8 @@
 #include <functional>
 #include <memory>
 
+#include "device_id.h"
+
 namespace bm {
 
 class TransportIface;
@@ -49,9 +51,9 @@ class PortMonitorIface {
   // putting it in TransportIface so that it is visible (e.g. for tests)
   struct msg_hdr_t {
     char sub_topic[4];
-    int switch_id;
+    s_device_id_t switch_id;
     unsigned int num_statuses;
-    char _padding[20];  // the header size for notifications is always 32 bytes
+    char _padding[16];  // the header size for notifications is always 32 bytes
   } __attribute__((packed));
 
   struct one_status_t {
@@ -81,12 +83,12 @@ class PortMonitorIface {
   static std::unique_ptr<PortMonitorIface> make_dummy();
   // a passive monitor does not periodically query the port status
   static std::unique_ptr<PortMonitorIface> make_passive(
-      int device_id,
+      device_id_t device_id,
       std::shared_ptr<TransportIface> notifications_writer = nullptr);
   // an active monitor periodically queries the port status (using separate
   // thread)
   static std::unique_ptr<PortMonitorIface> make_active(
-      int device_id,
+      device_id_t device_id,
       std::shared_ptr<TransportIface> notifications_writer = nullptr);
 
  private:

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -27,6 +27,7 @@
 
 #include "action_profile.h"
 #include "match_tables.h"
+#include "device_id.h"
 
 namespace bm {
 
@@ -51,19 +52,19 @@ class RuntimeInterface {
   // common to all tables
 
   virtual MatchErrorCode
-  mt_get_num_entries(size_t cxt_id,
+  mt_get_num_entries(cxt_id_t cxt_id,
                      const std::string &table_name,
                      size_t *num_entries) const = 0;
 
   virtual MatchErrorCode
-  mt_clear_entries(size_t cxt_id,
+  mt_clear_entries(cxt_id_t cxt_id,
                    const std::string &table_name,
                    bool reset_default_entry) = 0;
 
   // direct tables
 
   virtual MatchErrorCode
-  mt_add_entry(size_t cxt_id,
+  mt_add_entry(cxt_id_t cxt_id,
                const std::string &table_name,
                const std::vector<MatchKeyParam> &match_key,
                const std::string &action_name,
@@ -72,25 +73,25 @@ class RuntimeInterface {
                int priority = -1  /*only used for ternary*/) = 0;
 
   virtual MatchErrorCode
-  mt_set_default_action(size_t cxt_id,
+  mt_set_default_action(cxt_id_t cxt_id,
                         const std::string &table_name,
                         const std::string &action_name,
                         ActionData action_data) = 0;
 
   virtual MatchErrorCode
-  mt_delete_entry(size_t cxt_id,
+  mt_delete_entry(cxt_id_t cxt_id,
                   const std::string &table_name,
                   entry_handle_t handle) = 0;
 
   virtual MatchErrorCode
-  mt_modify_entry(size_t cxt_id,
+  mt_modify_entry(cxt_id_t cxt_id,
                   const std::string &table_name,
                   entry_handle_t handle,
                   const std::string &action_name,
                   ActionData action_data) = 0;
 
   virtual MatchErrorCode
-  mt_set_entry_ttl(size_t cxt_id,
+  mt_set_entry_ttl(cxt_id_t cxt_id,
                    const std::string &table_name,
                    entry_handle_t handle,
                    unsigned int ttl_ms) = 0;
@@ -98,66 +99,66 @@ class RuntimeInterface {
   // action profiles
 
   virtual MatchErrorCode
-  mt_act_prof_add_member(size_t cxt_id,
+  mt_act_prof_add_member(cxt_id_t cxt_id,
                          const std::string &act_prof_name,
                          const std::string &action_name,
                          ActionData action_data,
                          mbr_hdl_t *mbr) = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_delete_member(size_t cxt_id,
+  mt_act_prof_delete_member(cxt_id_t cxt_id,
                             const std::string &act_prof_name,
                             mbr_hdl_t mbr) = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_modify_member(size_t cxt_id,
+  mt_act_prof_modify_member(cxt_id_t cxt_id,
                             const std::string &act_prof_name,
                             mbr_hdl_t mbr,
                             const std::string &action_name,
                             ActionData action_data) = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_create_group(size_t cxt_id,
+  mt_act_prof_create_group(cxt_id_t cxt_id,
                            const std::string &act_prof_name,
                            grp_hdl_t *grp) = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_delete_group(size_t cxt_id,
+  mt_act_prof_delete_group(cxt_id_t cxt_id,
                            const std::string &act_prof_name,
                            grp_hdl_t grp) = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_add_member_to_group(size_t cxt_id,
+  mt_act_prof_add_member_to_group(cxt_id_t cxt_id,
                                   const std::string &act_prof_name,
                                   mbr_hdl_t mbr, grp_hdl_t grp) = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_remove_member_from_group(size_t cxt_id,
+  mt_act_prof_remove_member_from_group(cxt_id_t cxt_id,
                                        const std::string &act_prof_name,
                                        mbr_hdl_t mbr, grp_hdl_t grp) = 0;
 
   virtual std::vector<ActionProfile::Member>
-  mt_act_prof_get_members(size_t cxt_id,
+  mt_act_prof_get_members(cxt_id_t cxt_id,
                           const std::string &act_prof_name) const = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_get_member(size_t cxt_id, const std::string &act_prof_name,
+  mt_act_prof_get_member(cxt_id_t cxt_id, const std::string &act_prof_name,
                          mbr_hdl_t mbr,
                          ActionProfile::Member *member) const = 0;
 
   virtual std::vector<ActionProfile::Group>
-  mt_act_prof_get_groups(size_t cxt_id,
+  mt_act_prof_get_groups(cxt_id_t cxt_id,
                          const std::string &act_prof_name) const = 0;
 
   virtual MatchErrorCode
-  mt_act_prof_get_group(size_t cxt_id, const std::string &act_prof_name,
+  mt_act_prof_get_group(cxt_id_t cxt_id, const std::string &act_prof_name,
                         grp_hdl_t grp,
                         ActionProfile::Group *group) const = 0;
 
   // indirect tables
 
   virtual MatchErrorCode
-  mt_indirect_add_entry(size_t cxt_id,
+  mt_indirect_add_entry(cxt_id_t cxt_id,
                         const std::string &table_name,
                         const std::vector<MatchKeyParam> &match_key,
                         mbr_hdl_t mbr,
@@ -165,29 +166,29 @@ class RuntimeInterface {
                         int priority = 1) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_modify_entry(size_t cxt_id,
+  mt_indirect_modify_entry(cxt_id_t cxt_id,
                            const std::string &table_name,
                            entry_handle_t handle,
                            mbr_hdl_t mbr) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_delete_entry(size_t cxt_id,
+  mt_indirect_delete_entry(cxt_id_t cxt_id,
                            const std::string &table_name,
                            entry_handle_t handle) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_set_entry_ttl(size_t cxt_id,
+  mt_indirect_set_entry_ttl(cxt_id_t cxt_id,
                             const std::string &table_name,
                             entry_handle_t handle,
                             unsigned int ttl_ms) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_set_default_member(size_t cxt_id,
+  mt_indirect_set_default_member(cxt_id_t cxt_id,
                                  const std::string &table_name,
                                  mbr_hdl_t mbr) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_ws_add_entry(size_t cxt_id,
+  mt_indirect_ws_add_entry(cxt_id_t cxt_id,
                            const std::string &table_name,
                            const std::vector<MatchKeyParam> &match_key,
                            grp_hdl_t grp,
@@ -195,119 +196,119 @@ class RuntimeInterface {
                            int priority = 1) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_ws_modify_entry(size_t cxt_id,
+  mt_indirect_ws_modify_entry(cxt_id_t cxt_id,
                               const std::string &table_name,
                               entry_handle_t handle,
                               grp_hdl_t grp) = 0;
 
   virtual MatchErrorCode
-  mt_indirect_ws_set_default_group(size_t cxt_id,
+  mt_indirect_ws_set_default_group(cxt_id_t cxt_id,
                                    const std::string &table_name,
                                    grp_hdl_t grp) = 0;
 
 
   virtual MatchErrorCode
-  mt_read_counters(size_t cxt_id,
+  mt_read_counters(cxt_id_t cxt_id,
                    const std::string &table_name,
                    entry_handle_t handle,
                    MatchTableAbstract::counter_value_t *bytes,
                    MatchTableAbstract::counter_value_t *packets) = 0;
 
   virtual MatchErrorCode
-  mt_reset_counters(size_t cxt_id,
+  mt_reset_counters(cxt_id_t cxt_id,
                     const std::string &table_name) = 0;
 
   virtual MatchErrorCode
-  mt_write_counters(size_t cxt_id,
+  mt_write_counters(cxt_id_t cxt_id,
                     const std::string &table_name,
                     entry_handle_t handle,
                     MatchTableAbstract::counter_value_t bytes,
                     MatchTableAbstract::counter_value_t packets) = 0;
 
   virtual MatchErrorCode
-  mt_set_meter_rates(size_t cxt_id,
+  mt_set_meter_rates(cxt_id_t cxt_id,
                      const std::string &table_name,
                      entry_handle_t handle,
                      const std::vector<Meter::rate_config_t> &configs) = 0;
 
   virtual MatchErrorCode
-  mt_get_meter_rates(size_t cxt_id,
+  mt_get_meter_rates(cxt_id_t cxt_id,
                      const std::string &table_name,
                      entry_handle_t handle,
                      std::vector<Meter::rate_config_t> *configs) = 0;
 
   virtual MatchTableType
-  mt_get_type(size_t cxt_id, const std::string &table_name) const = 0;
+  mt_get_type(cxt_id_t cxt_id, const std::string &table_name) const = 0;
 
   virtual std::vector<MatchTable::Entry>
-  mt_get_entries(size_t cxt_id, const std::string &table_name) const = 0;
+  mt_get_entries(cxt_id_t cxt_id, const std::string &table_name) const = 0;
 
   virtual std::vector<MatchTableIndirect::Entry>
-  mt_indirect_get_entries(size_t cxt_id,
+  mt_indirect_get_entries(cxt_id_t cxt_id,
                           const std::string &table_name) const = 0;
 
   virtual std::vector<MatchTableIndirectWS::Entry>
-  mt_indirect_ws_get_entries(size_t cxt_id,
+  mt_indirect_ws_get_entries(cxt_id_t cxt_id,
                              const std::string &table_name) const = 0;
 
   virtual MatchErrorCode
-  mt_get_entry(size_t cxt_id, const std::string &table_name,
+  mt_get_entry(cxt_id_t cxt_id, const std::string &table_name,
                entry_handle_t handle, MatchTable::Entry *entry) const = 0;
 
   virtual MatchErrorCode
-  mt_indirect_get_entry(size_t cxt_id, const std::string &table_name,
+  mt_indirect_get_entry(cxt_id_t cxt_id, const std::string &table_name,
                         entry_handle_t handle,
                         MatchTableIndirect::Entry *entry) const = 0;
 
   virtual MatchErrorCode
-  mt_indirect_ws_get_entry(size_t cxt_id, const std::string &table_name,
+  mt_indirect_ws_get_entry(cxt_id_t cxt_id, const std::string &table_name,
                            entry_handle_t handle,
                            MatchTableIndirectWS::Entry *entry) const = 0;
 
   virtual MatchErrorCode
-  mt_get_default_entry(size_t cxt_id, const std::string &table_name,
+  mt_get_default_entry(cxt_id_t cxt_id, const std::string &table_name,
                        MatchTable::Entry *entry) const = 0;
 
   virtual MatchErrorCode
-  mt_indirect_get_default_entry(size_t cxt_id, const std::string &table_name,
+  mt_indirect_get_default_entry(cxt_id_t cxt_id, const std::string &table_name,
                                 MatchTableIndirect::Entry *entry) const = 0;
 
   virtual MatchErrorCode
   mt_indirect_ws_get_default_entry(
-      size_t cxt_id, const std::string &table_name,
+      cxt_id_t cxt_id, const std::string &table_name,
       MatchTableIndirectWS::Entry *entry) const = 0;
 
   virtual MatchErrorCode
-  mt_get_entry_from_key(size_t cxt_id, const std::string &table_name,
+  mt_get_entry_from_key(cxt_id_t cxt_id, const std::string &table_name,
                         const std::vector<MatchKeyParam> &match_key,
                         MatchTable::Entry *entry, int priority = 1) const = 0;
 
   virtual MatchErrorCode
-  mt_indirect_get_entry_from_key(size_t cxt_id, const std::string &table_name,
+  mt_indirect_get_entry_from_key(cxt_id_t cxt_id, const std::string &table_name,
                                  const std::vector<MatchKeyParam> &match_key,
                                  MatchTableIndirect::Entry *entry,
                                  int priority = 1) const = 0;
 
   virtual MatchErrorCode
-  mt_indirect_ws_get_entry_from_key(size_t cxt_id,
+  mt_indirect_ws_get_entry_from_key(cxt_id_t cxt_id,
                                     const std::string &table_name,
                                     const std::vector<MatchKeyParam> &match_key,
                                     MatchTableIndirectWS::Entry *entry,
                                     int priority = 1) const = 0;
 
   virtual Counter::CounterErrorCode
-  read_counters(size_t cxt_id,
+  read_counters(cxt_id_t cxt_id,
                 const std::string &counter_name,
                 size_t index,
                 MatchTableAbstract::counter_value_t *bytes,
                 MatchTableAbstract::counter_value_t *packets) = 0;
 
   virtual Counter::CounterErrorCode
-  reset_counters(size_t cxt_id,
+  reset_counters(cxt_id_t cxt_id,
                  const std::string &counter_name) = 0;
 
   virtual Counter::CounterErrorCode
-  write_counters(size_t cxt_id,
+  write_counters(cxt_id_t cxt_id,
                  const std::string &counter_name,
                  size_t index,
                  MatchTableAbstract::counter_value_t bytes,
@@ -315,48 +316,48 @@ class RuntimeInterface {
 
 
   virtual MeterErrorCode
-  meter_array_set_rates(size_t cxt_id,
+  meter_array_set_rates(cxt_id_t cxt_id,
                         const std::string &meter_name,
                         const std::vector<Meter::rate_config_t> &configs) = 0;
 
   virtual MeterErrorCode
-  meter_set_rates(size_t cxt_id,
+  meter_set_rates(cxt_id_t cxt_id,
                   const std::string &meter_name, size_t idx,
                   const std::vector<Meter::rate_config_t> &configs) = 0;
 
   virtual MeterErrorCode
-  meter_get_rates(size_t cxt_id,
+  meter_get_rates(cxt_id_t cxt_id,
                   const std::string &meter_name, size_t idx,
                   std::vector<Meter::rate_config_t> *configs) = 0;
 
   virtual RegisterErrorCode
-  register_read(size_t cxt_id,
+  register_read(cxt_id_t cxt_id,
                 const std::string &register_name,
                 const size_t idx, Data *value) = 0;
 
   virtual std::vector<Data>
-  register_read_all(size_t cxt_id, const std::string &register_name) = 0;
+  register_read_all(cxt_id_t cxt_id, const std::string &register_name) = 0;
 
   virtual RegisterErrorCode
-  register_write(size_t cxt_id,
+  register_write(cxt_id_t cxt_id,
                  const std::string &register_name,
                  const size_t idx, Data value) = 0;  // to be moved
 
   virtual RegisterErrorCode
-  register_write_range(size_t cxt_id,
+  register_write_range(cxt_id_t cxt_id,
                        const std::string &register_name,
                        const size_t start, const size_t end,
                        Data value) = 0;
 
   virtual RegisterErrorCode
-  register_reset(size_t cxt_id, const std::string &register_name) = 0;
+  register_reset(cxt_id_t cxt_id, const std::string &register_name) = 0;
 
   virtual ParseVSet::ErrorCode
-  parse_vset_add(size_t cxt_id, const std::string &parse_vset_name,
+  parse_vset_add(cxt_id_t cxt_id, const std::string &parse_vset_name,
                  const ByteContainer &value) = 0;
 
   virtual ParseVSet::ErrorCode
-  parse_vset_remove(size_t cxt_id, const std::string &parse_vset_name,
+  parse_vset_remove(cxt_id_t cxt_id, const std::string &parse_vset_name,
                     const ByteContainer &value) = 0;
 
   virtual ErrorCode
@@ -373,12 +374,12 @@ class RuntimeInterface {
 
   virtual CustomCrcErrorCode
   set_crc16_custom_parameters(
-      size_t cxt_id, const std::string &calc_name,
+      cxt_id_t cxt_id, const std::string &calc_name,
       const CustomCrcMgr<uint16_t>::crc_config_t &crc16_config) = 0;
 
   virtual CustomCrcErrorCode
   set_crc32_custom_parameters(
-      size_t cxt_id, const std::string &calc_name,
+      cxt_id_t cxt_id, const std::string &calc_name,
       const CustomCrcMgr<uint32_t>::crc_config_t &crc32_config) = 0;
 
   virtual ErrorCode

--- a/src/bm_apps/learn.cpp
+++ b/src/bm_apps/learn.cpp
@@ -55,13 +55,15 @@ namespace {
 
 struct learn_hdr_t {
   char sub_topic[4];
-  int switch_id;
-  int cxt_id;
+  uint64_t switch_id;
+  uint32_t cxt_id;
   int list_id;
   uint64_t buffer_id;
   unsigned int num_samples;
-  char _padding[4];
 } __attribute__((packed));
+
+static_assert(sizeof(learn_hdr_t) == 32u,
+              "Invalid size for learning notification header");
 
 }  // namespace
 

--- a/src/bm_apps/notifications.cpp
+++ b/src/bm_apps/notifications.cpp
@@ -35,30 +35,32 @@ namespace {
 
 struct LEA_hdr_t {
   char sub_topic[4];
-  int switch_id;
-  int cxt_id;
+  uint64_t switch_id;
+  uint32_t cxt_id;
   int list_id;
   uint64_t buffer_id;
   unsigned int num_samples;
-  char _padding[4];
 } __attribute__((packed));
 
 struct AGE_hdr_t {
   char sub_topic[4];
-  int switch_id;
-  int cxt_id;
+  uint64_t switch_id;
+  uint32_t cxt_id;
   uint64_t buffer_id;
   int table_id;
   unsigned int num_entries;
-  char _padding[4];
 } __attribute__((packed));
 
 struct PRT_hdr_t {
   char sub_topic[4];
-  int switch_id;
+  uint64_t switch_id;
   unsigned int num_statuses;
-  char _padding[20];
+  char _padding[16];
 } __attribute__((packed));
+
+static_assert(sizeof(LEA_hdr_t) == 32u, "Invalid size for notification header");
+static_assert(sizeof(AGE_hdr_t) == 32u, "Invalid size for notification header");
+static_assert(sizeof(PRT_hdr_t) == 32u, "Invalid size for notification header");
 
 }  // namespace
 

--- a/src/bm_runtime/SimplePreLAG_server.cpp
+++ b/src/bm_runtime/SimplePreLAG_server.cpp
@@ -31,7 +31,7 @@ using namespace bm;
 class SimplePreLAGHandler : virtual public SimplePreLAGIf {
 public:
   SimplePreLAGHandler(SwitchWContexts *sw) {
-    for (size_t cxt_id = 0; cxt_id < sw->get_nb_cxts(); cxt_id++) {
+    for (cxt_id_t cxt_id = 0; cxt_id < sw->get_nb_cxts(); cxt_id++) {
       auto pre = sw->get_cxt_component<McSimplePreLAG>(cxt_id);
       assert(pre != nullptr);
       pres.push_back(pre);

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -575,8 +575,8 @@ public:
 
   template <typename M,
             typename std::vector<typename M::Entry> (RuntimeInterface::*GetFn)(
-                size_t, const std::string &) const>
-  void get_entries_common(size_t cxt_id, const std::string &table_name,
+                cxt_id_t, const std::string &) const>
+  void get_entries_common(cxt_id_t cxt_id, const std::string &table_name,
                           std::vector<BmMtEntry> &_return) {
     const auto entries = std::bind(GetFn, switch_, cxt_id, table_name)();
     for (const auto &entry : entries) {
@@ -590,8 +590,8 @@ public:
 
   template <typename M,
             MatchErrorCode (RuntimeInterface::*GetFn)(
-                size_t, const std::string &, entry_handle_t, typename M::Entry *) const>
-  void get_entry_common(size_t cxt_id, const std::string &table_name,
+                cxt_id_t, const std::string &, entry_handle_t, typename M::Entry *) const>
+  void get_entry_common(cxt_id_t cxt_id, const std::string &table_name,
                         BmEntryHandle handle, BmMtEntry &e) {
     typename M::Entry entry;
     auto rc = std::bind(GetFn, switch_, cxt_id, table_name, handle, &entry)();
@@ -651,9 +651,9 @@ public:
 
   template <typename M,
             MatchErrorCode (RuntimeInterface::*GetFn)(
-                size_t, const std::string &, typename M::Entry *) const>
+                cxt_id_t, const std::string &, typename M::Entry *) const>
   typename M::Entry get_default_entry_common(
-      size_t cxt_id, const std::string &table_name, BmActionEntry &e) {
+      cxt_id_t cxt_id, const std::string &table_name, BmActionEntry &e) {
     typename M::Entry entry;
     auto error_code = std::bind(GetFn, switch_, cxt_id, table_name, &entry)();
     if (error_code == MatchErrorCode::NO_DEFAULT_ENTRY) {
@@ -695,9 +695,9 @@ public:
 
   template <typename M,
             MatchErrorCode (RuntimeInterface::*GetFn)(
-                size_t, const std::string &, const std::vector<MatchKeyParam> &,
+                cxt_id_t, const std::string &, const std::vector<MatchKeyParam> &,
                 typename M::Entry *, int) const>
-  void get_entry_from_key_common(size_t cxt_id, const std::string &table_name,
+  void get_entry_from_key_common(cxt_id_t cxt_id, const std::string &table_name,
                                  const BmMatchParams &match_key,
                                  const BmAddEntryOptions &options,
                                  BmMtEntry &e) {

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1981,7 +1981,7 @@ P4Objects::init_field_lists(const Json::Value &cfg_root) {
 int
 P4Objects::init_objects(std::istream *is,
                         LookupStructureFactory *lookup_factory,
-                        int device_id, size_t cxt_id,
+                        device_id_t device_id, cxt_id_t cxt_id,
                         std::shared_ptr<TransportIface> notifications_transport,
                         const std::set<header_field_pair> &required_fields,
                         const ForceArith &arith_objects) {

--- a/src/bm_sim/ageing.cpp
+++ b/src/bm_sim/ageing.cpp
@@ -43,7 +43,7 @@ class AgeingMonitor final : public AgeingMonitorIface {
   using buffer_id_t = uint64_t;
   using clock = Packet::clock;
 
-  AgeingMonitor(int device_id, int cxt_id,
+  AgeingMonitor(device_id_t device_id, cxt_id_t cxt_id,
                 std::shared_ptr<TransportIface> writer,
                 unsigned int sweep_interval_ms = 1000u);
 
@@ -79,8 +79,8 @@ class AgeingMonitor final : public AgeingMonitorIface {
 
   std::map<p4object_id_t, TableData> tables_with_ageing{};
 
-  int device_id{};
-  int cxt_id{};
+  device_id_t device_id{};
+  cxt_id_t cxt_id{};
 
   std::shared_ptr<TransportIface> writer{nullptr};
 
@@ -95,7 +95,7 @@ class AgeingMonitor final : public AgeingMonitorIface {
   mutable std::condition_variable stop_condvar{};
 };
 
-AgeingMonitor::AgeingMonitor(int device_id, int cxt_id,
+AgeingMonitor::AgeingMonitor(device_id_t device_id, cxt_id_t cxt_id,
                              std::shared_ptr<TransportIface> writer,
                              unsigned int sweep_interval_ms)
     : device_id(device_id), cxt_id(cxt_id), writer(writer),
@@ -201,7 +201,7 @@ AgeingMonitor::do_sweep() {
 }
 
 std::unique_ptr<AgeingMonitorIface>
-AgeingMonitorIface::make(int device_id, int cxt_id,
+AgeingMonitorIface::make(device_id_t device_id, cxt_id_t cxt_id,
                          std::shared_ptr<TransportIface> writer,
                          unsigned int sweep_interval_ms) {
   return std::unique_ptr<AgeingMonitorIface>(new AgeingMonitor(

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -702,12 +702,12 @@ Context::set_notifications_transport(
 }
 
 void
-Context::set_device_id(int dev_id) {
+Context::set_device_id(device_id_t dev_id) {
   device_id = dev_id;
 }
 
 void
-Context::set_cxt_id(int id) {
+Context::set_cxt_id(cxt_id_t id) {
   cxt_id = id;
 }
 

--- a/src/bm_sim/dev_mgr_bmi.cpp
+++ b/src/bm_sim/dev_mgr_bmi.cpp
@@ -43,7 +43,7 @@ namespace bm {
 
 class BmiDevMgrImp : public DevMgrIface {
  public:
-  BmiDevMgrImp(int device_id,
+  BmiDevMgrImp(device_id_t device_id,
                std::shared_ptr<TransportIface> notifications_transport) {
     if (bmi_port_create_mgr(&port_mgr)) {
       Logger::get()->critical("Could not initialize BMI port manager");
@@ -143,7 +143,8 @@ class BmiDevMgrImp : public DevMgrIface {
 
 void
 DevMgr::set_dev_mgr_bmi(
-    int device_id, std::shared_ptr<TransportIface> notifications_transport) {
+    device_id_t device_id,
+    std::shared_ptr<TransportIface> notifications_transport) {
   assert(!pimp);
   pimp = std::unique_ptr<DevMgrIface>(
       new BmiDevMgrImp(device_id, notifications_transport));

--- a/src/bm_sim/dev_mgr_packet_in.cpp
+++ b/src/bm_sim/dev_mgr_packet_in.cpp
@@ -41,7 +41,7 @@ namespace bm {
 class PacketInDevMgrImp : public DevMgrIface {
  public:
   explicit PacketInDevMgrImp(
-      int device_id, const std::string &addr,
+      device_id_t device_id, const std::string &addr,
       std::shared_ptr<TransportIface> notifications_transport,
       bool enforce_ports = false)
       : addr(addr), s(AF_SP, NN_PAIR), enforce_ports(enforce_ports) {
@@ -314,7 +314,7 @@ PacketInDevMgrImp::receive_loop() {
 
 void
 DevMgr::set_dev_mgr_packet_in(
-    int device_id, const std::string &addr,
+    device_id_t device_id, const std::string &addr,
     std::shared_ptr<TransportIface> notifications_transport,
     bool enforce_ports) {
   assert(!pimp);

--- a/src/bm_sim/event_logger.cpp
+++ b/src/bm_sim/event_logger.cpp
@@ -45,8 +45,8 @@ enum EventType {
 
 struct msg_hdr_t {
   int type;
-  int switch_id;
-  int cxt_id;
+  s_device_id_t switch_id;
+  s_cxt_id_t cxt_id;
   uint64_t sig;
   uint64_t id;
   uint64_t copy_id;
@@ -55,7 +55,7 @@ struct msg_hdr_t {
 namespace {
 
 void
-fill_msg_hdr(EventType type, int device_id,
+fill_msg_hdr(EventType type, device_id_t device_id,
              const Packet &packet, msg_hdr_t *msg_hdr) {
   msg_hdr->type = static_cast<int>(type);
   msg_hdr->switch_id = device_id;

--- a/src/bm_sim/learning.cpp
+++ b/src/bm_sim/learning.cpp
@@ -50,7 +50,7 @@ class LearnEngine final : public LearnEngineIface {
   using LearnEngineIface::msg_hdr_t;
   using LearnEngineIface::LearnCb;
 
-  explicit LearnEngine(int device_id = 0, int cxt_id = 0);
+  explicit LearnEngine(device_id_t device_id = 0, cxt_id_t cxt_id = 0);
 
   void list_create(list_id_t list_id, size_t max_samples = 1,
                    unsigned int timeout_ms = 1000) override;
@@ -135,7 +135,7 @@ class LearnEngine final : public LearnEngineIface {
     enum class LearnMode {NONE, WRITER, CB};
 
    public:
-    LearnList(list_id_t list_id, int device_id, int cxt_id,
+    LearnList(list_id_t list_id, device_id_t device_id, cxt_id_t cxt_id,
               size_t max_samples, unsigned int timeout);
 
     void init();
@@ -179,8 +179,8 @@ class LearnEngine final : public LearnEngineIface {
 
     list_id_t list_id;
 
-    int device_id;
-    int cxt_id;
+    device_id_t device_id;
+    cxt_id_t cxt_id;
 
     LearnSampleBuilder builder{};
     std::vector<char> buffer{};
@@ -217,8 +217,8 @@ class LearnEngine final : public LearnEngineIface {
  private:
   LearnList *get_learn_list(list_id_t list_id);
 
-  int device_id{};
-  int cxt_id{};
+  device_id_t device_id{};
+  cxt_id_t cxt_id{};
   // LearnList is not movable because of the mutex, I am using pointers
   std::unordered_map<list_id_t, std::unique_ptr<LearnList> > learn_lists{};
 };
@@ -263,8 +263,9 @@ LearnEngine::LearnSampleBuilder::operator()(const PHV &phv,
   }
 }
 
-LearnEngine::LearnList::LearnList(list_id_t list_id, int device_id, int cxt_id,
-                                  size_t max_samples, unsigned int timeout)
+LearnEngine::LearnList::LearnList(list_id_t list_id, device_id_t device_id,
+                                  cxt_id_t cxt_id, size_t max_samples,
+                                  unsigned int timeout)
     : list_id(list_id), device_id(device_id), cxt_id(cxt_id),
       max_samples(max_samples), timeout(timeout), with_timeout(timeout > 0) { }
 
@@ -514,7 +515,7 @@ LearnEngine::LearnList::reset_state() {
   buffer_tmp.clear();
 }
 
-LearnEngine::LearnEngine(int device_id, int cxt_id)
+LearnEngine::LearnEngine(device_id_t device_id, cxt_id_t cxt_id)
     : device_id(device_id), cxt_id(cxt_id) { }
 
 LearnEngine::LearnList *
@@ -656,7 +657,7 @@ LearnEngine::reset_state() {
 }
 
 std::unique_ptr<LearnEngineIface>
-LearnEngineIface::make(int device_id, int cxt_id) {
+LearnEngineIface::make(device_id_t device_id, cxt_id_t cxt_id) {
   return std::unique_ptr<LearnEngineIface>(new LearnEngine(device_id, cxt_id));
 }
 

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -105,7 +105,7 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
       ("thrift-port", po::value<int>(),
        "TCP port on which to run the Thrift runtime server")
 #endif
-      ("device-id", po::value<int>(),
+      ("device-id", po::value<device_id_t>(),
        "Device ID, used to identify the device in IPC messages (default 0)")
       ("nanolog", po::value<std::string>(),
        "IPC socket to use for nanomsg pub/sub logs "
@@ -232,7 +232,7 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
 
   device_id = 0;
   if (vm.count("device-id")) {
-    device_id = vm["device-id"].as<int>();
+    device_id = vm["device-id"].as<device_id_t>();
   }
 
 #ifdef BMNANOMSG_ON

--- a/src/bm_sim/packet.cpp
+++ b/src/bm_sim/packet.cpp
@@ -89,7 +89,7 @@ Packet::set_ingress_ts() {
     ingress_ts.time_since_epoch()).count();
 }
 
-Packet::Packet(size_t cxt_id, int ingress_port, packet_id_t id,
+Packet::Packet(cxt_id_t cxt_id, int ingress_port, packet_id_t id,
                copy_id_t copy_id, int ingress_length, PacketBuffer &&buffer,
                PHVSourceIface *phv_source)
     : cxt_id(cxt_id), ingress_port(ingress_port), packet_id(id),
@@ -120,7 +120,7 @@ Packet::~Packet() {
 }
 
 void
-Packet::change_context(size_t new_cxt) {
+Packet::change_context(cxt_id_t new_cxt) {
   if (cxt_id == new_cxt) return;
   assert(phv);
   phv->reset();
@@ -183,7 +183,7 @@ Packet::clone_with_phv_reset_metadata_ptr() const {
 }
 
 Packet
-Packet::clone_choose_context(size_t new_cxt) const {
+Packet::clone_choose_context(cxt_id_t new_cxt) const {
   copy_id_t new_copy_id = copy_id_gen->add_one(packet_id);
   Packet pkt(new_cxt, ingress_port, packet_id, new_copy_id, ingress_length,
              buffer.clone(buffer.get_data_size()), phv_source);
@@ -193,7 +193,7 @@ Packet::clone_choose_context(size_t new_cxt) const {
 }
 
 std::unique_ptr<Packet>
-Packet::clone_choose_context_ptr(size_t new_cxt) const {
+Packet::clone_choose_context_ptr(cxt_id_t new_cxt) const {
   return std::unique_ptr<Packet>(new Packet(clone_choose_context(new_cxt)));
 }
 
@@ -254,7 +254,7 @@ Packet::make_new(int ingress_length, PacketBuffer &&buffer,
 }
 
 Packet
-Packet::make_new(size_t cxt, int ingress_port, packet_id_t id,
+Packet::make_new(cxt_id_t cxt, int ingress_port, packet_id_t id,
                  copy_id_t copy_id, int ingress_length,
                  PacketBuffer &&buffer, PHVSourceIface *phv_source) {
   return Packet(cxt, ingress_port, id, copy_id, ingress_length,

--- a/src/bm_sim/phv_source.cpp
+++ b/src/bm_sim/phv_source.cpp
@@ -72,19 +72,19 @@ class PHVSourceContextPools : public PHVSourceIface {
     size_t count{0};
   };
 
-  std::unique_ptr<PHV> get_(size_t cxt) override {
+  std::unique_ptr<PHV> get_(cxt_id_t cxt) override {
     return phv_pools.at(cxt).get();
   }
 
-  void release_(size_t cxt, std::unique_ptr<PHV> phv) override {
+  void release_(cxt_id_t cxt, std::unique_ptr<PHV> phv) override {
     return phv_pools.at(cxt).release(std::move(phv));
   }
 
-  void set_phv_factory_(size_t cxt, const PHVFactory *factory) override {
+  void set_phv_factory_(cxt_id_t cxt, const PHVFactory *factory) override {
     phv_pools.at(cxt).set_phv_factory(factory);
   }
 
-  size_t phvs_in_use_(size_t cxt) override {
+  size_t phvs_in_use_(cxt_id_t cxt) override {
     return phv_pools.at(cxt).phvs_in_use();
   }
 
@@ -92,20 +92,20 @@ class PHVSourceContextPools : public PHVSourceIface {
 };
 
 std::unique_ptr<PHV>
-PHVSourceIface::get(size_t cxt) { return get_(cxt); }
+PHVSourceIface::get(cxt_id_t cxt) { return get_(cxt); }
 
 void
-PHVSourceIface::release(size_t cxt, std::unique_ptr<PHV> phv) {
+PHVSourceIface::release(cxt_id_t cxt, std::unique_ptr<PHV> phv) {
   release_(cxt, std::move(phv));
 }
 
 void
-PHVSourceIface::set_phv_factory(size_t cxt, const PHVFactory *factory) {
+PHVSourceIface::set_phv_factory(cxt_id_t cxt, const PHVFactory *factory) {
   set_phv_factory_(cxt, factory);
 }
 
 size_t
-PHVSourceIface::phvs_in_use(size_t cxt) {
+PHVSourceIface::phvs_in_use(cxt_id_t cxt) {
   return phvs_in_use_(cxt);
 }
 

--- a/src/bm_sim/port_monitor.cpp
+++ b/src/bm_sim/port_monitor.cpp
@@ -54,7 +54,7 @@ class PortMonitorDummy : public PortMonitorIface {
 
 class PortMonitorPassive : public PortMonitorIface {
  public:
-  PortMonitorPassive(int device_id,
+  PortMonitorPassive(device_id_t device_id,
                      std::shared_ptr<TransportIface> notifications_writer)
       : device_id(device_id), notifications_writer(notifications_writer) { }
 
@@ -95,7 +95,7 @@ class PortMonitorPassive : public PortMonitorIface {
   mutable std::mutex cb_map_mutex{};
   std::unordered_map<port_t, bool> curr_ports{};
   mutable std::mutex port_mutex{};
-  int device_id{};
+  device_id_t device_id{};
   std::shared_ptr<TransportIface> notifications_writer{nullptr};
 
  private:
@@ -143,7 +143,7 @@ class PortMonitorPassive : public PortMonitorIface {
 
 class PortMonitorActive : public PortMonitorPassive {
  public:
-  PortMonitorActive(int device_id,
+  PortMonitorActive(device_id_t device_id,
                     std::shared_ptr<TransportIface> notifications_writer)
       : PortMonitorPassive(device_id, notifications_writer) { }
 
@@ -216,14 +216,16 @@ PortMonitorIface::make_dummy() {
 
 std::unique_ptr<PortMonitorIface>
 PortMonitorIface::make_passive(
-    int device_id, std::shared_ptr<TransportIface> notifications_writer) {
+    device_id_t device_id,
+    std::shared_ptr<TransportIface> notifications_writer) {
   return std::unique_ptr<PortMonitorIface>(
       new PortMonitorPassive(device_id, notifications_writer));
 }
 
 std::unique_ptr<PortMonitorIface>
 PortMonitorIface::make_active(
-    int device_id, std::shared_ptr<TransportIface> notifications_writer) {
+    device_id_t device_id,
+    std::shared_ptr<TransportIface> notifications_writer) {
   return std::unique_ptr<PortMonitorIface>(
       new PortMonitorActive(device_id, notifications_writer));
 }

--- a/targets/simple_switch/tests/test_packet_redirect.cpp
+++ b/targets/simple_switch/tests/test_packet_redirect.cpp
@@ -52,7 +52,7 @@ class SimpleSwitch_PacketRedirectP4 : public ::testing::Test {
  protected:
   static constexpr size_t kMaxBufSize = 512;
 
-  static constexpr int device_id{0};
+  static constexpr bm::device_id_t device_id{0};
 
   SimpleSwitch_PacketRedirectP4()
       : packet_inject(packet_in_addr),

--- a/targets/simple_switch/tests/test_queueing.cpp
+++ b/targets/simple_switch/tests/test_queueing.cpp
@@ -54,7 +54,7 @@ class SimpleSwitch_QueueingP4 : public ::testing::Test {
  protected:
   static constexpr size_t kQueueingHdrSize = (48u + 24u + 32u + 24u) / 8u;
 
-  static constexpr int device_id{0};
+  static constexpr bm::device_id_t device_id{0};
 
   SimpleSwitch_QueueingP4()
       : packet_inject(packet_in_addr) { }

--- a/targets/simple_switch/tests/test_swap.cpp
+++ b/targets/simple_switch/tests/test_swap.cpp
@@ -50,7 +50,7 @@ class SimpleSwitch_SwapP4 : public ::testing::Test {
  protected:
   static constexpr size_t kMaxBufSize = 512;
 
-  static constexpr int device_id{0};
+  static constexpr bm::device_id_t device_id{0};
 
   SimpleSwitch_SwapP4()
       : packet_inject(packet_in_addr) { }

--- a/targets/simple_switch/tests/test_truncate.cpp
+++ b/targets/simple_switch/tests/test_truncate.cpp
@@ -48,7 +48,7 @@ class SimpleSwitch_TruncateP4 : public ::testing::Test {
  protected:
   static constexpr size_t kMaxBufSize = 512;
 
-  static constexpr int device_id{0};
+  static constexpr bm::device_id_t device_id{0};
 
   SimpleSwitch_TruncateP4()
       : packet_inject(packet_in_addr) { }

--- a/targets/simple_switch/tests/utils.cpp
+++ b/targets/simple_switch/tests/utils.cpp
@@ -83,8 +83,8 @@ void
 NNEventListener::receive_loop() {
   struct msg_hdr_t {
     int type;
-    int switch_id;
-    int cxt_id;
+    uint64_t switch_id;
+    uint32_t cxt_id;
     uint64_t sig;
     uint64_t id;
     uint64_t copy_id;

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -60,7 +60,7 @@ class DataplaneInterfaceServiceImpl
     : public p4::bm::DataplaneInterface::Service,
       public bm::DevMgrIface {
  public:
-  explicit DataplaneInterfaceServiceImpl(int device_id)
+  explicit DataplaneInterfaceServiceImpl(bm::device_id_t device_id)
       : device_id(device_id) {
     p_monitor = bm::PortMonitorIface::make_dummy();
   }
@@ -140,7 +140,7 @@ class DataplaneInterfaceServiceImpl
     return {};
   }
 
-  int device_id;
+  bm::device_id_t device_id;
   // protects the shared state (active) and prevents concurrent Write calls by
   // different threads
   std::mutex mutex{};

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -34,7 +34,7 @@ namespace testing {
 constexpr char SimpleSwitchGrpcBaseTest::grpc_server_addr[];
 constexpr char SimpleSwitchGrpcBaseTest::dp_grpc_server_addr[];
 constexpr int SimpleSwitchGrpcBaseTest::cpu_port;
-constexpr int SimpleSwitchGrpcBaseTest::device_id;
+constexpr uint64_t SimpleSwitchGrpcBaseTest::device_id;
 
 SimpleSwitchGrpcBaseTest::SimpleSwitchGrpcBaseTest(
     const char *p4info_proto_txt_path)

--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -48,7 +48,7 @@ class SimpleSwitchGrpcBaseTest : public ::testing::Test {
   static constexpr char grpc_server_addr[] = "0.0.0.0:50056";
   static constexpr char dp_grpc_server_addr[] = "0.0.0.0:50057";
   static constexpr int cpu_port = 64;
-  static constexpr int device_id = 3;
+  static constexpr uint64_t device_id = 3;
 
  protected:
   explicit SimpleSwitchGrpcBaseTest(const char *p4info_proto_txt_path);

--- a/tests/test_ageing.cpp
+++ b/tests/test_ageing.cpp
@@ -49,8 +49,8 @@ class AgeingTest : public ::testing::Test {
  protected:
   PHVFactory phv_factory;
 
-  const int device_id = 0;
-  const int cxt_id = 0;
+  const device_id_t device_id = 0;
+  const cxt_id_t cxt_id = 0;
 
   MatchKeyBuilder key_builder;
   std::unique_ptr<MatchTable> table;

--- a/tests/test_devmgr.cpp
+++ b/tests/test_devmgr.cpp
@@ -456,7 +456,7 @@ class PortMonitorTest : public ::testing::Test {
   using port_t = DevMgrIface::port_t;
   using PortStatus = DevMgrIface::PortStatus;
 
-  static constexpr int device_id = 0;
+  static constexpr device_id_t device_id = 0;
 
   PortMonitorTest()
       : notifications_writer(new MemoryAccessor(4096)) {
@@ -493,7 +493,7 @@ class PortMonitorTest : public ::testing::Test {
 };
 
 template <typename PMType>
-constexpr int PortMonitorTest<PMType>::device_id;
+constexpr device_id_t PortMonitorTest<PMType>::device_id;
 
 template<>
 void

--- a/tests/test_learning.cpp
+++ b/tests/test_learning.cpp
@@ -51,8 +51,8 @@ class LearningTest : public ::testing::Test {
  protected:
   PHVFactory phv_factory;
 
-  const int device_id = 0;
-  const int cxt_id = 0;
+  const device_id_t device_id = 0;
+  const cxt_id_t cxt_id = 0;
 
   HeaderType testHeaderType;
   header_id_t testHeader1{0}, testHeader2{1};

--- a/tests/test_packet.cpp
+++ b/tests/test_packet.cpp
@@ -47,34 +47,34 @@ class PHVSourceTest : public PHVSourceIface {
   explicit PHVSourceTest(size_t size)
       : phv_factories(size, nullptr), created(size, 0u), destroyed(size, 0u) { }
 
-  size_t get_created(size_t cxt) {
+  size_t get_created(cxt_id_t cxt) {
     return created.at(cxt);
   }
 
-  size_t get_destroyed(size_t cxt) {
+  size_t get_destroyed(cxt_id_t cxt) {
     return destroyed.at(cxt);
   }
 
  private:
-  std::unique_ptr<PHV> get_(size_t cxt) override {
+  std::unique_ptr<PHV> get_(cxt_id_t cxt) override {
     assert(phv_factories[cxt]);
     ++count;
     ++created.at(cxt);
     return phv_factories[cxt]->create();
   }
 
-  void release_(size_t cxt, std::unique_ptr<PHV> phv) override {
+  void release_(cxt_id_t cxt, std::unique_ptr<PHV> phv) override {
     // let the PHV be destroyed
     (void) cxt; (void) phv;
     --count;
     ++destroyed.at(cxt);
   }
 
-  void set_phv_factory_(size_t cxt, const PHVFactory *factory) override {
+  void set_phv_factory_(cxt_id_t cxt, const PHVFactory *factory) override {
     phv_factories.at(cxt) = factory;
   }
 
-  size_t phvs_in_use_(size_t cxt) override {
+  size_t phvs_in_use_(cxt_id_t cxt) override {
     (void)cxt;
     return count;
   }
@@ -102,7 +102,7 @@ class PacketTest : public ::testing::Test {
 
   // virtual void TearDown() { }
 
-  Packet get_packet(size_t cxt, packet_id_t id = 0) {
+  Packet get_packet(cxt_id_t cxt, packet_id_t id = 0) {
     // dummy packet, never parsed
     return Packet::make_new(cxt, 0, id, 0, 0, PacketBuffer(), phv_source.get());
   }
@@ -132,7 +132,7 @@ TEST_F(PacketTest, ChangeContext) {
 }
 
 TEST_F(PacketTest, Truncate) {
-  const size_t cxt = 0;
+  const cxt_id_t cxt = 0;
   const size_t first_length = 128;
   std::vector<char> data;
   data.reserve(first_length);

--- a/tests/test_switch.cpp
+++ b/tests/test_switch.cpp
@@ -288,9 +288,9 @@ TEST(Switch, MyTransport) {
   sw.transport_send_probe(0xaba);
   struct msg_t {
     char sub_topic[4];
-    int switch_id;
+    uint64_t switch_id;
     uint64_t x;
-    char _padding[16];  // the header size for notifications is always 32 bytes
+    char _padding[12];  // the header size for notifications is always 32 bytes
   } __attribute__((packed));
   msg_t msg;
   transport->read(reinterpret_cast<char *>(&msg), sizeof(msg));

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -270,7 +270,7 @@ struct BmMtActProfGroup {
 }
 
 struct BmConfig {
- 1:i32 device_id,
+ 1:i64 device_id,
  2:i32 thrift_port,
  3:optional string notifications_socket,
  4:optional string elogger_socket,

--- a/tools/nanomsg_client.py
+++ b/tools/nanomsg_client.py
@@ -133,7 +133,7 @@ class Msg(object):
 
     def extract_hdr(self):
         # < required to prevent 8-byte alignment
-        struct_ = struct.Struct("<iiiQQQ")
+        struct_ = struct.Struct("<iQIQQQ")
         (_, self.switch_id, self.cxt_id,
          self.sig, self.id_, self.copy_id) = struct_.unpack_from(self.msg)
         return struct_.size

--- a/tools/p4dbg.py
+++ b/tools/p4dbg.py
@@ -354,7 +354,7 @@ def decorate_msg(P, t, fmt):
 
 @decorate_msg(
     Msg, None,
-    [("type", "i", None), ("switch_id", "i", None), ("req_id", "Q", None)],
+    [("type", "i", None), ("switch_id", "Q", None), ("req_id", "Q", None)],
 )
 class BasicMsg(Msg):
     pass
@@ -389,7 +389,8 @@ class Msg_FieldValue(EventMsg):
 
 def _test():
     m = Msg_FieldValue()
-    req = struct.pack("iiQQQQi", MsgType.FIELD_VALUE, 0, 99, 1, 2, 55, 3)
+    # < required to prevent 8-byte alignment
+    req = struct.pack("<iQQQQQi", MsgType.FIELD_VALUE, 0, 99, 1, 2, 55, 3)
     req += struct.pack(">3s", "\x01\x02\x03")
     m.extract(req)
     s = m.generate()


### PR DESCRIPTION
Some users have expressed interest in being able to use 64-bit device
ids with bmv2. The biggest issue with this change is that the format for
notification messages (ageing, learning, port) has changes to accomodate
the larger device ids. As a consequence external tools subscribing to
these messages directly need to be updated.