### PR TITLE
Add queueing_metadata.qid support to simple_switch

### DIFF
--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -73,6 +73,7 @@ header_type queueing_metadata_t {
         enq_qdepth : 16;
         deq_timedelta : 32;
         deq_qdepth : 16;
+        qid : 8;
     }
 }
 metadata queueing_metadata_t queueing_metadata;
@@ -85,6 +86,9 @@ enqueued.
 - `deq_timedelta`: the time, in microseconds, that the packet spent in the
 queue.
 - `deq_qdepth`: the depth of queue when the packet was dequeued.
+- `qid`: when there are multiple queues servicing each egress port (e.g. when
+priority queueing is enabled), each queue is assigned a fixed unique id, which
+is written to this field. Otherwise, this field is set to 0.
 
 ## Supported primitive actions
 

--- a/targets/simple_switch/tests/testdata/queueing.json
+++ b/targets/simple_switch/tests/testdata/queueing.json
@@ -1,4 +1,11 @@
 {
+    "__meta__": {
+        "version": [
+            2,
+            5
+        ],
+        "compiler": "https://github.com/p4lang/p4c-bm"
+    },
     "header_types": [
         {
             "name": "standard_metadata_t",
@@ -75,6 +82,10 @@
                 [
                     "deq_qdepth",
                     24
+                ],
+                [
+                    "qid",
+                    8
                 ]
             ],
             "length_exp": null,
@@ -139,12 +150,14 @@
                     ],
                     "transitions": [
                         {
+                            "type": "hexstr",
                             "value": "0x00000000",
                             "mask": null,
                             "next_state": "queueing_dummy"
                         },
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": null
                         }
@@ -167,7 +180,8 @@
                     "transition_key": [],
                     "transitions": [
                         {
-                            "value": "default",
+                            "type": "default",
+                            "value": null,
                             "mask": null,
                             "next_state": null
                         }
@@ -176,6 +190,7 @@
             ]
         }
     ],
+    "parse_vsets": [],
     "deparsers": [
         {
             "name": "deparser",
@@ -353,10 +368,10 @@
                         "set_port": null,
                         "_drop": null
                     },
-                    "default_action": null,
                     "base_default_next": null
                 }
             ],
+            "action_profiles": [],
             "conditionals": []
         },
         {
@@ -380,10 +395,10 @@
                     "next_tables": {
                         "copy_queueing_data": null
                     },
-                    "default_action": null,
                     "base_default_next": null
                 }
             ],
+            "action_profiles": [],
             "conditionals": []
         }
     ],

--- a/targets/simple_switch/tests/testdata/queueing.p4
+++ b/targets/simple_switch/tests/testdata/queueing.p4
@@ -30,6 +30,7 @@ header_type queueing_metadata_t {
         enq_qdepth : 24;
         deq_timedelta : 32;
         deq_qdepth : 24;
+        qid : 8;
     }
 }
 


### PR DESCRIPTION
This identifies the queue used for the packet, which is useful when
multiple queues are servicing an egress port (e.g. priority
queueing). Can be consummed in the egress pipeline.