### PR TITLE
Add a new debug output line when entering a parser state

### DIFF
--- a/src/bm_sim/parser.cpp
+++ b/src/bm_sim/parser.cpp
@@ -972,6 +972,8 @@ Parser::parse(Packet *pkt) const {
   const ParseState *next_state = init_state;
   size_t bytes_parsed = 0;
   while (next_state) {
+    BMLOG_DEBUG_PKT(*pkt, "Parser '{}' entering state '{}'",
+                    get_name(), next_state->get_name());
     try {
       next_state = (*next_state)(pkt, data, &bytes_parsed);
     } catch (const parser_exception &e) {


### PR DESCRIPTION
This can be useful for understanding what is going on, especially when
an error is detected during the state.  In that case, there is
currently no line in the log indicating that the parser state was
entered at all.