### PR TITLE
Added get_dp_grpc_server_port() to switch runner

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -170,7 +170,8 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
     auto service = new DataplaneInterfaceServiceImpl(parser.device_id);
     grpc::ServerBuilder builder;
     builder.AddListeningPort(dp_grpc_server_addr,
-                             grpc::InsecureServerCredentials());
+                             grpc::InsecureServerCredentials(),
+                             &dp_grpc_server_port);
     builder.RegisterService(service);
     dp_grpc_server = builder.BuildAndStart();
     my_dev_mgr.reset(service);

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -57,6 +57,9 @@ class SimpleSwitchGrpcRunner {
   int init_and_start(const bm::OptionsParser &parser);
   void wait();
   void shutdown();
+  int get_dp_grpc_server_port() {
+    return dp_grpc_server_port;
+  }
 
  private:
   SimpleSwitchGrpcRunner(int max_port = 512, bool enable_swap = false,
@@ -69,6 +72,7 @@ class SimpleSwitchGrpcRunner {
   std::string grpc_server_addr;
   int cpu_port;
   std::string dp_grpc_server_addr;
+  int dp_grpc_server_port;
   std::unique_ptr<grpc::Server> dp_grpc_server;
 };
 


### PR DESCRIPTION
This is useful in case when the server is run on a random port.