### PR TITLE
User can now choose a directory for pcap dumps

### DIFF
--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -66,6 +66,7 @@ class OptionsParser {
   bool no_p4{false};
   InterfaceList ifaces{};
   bool pcap{false};
+  std::string pcap_dir{};
   int thrift_port{0};
   device_id_t device_id{};
   // if true read/write packets from files instead of interfaces

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,4 +36,4 @@ $(top_builddir)/thrift_src/libruntimestubs.la
 endif
 
 libbmall_la_LIBADD += \
--lboost_system $(THRIFT_LIB) -lboost_program_options
+-lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <boost/filesystem.hpp>
+
 #include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/P4Objects.h>
@@ -35,6 +37,8 @@
 #include <streambuf>
 
 #include "md5.h"
+
+namespace fs = boost::filesystem;
 
 namespace bm {
 
@@ -271,8 +275,12 @@ SwitchWContexts::init_from_options_parser(
       // Issue 2 may be fixed by detecting that we are using the same file and
       // using a single file descriptor (assuming that fwrite is thread-safe),
       // but I believe there is calue in having 2 different files.
-      inFile = iface.second + "_in.pcap";
-      outFile = iface.second + "_out.pcap";
+      assert(!parser.pcap_dir.empty());
+      fs::path pcap_dir(parser.pcap_dir);
+      auto inFilePath = pcap_dir / fs::path(iface.second + "_in.pcap");
+      inFile = inFilePath.string();
+      auto outFilePath = pcap_dir / fs::path(iface.second + "_out.pcap");
+      outFile = outFilePath.string();
       // inFile = iface.second + ".pcap";
       // outFile = inFile;
     }

--- a/targets/l2_switch/Makefile.am
+++ b/targets/l2_switch/Makefile.am
@@ -8,4 +8,4 @@ $(top_builddir)/src/bf_lpm_trie/libbflpmtrie.la \
 $(top_builddir)/thrift_src/libruntimestubs.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options
+-lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem

--- a/targets/simple_router/Makefile.am
+++ b/targets/simple_router/Makefile.am
@@ -7,4 +7,4 @@ $(top_builddir)/src/bf_lpm_trie/libbflpmtrie.la \
 $(top_builddir)/thrift_src/libruntimestubs.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options
+-lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -15,7 +15,7 @@ $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/src/bf_lpm_trie/libbflpmtrie.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options
+-lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
 
 if COND_THRIFT
 


### PR DESCRIPTION
--pcap now takes an optional argument (path to existing directory)
This adds a new dependency on the Boost filesystem library for the bm
core library. However this library was already required to run
tests. Target implementations using the bm core library may need to link
with the Boost filesystem library when picking up this change.