### PR TITLE
Use new {Set|Get}ForwardingPipelineConfig RPC fields

### DIFF
--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -71,11 +71,11 @@ SimpleSwitchGrpcBaseTest::TearDown() {
 void
 SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
   p4::SetForwardingPipelineConfigRequest request;
+  request.set_device_id(device_id);
   request.set_action(
       p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
   set_election_id(request.mutable_election_id());
-  auto config = request.add_configs();
-  config->set_device_id(device_id);
+  auto config = request.mutable_config();
   p4::tmp::P4DeviceConfig device_config;
   std::ifstream istream(json_path);
   device_config.mutable_device_data()->assign(

--- a/targets/simple_switch_grpc/tests/example.cpp
+++ b/targets/simple_switch_grpc/tests/example.cpp
@@ -81,11 +81,11 @@ test() {
 
   {
     p4::SetForwardingPipelineConfigRequest request;
+    request.set_device_id(dev_id);
     request.set_action(
         p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
     set_election_id(request.mutable_election_id());
-    auto config = request.add_configs();
-    config->set_device_id(dev_id);
+    auto config = request.mutable_config();
     config->set_allocated_p4info(&p4info);
     p4::tmp::P4DeviceConfig device_config;
     std::ifstream istream(test_json);


### PR DESCRIPTION
p4runtime.proto was updated and the format of the
{Set|Get}ForwardingPipelineConfig RPCs was modified, with some fields
marked as deprecated and some new fields introduced. This commit makes
sure that only the new fields are used.