### PR TITLE
Copy header stack internal state when copying PHV

### DIFF
--- a/include/bm/bm_sim/phv.h
+++ b/include/bm/bm_sim/phv.h
@@ -37,7 +37,6 @@
 #include "fields.h"
 #include "headers.h"
 #include "header_unions.h"
-// #include "header_stacks.h"
 #include "stacks.h"
 #include "named_p4object.h"
 #include "expressions.h"
@@ -230,14 +229,7 @@ class PHV {
   //!   - is marked as metadata iff the corresponding \p src header is metadata
   //!   - receives the same field values as the corresponding \p src header iff
   //! it is a valid packet header or a metadata header
-  void copy_headers(const PHV &src) {
-    for (size_t h = 0; h < headers.size(); h++) {
-      headers[h].valid = src.headers[h].valid;
-      headers[h].metadata = src.headers[h].metadata;
-      if (headers[h].valid || headers[h].metadata)
-        headers[h].copy_fields(src.headers[h]);
-    }
-  }
+  void copy_headers(const PHV &src);
 
   void set_packet_id(const uint64_t id1, const uint64_t id2) {
     packet_id = {id1, id2};

--- a/src/bm_sim/phv.cpp
+++ b/src/bm_sim/phv.cpp
@@ -78,6 +78,26 @@ PHV::set_written_to(bool written_to_value) {
 }
 
 void
+PHV::copy_headers(const PHV &src) {
+  for (size_t h = 0; h < headers.size(); h++) {
+    headers[h].valid = src.headers[h].valid;
+    headers[h].metadata = src.headers[h].metadata;
+    if (headers[h].valid || headers[h].metadata)
+      headers[h].copy_fields(src.headers[h]);
+  }
+  for (size_t hs = 0; hs < header_stacks.size(); hs++) {
+    header_stacks[hs].next = src.header_stacks[hs].next;
+  }
+  for (size_t hu = 0; hu < header_unions.size(); hu++) {
+    header_unions[hu].valid = src.header_unions[hu].valid;
+    header_unions[hu].valid_header_idx = src.header_unions[hu].valid_header_idx;
+  }
+  for (size_t hus = 0; hus < header_union_stacks.size(); hus++) {
+    header_union_stacks[hus].next = src.header_union_stacks[hus].next;
+  }
+}
+
+void
 PHV::push_back_header(const std::string &header_name,
                       header_id_t header_index,
                       const HeaderType &header_type,


### PR DESCRIPTION
When creating packet copies (e.g. for multicast), we copy the PHV object
for the packet. In addition to copying field values and header validity
information, we need to copy the internal state for header stacks,
header unions and header union stacks.

Fixes #456