### PR TITLE
Check for duplicate names / ids in JSON input

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -28,6 +28,7 @@
 #include <tuple>
 #include <vector>
 #include <set>
+#include <unordered_set>
 #include <exception>
 
 #include "jsoncpp/json.h"
@@ -617,6 +618,38 @@ void check_json_version(const Json::Value &cfg_root) {
   }
 }
 
+class DupIdChecker {
+ public:
+  explicit DupIdChecker(const std::string &type_name)
+      : type_name(type_name) { }
+
+  void add(p4object_id_t id) {
+    auto p = ids.insert(id);
+    if (!p.second) {  // insertion did not take place
+      throw json_exception(
+          EFormat() << "Several objects of type '" << type_name
+          << "' have the same id " << id);
+    }
+  }
+
+ private:
+  std::string type_name;
+  std::unordered_set<p4object_id_t> ids{};
+};
+
+template <typename T>
+void add_new_object(std::unordered_map<std::string, T> *map,
+                    const std::string &type_name,
+                    const std::string &name, T obj) {
+  auto it = map->find(name);
+  if (it != map->end()) {
+    throw json_exception(
+        EFormat() << "Duplicate objects of type '" << type_name
+                  << "' with name '" << name << "'");
+  }
+  map->emplace(name, std::move(obj));
+}
+
 }  // namespace
 
 struct P4Objects::InitState {
@@ -656,10 +689,12 @@ P4Objects::init_enums(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_header_types(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("header type");
   const Json::Value &cfg_header_types = cfg_root["header_types"];
   for (const auto &cfg_header_type : cfg_header_types) {
     const string header_type_name = cfg_header_type["name"].asString();
     header_type_id_t header_type_id = cfg_header_type["id"].asInt();
+    dup_id_checker.add(header_type_id);
     HeaderType *header_type = new HeaderType(header_type_name,
                                              header_type_id);
 
@@ -700,12 +735,14 @@ P4Objects::init_header_types(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_headers(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("header");
   const Json::Value &cfg_headers = cfg_root["headers"];
 
   for (const auto &cfg_header : cfg_headers) {
     const string header_name = cfg_header["name"].asString();
     const string header_type_name = cfg_header["header_type"].asString();
     header_id_t header_id = cfg_header["id"].asInt();
+    dup_id_checker.add(header_id);
     bool metadata = cfg_header["metadata"].asBool();
 
     HeaderType *header_type = get_header_type(header_type_name);
@@ -720,12 +757,14 @@ P4Objects::init_headers(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_header_stacks(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("header stack");
   const Json::Value &cfg_header_stacks = cfg_root["header_stacks"];
 
   for (const auto &cfg_header_stack : cfg_header_stacks) {
     const string header_stack_name = cfg_header_stack["name"].asString();
     const string header_type_name = cfg_header_stack["header_type"].asString();
     header_stack_id_t header_stack_id = cfg_header_stack["id"].asInt();
+    dup_id_checker.add(header_stack_id);
 
     HeaderType *header_stack_type = get_header_type(header_type_name);
     header_stack_to_type_map[header_stack_name] = header_stack_type;
@@ -824,10 +863,12 @@ P4Objects::init_header_union_stacks(const Json::Value &cfg_root,
 
 void
 P4Objects::init_extern_instances(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("extern");
   const Json::Value &cfg_extern_instances = cfg_root["extern_instances"];
   for (const auto &cfg_extern_instance : cfg_extern_instances) {
     const string extern_instance_name = cfg_extern_instance["name"].asString();
     const p4object_id_t extern_instance_id = cfg_extern_instance["id"].asInt();
+    dup_id_checker.add(extern_instance_id);
 
     const string extern_type_name = cfg_extern_instance["type"].asString();
     auto instance = ExternFactoryMap::get_instance()->get_extern_instance(
@@ -888,10 +929,12 @@ P4Objects::init_extern_instances(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_parse_vsets(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("parser vset");
   const Json::Value &cfg_parse_vsets = cfg_root["parse_vsets"];
   for (const auto &cfg_parse_vset : cfg_parse_vsets) {
     const string parse_vset_name = cfg_parse_vset["name"].asString();
     const p4object_id_t parse_vset_id = cfg_parse_vset["id"].asInt();
+    dup_id_checker.add(parse_vset_id);
     const size_t parse_vset_cbitwidth =
         cfg_parse_vset["compressed_bitwidth"].asUInt();
 
@@ -919,15 +962,18 @@ P4Objects::init_parsers(const Json::Value &cfg_root, InitState *init_state) {
   auto &header_union_stack_to_type_map =
       init_state->header_union_stack_to_type_map;
 
+  DupIdChecker dup_id_checker("parser");
   const auto &cfg_parsers = cfg_root["parsers"];
   for (const auto &cfg_parser : cfg_parsers) {
     const string parser_name = cfg_parser["name"].asString();
     p4object_id_t parser_id = cfg_parser["id"].asInt();
+    dup_id_checker.add(parser_id);
 
     std::unique_ptr<Parser> parser(
         new Parser(parser_name, parser_id, &error_codes));
 
     std::unordered_map<string, ParseState *> current_parse_states;
+    DupIdChecker dup_id_checker_states("parse state");
 
     // parse states
 
@@ -935,6 +981,7 @@ P4Objects::init_parsers(const Json::Value &cfg_root, InitState *init_state) {
     for (const auto &cfg_parse_state : cfg_parse_states) {
       const string parse_state_name = cfg_parse_state["name"].asString();
       const p4object_id_t id = cfg_parse_state["id"].asInt();
+      dup_id_checker_states.add(id);
       // p4object_id_t parse_state_id = cfg_parse_state["id"].asInt();
       std::unique_ptr<ParseState> parse_state(
           new ParseState(parse_state_name, id));
@@ -1129,7 +1176,8 @@ P4Objects::init_parsers(const Json::Value &cfg_root, InitState *init_state) {
       if (cfg_transition_key.size() > 0u)
         parse_state->set_key_builder(key_builder);
 
-      current_parse_states[parse_state_name] = parse_state.get();
+      add_new_object(&current_parse_states, "parse state", parse_state_name,
+                     parse_state.get());
       parse_states.push_back(std::move(parse_state));
     }
 
@@ -1205,10 +1253,12 @@ P4Objects::init_parsers(const Json::Value &cfg_root, InitState *init_state) {
 
 void
 P4Objects::init_deparsers(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("deparser");
   const Json::Value &cfg_deparsers = cfg_root["deparsers"];
   for (const auto &cfg_deparser : cfg_deparsers) {
     const string deparser_name = cfg_deparser["name"].asString();
     p4object_id_t deparser_id = cfg_deparser["id"].asInt();
+    dup_id_checker.add(deparser_id);
     Deparser *deparser = new Deparser(deparser_name, deparser_id);
 
     const Json::Value &cfg_ordered_headers = cfg_deparser["order"];
@@ -1223,10 +1273,12 @@ P4Objects::init_deparsers(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_calculations(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("calculation");
   const Json::Value &cfg_calculations = cfg_root["calculations"];
   for (const auto &cfg_calculation : cfg_calculations) {
     const string name = cfg_calculation["name"].asString();
     const p4object_id_t id = cfg_calculation["id"].asInt();
+    dup_id_checker.add(id);
     const string algo = cfg_calculation["algo"].asString();
 
     BufBuilder builder;
@@ -1262,10 +1314,12 @@ P4Objects::init_calculations(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_counter_arrays(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("counter");
   const Json::Value &cfg_counter_arrays = cfg_root["counter_arrays"];
   for (const auto &cfg_counter_array : cfg_counter_arrays) {
     const string name = cfg_counter_array["name"].asString();
     const p4object_id_t id = cfg_counter_array["id"].asInt();
+    dup_id_checker.add(id);
     const size_t size = cfg_counter_array["size"].asUInt();
     const Json::Value false_value(false);
     const bool is_direct =
@@ -1282,10 +1336,12 @@ P4Objects::init_meter_arrays(const Json::Value &cfg_root,
                              InitState *init_state) {
   auto &direct_meters = init_state->direct_meters;
 
+  DupIdChecker dup_id_checker("meter");
   const Json::Value &cfg_meter_arrays = cfg_root["meter_arrays"];
   for (const auto &cfg_meter_array : cfg_meter_arrays) {
     const string name = cfg_meter_array["name"].asString();
     const p4object_id_t id = cfg_meter_array["id"].asInt();
+    dup_id_checker.add(id);
     const string type = cfg_meter_array["type"].asString();
     Meter::MeterType meter_type;
     if (type == "packets") {
@@ -1321,10 +1377,12 @@ P4Objects::init_meter_arrays(const Json::Value &cfg_root,
 
 void
 P4Objects::init_register_arrays(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("register");
   const Json::Value &cfg_register_arrays = cfg_root["register_arrays"];
   for (const auto &cfg_register_array : cfg_register_arrays) {
     const string name = cfg_register_array["name"].asString();
     const p4object_id_t id = cfg_register_array["id"].asInt();
+    dup_id_checker.add(id);
     const size_t size = cfg_register_array["size"].asUInt();
     const int bitwidth = cfg_register_array["bitwidth"].asInt();
 
@@ -1335,10 +1393,12 @@ P4Objects::init_register_arrays(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_actions(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("action");
   const Json::Value &cfg_actions = cfg_root["actions"];
   for (const auto &cfg_action : cfg_actions) {
     const string action_name = cfg_action["name"].asString();
     p4object_id_t action_id = cfg_action["id"].asInt();
+    dup_id_checker.add(action_id);
     std::unique_ptr<ActionFn> action_fn(new ActionFn(
         action_name, action_id, cfg_action["runtime_data"].size(),
         object_source_info(cfg_action)));
@@ -1479,17 +1539,21 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
                           InitState *init_state) {
   auto &direct_meters = init_state->direct_meters;
 
+  DupIdChecker dup_id_checker("pipeline");
   const Json::Value &cfg_pipelines = cfg_root["pipelines"];
   for (const auto &cfg_pipeline : cfg_pipelines) {
     const string pipeline_name = cfg_pipeline["name"].asString();
     p4object_id_t pipeline_id = cfg_pipeline["id"].asInt();
+    dup_id_checker.add(pipeline_id);
 
     // pipelines -> action profiles
 
+    DupIdChecker dup_id_checker_act_prof("action profile");
     const auto &cfg_act_profs = cfg_pipeline["action_profiles"];
     for (const auto &cfg_act_prof : cfg_act_profs) {
       const auto act_prof_name = cfg_act_prof["name"].asString();
       const auto act_prof_id = cfg_act_prof["id"].asInt();
+      dup_id_checker_act_prof.add(act_prof_id);
       const auto act_prof_size = cfg_act_prof["max_size"].asInt();
       // we ignore size for action profiles, at least for now
       (void) act_prof_size;
@@ -1506,10 +1570,12 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
 
     // pipelines -> tables
 
+    DupIdChecker dup_id_checker_table("table");
     const Json::Value &cfg_tables = cfg_pipeline["tables"];
     for (const auto &cfg_table : cfg_tables) {
       const string table_name = cfg_table["name"].asString();
       p4object_id_t table_id = cfg_table["id"].asInt();
+      dup_id_checker_table.add(table_id);
 
       MatchKeyBuilder key_builder;
       const Json::Value &cfg_match_key = cfg_table["key"];
@@ -1642,10 +1708,12 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
 
     // pipelines -> conditionals
 
+    DupIdChecker dup_id_checker_condition("condition");
     const auto &cfg_conditionals = cfg_pipeline["conditionals"];
     for (const auto &cfg_conditional : cfg_conditionals) {
       const string conditional_name = cfg_conditional["name"].asString();
       p4object_id_t conditional_id = cfg_conditional["id"].asInt();
+      dup_id_checker_condition.add(conditional_id);
       auto conditional = new Conditional(
         conditional_name, conditional_id, object_source_info(cfg_conditional));
       const auto &cfg_expression = cfg_conditional["expression"];
@@ -1876,10 +1944,12 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
 
 void
 P4Objects::init_checksums(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("checksum");
   const Json::Value &cfg_checksums = cfg_root["checksums"];
   for (const auto &cfg_checksum : cfg_checksums) {
     const string checksum_name = cfg_checksum["name"].asString();
     p4object_id_t checksum_id = cfg_checksum["id"].asInt();
+    dup_id_checker.add(checksum_id);
     const string checksum_type = cfg_checksum["type"].asString();
 
     const Json::Value &cfg_cksum_field = cfg_checksum["target"];
@@ -1930,6 +2000,7 @@ P4Objects::init_checksums(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_learn_lists(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("learn list");
   const Json::Value &cfg_learn_lists = cfg_root["learn_lists"];
 
   if (cfg_learn_lists.size() > 0) {
@@ -1938,6 +2009,7 @@ P4Objects::init_learn_lists(const Json::Value &cfg_root) {
 
   for (const auto &cfg_learn_list : cfg_learn_lists) {
     LearnEngineIface::list_id_t list_id = cfg_learn_list["id"].asInt();
+    dup_id_checker.add(list_id);
     learn_engine->list_create(list_id, 16);  // 16 is max nb of samples
     learn_engine->list_set_learn_writer(list_id, notifications_transport);
     auto list_name = cfg_learn_list["name"].asString();
@@ -1967,6 +2039,7 @@ P4Objects::init_learn_lists(const Json::Value &cfg_root) {
 
 void
 P4Objects::init_field_lists(const Json::Value &cfg_root) {
+  DupIdChecker dup_id_checker("field list");
   const Json::Value &cfg_field_lists = cfg_root["field_lists"];
   // used only for cloning
 
@@ -1974,6 +2047,7 @@ P4Objects::init_field_lists(const Json::Value &cfg_root) {
   // lists
   for (const auto &cfg_field_list : cfg_field_lists) {
     p4object_id_t list_id = cfg_field_list["id"].asInt();
+    dup_id_checker.add(list_id);
     std::unique_ptr<FieldList> field_list(new FieldList());
     const Json::Value &cfg_elements = cfg_field_list["elements"];
 
@@ -2499,7 +2573,8 @@ P4Objects::get_enum_name(const std::string &enum_name,
 void
 P4Objects::add_header_type(const std::string &name,
                            std::unique_ptr<HeaderType> header_type) {
-  header_types_map[name] = std::move(header_type);
+  add_new_object(&header_types_map, "header type", name,
+                 std::move(header_type));
 }
 
 HeaderType *
@@ -2509,13 +2584,13 @@ P4Objects::get_header_type(const std::string &name) {
 
 void
 P4Objects::add_header_id(const std::string &name, header_id_t header_id) {
-  header_ids_map[name] = header_id;
+  add_new_object(&header_ids_map, "header", name, header_id);
 }
 
 void
 P4Objects::add_header_stack_id(const std::string &name,
                                header_stack_id_t header_stack_id) {
-  header_stack_ids_map[name] = header_stack_id;
+  add_new_object(&header_stack_ids_map, "header stack", name, header_stack_id);
 }
 
 void
@@ -2564,7 +2639,14 @@ void
 P4Objects::add_action_to_table(
     const std::string &table_name,
     const std::string &action_name, ActionFn *action) {
-  t_actions_map[std::make_pair(table_name, action_name)] = action;
+  auto pair = std::make_pair(table_name, action_name);
+  auto it = t_actions_map.find(pair);
+  if (it != t_actions_map.end()) {
+    throw json_exception(
+        EFormat() << "Duplicate actions with name '" << action_name
+                  << "' in table '" << table_name << "'");
+  }
+  t_actions_map.emplace(pair, action);
 }
 
 void
@@ -2576,39 +2658,43 @@ P4Objects::add_action_to_act_prof(const std::string &act_prof_name,
 
 void
 P4Objects::add_parser(const std::string &name, std::unique_ptr<Parser> parser) {
-  parsers[name] = std::move(parser);
+  add_new_object(&parsers, "parser", name, std::move(parser));
 }
 
 void
 P4Objects::add_parse_vset(const std::string &name,
                           std::unique_ptr<ParseVSet> parse_vset) {
-  parse_vsets[name] = std::move(parse_vset);
+  add_new_object(&parse_vsets, "parser vset", name, std::move(parse_vset));
 }
 
 void
 P4Objects::add_deparser(const std::string &name,
                         std::unique_ptr<Deparser> deparser) {
-  deparsers[name] = std::move(deparser);
+  add_new_object(&deparsers, "deparser", name, std::move(deparser));
 }
 
 void
 P4Objects::add_match_action_table(const std::string &name,
                                   std::unique_ptr<MatchActionTable> table) {
   add_control_node(name, table.get());
-  match_action_tables_map[name] = std::move(table);
+  // not really needed as add_control_node enforces a stricter check
+  add_new_object(&match_action_tables_map, "match-action table", name,
+                 std::move(table));
 }
 
 void
 P4Objects::add_action_profile(const std::string &name,
                               std::unique_ptr<ActionProfile> action_profile) {
-  action_profiles_map[name] = std::move(action_profile);
+  add_new_object(&action_profiles_map, "action profile", name,
+                 std::move(action_profile));
 }
 
 void
 P4Objects::add_conditional(const std::string &name,
                            std::unique_ptr<Conditional> conditional) {
   add_control_node(name, conditional.get());
-  conditionals_map[name] = std::move(conditional);
+  // not really needed as add_control_node enforces a stricter check
+  add_new_object(&conditionals_map, "condition", name, std::move(conditional));
 }
 
 void
@@ -2620,37 +2706,37 @@ P4Objects::add_control_action(const std::string &name,
 
 void
 P4Objects::add_control_node(const std::string &name, ControlFlowNode *node) {
-  control_nodes_map[name] = node;
+  add_new_object(&control_nodes_map, "control node", name, node);
 }
 
 void
 P4Objects::add_pipeline(const std::string &name,
                         std::unique_ptr<Pipeline> pipeline) {
-  pipelines_map[name] = std::move(pipeline);
+  add_new_object(&pipelines_map, "pipeline", name, std::move(pipeline));
 }
 
 void
 P4Objects::add_meter_array(const std::string &name,
                            std::unique_ptr<MeterArray> meter_array) {
-  meter_arrays[name] = std::move(meter_array);
+  add_new_object(&meter_arrays, "meter", name, std::move(meter_array));
 }
 
 void
 P4Objects::add_counter_array(const std::string &name,
                              std::unique_ptr<CounterArray> counter_array) {
-  counter_arrays[name] = std::move(counter_array);
+  add_new_object(&counter_arrays, "counter", name, std::move(counter_array));
 }
 
 void
 P4Objects::add_register_array(const std::string &name,
                               std::unique_ptr<RegisterArray> register_array) {
-  register_arrays[name] = std::move(register_array);
+  add_new_object(&register_arrays, "register", name, std::move(register_array));
 }
 
 void
 P4Objects::add_named_calculation(
     const std::string &name, std::unique_ptr<NamedCalculation> calculation) {
-  calculations[name] = std::move(calculation);
+  add_new_object(&calculations, "calculation", name, std::move(calculation));
 }
 
 void
@@ -2662,7 +2748,7 @@ P4Objects::add_field_list(const p4object_id_t field_list_id,
 void
 P4Objects::add_extern_instance(const std::string &name,
                                std::unique_ptr<ExternType> extern_instance) {
-  extern_instances[name] = std::move(extern_instance);
+  add_new_object(&extern_instances, "extern", name, std::move(extern_instance));
 }
 
 }  // namespace bm

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -1002,3 +1002,44 @@ TEST(P4Objects, LearnListIdFromName) {
   ASSERT_EQ(P4Objects::IdLookupErrorCode::SUCCESS, rc);
   EXPECT_EQ(id, queried_id);
 }
+
+namespace {
+
+void create_2_header_types_json(std::ostream *ss,
+                                const std::string &name_1, int id_1,
+                                const std::string &name_2, int id_2) {
+  *ss << "{\"header_types\":[";
+  auto add_one = [ss] (const std::string &name, int id) {
+    *ss << "{\"name\":\"" << name << "\",\"id\":" << id << ",\"fields\":[]}";
+  };
+  add_one(name_1, id_1);
+  *ss << ",";
+  add_one(name_2, id_2);
+  *ss << "]}";
+}
+
+}  // namespace
+
+TEST(P4Objects, DupName) {
+  std::stringstream is;
+  create_2_header_types_json(&is, "ht0", 0, "ht0", 1);
+  std::stringstream os;
+  P4Objects objects(os);
+  LookupStructureFactory factory;
+  std::string expected_error_msg(
+      "Duplicate objects of type 'header type' with name 'ht0'\n");
+  ASSERT_NE(0, objects.init_objects(&is, &factory));
+  EXPECT_EQ(expected_error_msg, os.str());
+}
+
+TEST(P4Objects, DupId) {
+  std::stringstream is;
+  create_2_header_types_json(&is, "ht0", 0, "ht1", 0);
+  std::stringstream os;
+  P4Objects objects(os);
+  LookupStructureFactory factory;
+  std::string expected_error_msg(
+      "Several objects of type 'header type' have the same id 0\n");
+  ASSERT_NE(0, objects.init_objects(&is, &factory));
+  EXPECT_EQ(expected_error_msg, os.str());
+}


### PR DESCRIPTION
Duplicate names or ids are forbidden for objects of the same type
(e.g. header type, parser...). We enforce this restriction in the JSON
parser.