### PR TITLE
Check parser transition values in JSON parser

### DIFF
--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -273,6 +273,8 @@ class ParseState : public NamedP4Object {
 
   void set_default_switch_case(const ParseState *default_next);
 
+  int expected_switch_case_key_size() const;
+
   // Copy constructor
   ParseState(const ParseState& other) = delete;
 

--- a/src/bm_sim/parser.cpp
+++ b/src/bm_sim/parser.cpp
@@ -866,6 +866,14 @@ ParseState::set_default_switch_case(const ParseState *default_next) {
   default_next_state = default_next;
 }
 
+int
+ParseState::expected_switch_case_key_size() const {
+  int size = 0;
+  for (auto bitwidth : key_builder.get_bitwidths())
+    size += (bitwidth + 7) / 8;
+  return size;
+}
+
 const ParseState *
 ParseState::find_next_state(Packet *pkt, const char *data,
                             size_t *bytes_parsed) const {


### PR DESCRIPTION
The JSON parser will complain if the width of the value does not match
the expected width, which depends on the transition key and is detailed
in the JSON documentation.