### PR TITLE
Initial support for gNMI & OpenConfig

### DIFF
--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -8,6 +8,10 @@ AM_CPPFLAGS += \
 -I$(srcdir)/../../PI \
 -isystem$(srcdir)/../../third_party/spdlog
 
+if WITH_SYSREPO
+AM_CPPFLAGS += -DWITH_SYSREPO
+endif
+
 bin_PROGRAMS = simple_switch_grpc
 
 simple_switch_grpc_SOURCES = main.cpp
@@ -25,6 +29,10 @@ noinst_LTLIBRARIES = libsimple_switch_grpc.la
 
 libsimple_switch_grpc_la_SOURCES = \
 switch_runner.cpp switch_runner.h
+if WITH_SYSREPO
+libsimple_switch_grpc_la_SOURCES += \
+switch_sysrepo.h switch_sysrepo.cpp
+endif
 
 libsimple_switch_grpc_la_LIBADD = \
 $(builddir)/../simple_switch/libsimpleswitch.la \

--- a/targets/simple_switch_grpc/README.md
+++ b/targets/simple_switch_grpc/README.md
@@ -1,7 +1,23 @@
+# SimpleSwitchGrpc
+
 This is an alternative version of the simple_switch target, which does not use
 the Thrift runtime server for table programming. Instead it starts a gRPC server
-which implements p4untime.proto
-(https://github.com/p4lang/PI/blob/master/proto/p4/p4runtime.proto).
+which implements
+[p4untime.proto](https://github.com/p4lang/PI/blob/master/proto/p4/p4runtime.proto).
 
 To compile, make sure you build the bmv2 code first, then run `./autogen.sh`,
 `./configure --with-pi` and `make`.
+
+## Tentative gNMI support with sysrepo
+
+We are working on supporting gNMI and OpenConfig YANG models as part of the P4
+Runtime server. We are using [sysrepo](https://github.com/sysrepo/sysrepo) as
+our YANG configuration data store and operational state manager. See [this
+README](https://github.com/p4lang/PI/blob/master/proto/README.md) for more
+information on how to try it out. After installing sysrepo, building and
+installing the PI project with sysrepo support enabled, you will need to
+configure simple_switch_grpc with `--with-sysrepo` and build it again.
+
+This directory includes a Python script, [gnmi_sub_once.py](gnmi_sub_once.py),
+which you can run to issue a gNMI ONCE subscription request to the P4 Runtime
+gRPC server running in the simple_switch_grpc process.

--- a/targets/simple_switch_grpc/configure.ac
+++ b/targets/simple_switch_grpc/configure.ac
@@ -56,6 +56,16 @@ AS_IF([test "$PYTHON" != :], [
 ])
 AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
 
+AC_ARG_WITH([sysrepo],
+    AS_HELP_STRING([--with-sysrepo],
+                   [Use sysrepo gNMI service implementation @<:@default=no@:>@]),
+    [with_sysrepo="$withval"], [with_sysrepo=no])
+AM_CONDITIONAL([WITH_SYSREPO], [test "$with_sysrepo" = yes])
+AM_COND_IF([WITH_SYSREPO], [
+    AC_CHECK_LIB([sysrepo], [sr_connect], [],
+                 [AC_MSG_ERROR([Missing libsysrepo])])
+])
+
 # Generate makefiles
 AC_CONFIG_FILES([Makefile
                  tests/Makefile])

--- a/targets/simple_switch_grpc/gnmi_sub_once.py
+++ b/targets/simple_switch_grpc/gnmi_sub_once.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python2
+
+# Copyright 2013-present Barefoot Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+from time import sleep
+
+import grpc
+from gnmi import gnmi_pb2
+import google.protobuf.text_format
+import struct
+
+parser = argparse.ArgumentParser(description='Mininet demo')
+parser.add_argument('--grpc-addr', help='P4Runtime gRPC server address',
+                    type=str, action="store", default='localhost:50051')
+
+args = parser.parse_args()
+
+def main():
+    channel = grpc.insecure_channel(args.grpc_addr)
+    stub = gnmi_pb2.gNMIStub(channel)
+
+    def req_iterator():
+        while True:
+            req = gnmi_pb2.SubscribeRequest()
+            subList = req.subscribe
+            subList.mode = gnmi_pb2.SubscriptionList.ONCE
+            sub = subList.subscription.add()
+            path = sub.path
+            for name in ["interfaces", "interface", "..."]:
+                e = path.elem.add()
+                e.name = name
+            print "***************************"
+            print "REQUEST"
+            print req
+            print "***************************"
+            yield req
+            return
+
+    for response in stub.Subscribe(req_iterator()):
+        print "***************************"
+        print "RESPONSE"
+        print response
+        print "***************************"
+
+if __name__ == '__main__':
+    main()
+

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -21,6 +21,8 @@
 #ifndef SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_
 #define SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_
 
+#include <bm/bm_sim/dev_mgr.h>
+
 #include <memory>
 #include <string>
 
@@ -39,6 +41,9 @@ class OptionsParser;
 }  // namespace bm
 
 namespace sswitch_grpc {
+
+class SysrepoSubscriber;
+class SysrepoTest;
 
 class SimpleSwitchGrpcRunner {
  public:
@@ -68,12 +73,19 @@ class SimpleSwitchGrpcRunner {
                          std::string dp_grpc_server_addr = "");
   ~SimpleSwitchGrpcRunner();
 
+  void port_status_cb(bm::DevMgrIface::port_t port,
+                      const bm::DevMgrIface::PortStatus port_status);
+
   std::unique_ptr<SimpleSwitch> simple_switch;
   std::string grpc_server_addr;
   int cpu_port;
   std::string dp_grpc_server_addr;
   int dp_grpc_server_port;
   std::unique_ptr<grpc::Server> dp_grpc_server;
+#ifdef WITH_SYSREPO
+  std::unique_ptr<SysrepoSubscriber> sysrepo_sub;
+  std::unique_ptr<SysrepoTest> sysrepo_test;
+#endif  // WITH_SYSREPO
 };
 
 }  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/switch_sysrepo.cpp
+++ b/targets/simple_switch_grpc/switch_sysrepo.cpp
@@ -1,0 +1,262 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "switch_sysrepo.h"
+
+#include <bm/bm_sim/dev_mgr.h>
+#include <bm/bm_sim/logger.h>
+
+#include <iostream>
+#include <string>
+
+extern "C" {
+#include "sysrepo.h"
+#include "sysrepo/values.h"
+#include "sysrepo/xpath.h"
+}
+
+namespace sswitch_grpc {
+
+namespace {
+
+using bm::Logger;
+
+int module_change_cb(sr_session_ctx_t *session, const char *module_name,
+                     sr_notif_event_t event, void *private_ctx) {
+  (void) session;
+  (void) module_name;
+  (void) event;
+  (void) private_ctx;
+  Logger::get()->debug("YANG config change");
+  return SR_ERR_OK;
+}
+
+}  // namespace
+
+bool
+SysrepoSubscriber::start() {
+  int rc = SR_ERR_OK;
+  rc = sr_connect(app_name, SR_CONN_DEFAULT, &connection);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_connect: {}", sr_strerror(rc));
+    return false;
+  }
+  rc = sr_session_start(connection, SR_DS_STARTUP, SR_SESS_DEFAULT, &session);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_session_start: {}", sr_strerror(rc));
+    return false;
+  }
+  // TODO(antonin): needed?
+  // rc = sr_copy_config(session, module_name, SR_DS_STARTUP, SR_DS_RUNNING);
+  // if (rc != SR_ERR_OK) {
+  //   Logger::get()->error("Error by sr_copy_config: {}", sr_strerror(rc));
+  //   return false;
+  // }
+  rc = sr_module_change_subscribe(
+      session, module_name, module_change_cb, static_cast<void *>(this),
+      0, SR_SUBSCR_DEFAULT, &subscription);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_module_change_subscribe: {}",
+                         sr_strerror(rc));
+    return false;
+  }
+  Logger::get()->info("Successfully started YANG config subscriber");
+  return true;
+}
+
+SysrepoSubscriber::~SysrepoSubscriber() {
+  if (subscription != NULL) {
+    sr_unsubscribe(session, subscription);
+    subscription = NULL;
+  }
+  if (session != NULL) {
+    sr_session_stop(session);
+    session = NULL;
+  }
+  if (connection != NULL) {
+    sr_disconnect(connection);
+    connection = NULL;
+  }
+}
+
+namespace {
+
+int data_provider_cb(const char *xpath, sr_val_t **values, size_t *values_cnt,
+                     void *private_ctx) {
+  Logger::get()->debug("YANG oper data requested for {}", xpath);
+  auto *tester = static_cast<SysrepoTest *>(private_ctx);
+  tester->provide_oper_state(values, values_cnt);
+  return SR_ERR_OK;
+}
+
+}  // namespace
+
+SysrepoTest::SysrepoTest(const bm::DevMgr *dev_mgr)
+    : dev_mgr(dev_mgr) { }
+
+bool
+SysrepoTest::connect() {
+  int rc = SR_ERR_OK;
+  rc = sr_connect(app_name, SR_CONN_DEFAULT, &connection);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_connect: {}", sr_strerror(rc));
+    return false;
+  }
+  rc = sr_session_start(connection, SR_DS_RUNNING, SR_SESS_DEFAULT, &session);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_session_start: {}", sr_strerror(rc));
+    return false;
+  }
+  rc = sr_dp_get_items_subscribe(
+      session, "/openconfig-interfaces:interfaces/interface/state",
+      data_provider_cb, static_cast<void *>(this),
+      SR_SUBSCR_DEFAULT, &subscription);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_dp_get_items_subscribe: {}",
+                         sr_strerror(rc));
+    return false;
+  }
+  Logger::get()->info("Successfully started YANG oper state provider");
+  return true;
+}
+
+void
+SysrepoTest::refresh_ports() {
+  auto port_info = dev_mgr->get_port_info();
+  for (const auto &p : port_info) add_iface(p.second.iface_name);
+}
+
+void
+SysrepoTest::add_iface(const std::string &name) {
+  int rc = SR_ERR_OK;
+  std::string prefix("/openconfig-interfaces:interfaces/interface");
+  prefix.append("[name='");
+  prefix.append(name);
+  prefix.append("']");
+  prefix.append("/config");
+  {
+    std::string path = prefix + "/name";
+    rc = sr_set_item_str(session, path.c_str(), name.c_str(), SR_EDIT_DEFAULT);
+  }
+  {
+    sr_val_t value = { 0 };
+    value.type = SR_UINT16_T;
+    value.data.uint16_val = 1500;
+    std::string path = prefix + "/mtu";
+    rc = sr_set_item(session, path.c_str(), &value, SR_EDIT_DEFAULT);
+  }
+  {
+    sr_val_t value = { 0 };
+    value.type = SR_IDENTITYREF_T;
+    value.data.string_val = const_cast<char *>("iana-if-type:ethernetCsmacd");
+    std::string path = prefix + "/type";
+    rc = sr_set_item(session, path.c_str(), &value, SR_EDIT_DEFAULT);
+  }
+  {
+    sr_val_t value = { 0 };
+    value.type = SR_BOOL_T;
+    value.data.bool_val = true;
+    std::string path = prefix + "/enabled";
+    rc = sr_set_item(session, path.c_str(), &value, SR_EDIT_DEFAULT);
+  }
+  rc = sr_commit(session);
+  if (rc != SR_ERR_OK) {
+    Logger::get()->error("Error by sr_commit: {}", sr_strerror(rc));
+    return;
+  }
+}
+
+void
+SysrepoTest::provide_oper_state(sr_val_t **values, size_t *values_cnt) {
+  const auto port_info = dev_mgr->get_port_info();
+  int entries_per_iface = 6;
+  int num_entries = entries_per_iface * port_info.size();
+  int rc = SR_ERR_OK;
+  sr_val_t *varray = NULL;
+  rc = sr_new_values(num_entries, &varray);
+  if (rc != SR_ERR_OK) return;
+  sr_val_t *v = varray;
+  for (const auto &p : port_info) {
+    const auto &iface = p.second.iface_name;
+    std::string prefix("/openconfig-interfaces:interfaces/interface");
+    prefix.append("[name='");
+    prefix.append(iface);
+    prefix.append("']");
+    prefix.append("/state");
+    {
+      std::string path = prefix + "/mtu";
+      sr_val_set_xpath(v, path.c_str());
+      v->type = SR_UINT16_T;
+      v->data.uint16_val = 1500;
+      v++;
+    }
+    {
+      std::string path = prefix + "/type";
+      sr_val_set_xpath(v, path.c_str());
+      sr_val_set_str_data(v, SR_IDENTITYREF_T, "iana-if-type:ethernetCsmacd");
+      v++;
+    }
+    {
+      std::string path = prefix + "/enabled";
+      sr_val_set_xpath(v, path.c_str());
+      v->type = SR_BOOL_T;
+      v->data.bool_val = true;
+      v++;
+    }
+    {
+      std::string path = prefix + "/ifindex";
+      sr_val_set_xpath(v, path.c_str());
+      v->type = SR_UINT32_T;
+      v->data.uint32_val = p.first;
+      v++;
+    }
+    {
+      std::string path = prefix + "/admin-status";
+      sr_val_set_xpath(v, path.c_str());
+      sr_val_set_str_data(v, SR_ENUM_T, "UP");
+      v++;
+    }
+    {
+      std::string path = prefix + "/oper-status";
+      sr_val_set_xpath(v, path.c_str());
+      sr_val_set_str_data(v, SR_ENUM_T, "UP");
+      v++;
+    }
+  }
+  *values = varray;
+  *values_cnt = num_entries;
+}
+
+SysrepoTest::~SysrepoTest() {
+  if (subscription != NULL) {
+    sr_unsubscribe(session, subscription);
+    subscription = NULL;
+  }
+  if (session != NULL) {
+    sr_session_stop(session);
+    session = NULL;
+  }
+  if (connection != NULL) {
+    sr_disconnect(connection);
+    connection = NULL;
+  }
+}
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/switch_sysrepo.h
+++ b/targets/simple_switch_grpc/switch_sysrepo.h
@@ -1,0 +1,75 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SIMPLE_SWITCH_GRPC_SWITCH_SYSREPO_H_
+#define SIMPLE_SWITCH_GRPC_SWITCH_SYSREPO_H_
+
+#include <set>
+#include <string>
+
+extern "C" {
+#include "sysrepo.h"
+#include "sysrepo/values.h"
+#include "sysrepo/xpath.h"
+}
+
+namespace bm {
+
+class DevMgr;
+
+}  // namespace bm
+
+namespace sswitch_grpc {
+
+class SysrepoSubscriber {
+ public:
+  ~SysrepoSubscriber();
+  bool start();
+
+ private:
+  sr_conn_ctx_t *connection{NULL};
+  sr_session_ctx_t *session{NULL};
+  sr_subscription_ctx_t *subscription{NULL};
+  const char *module_name{"openconfig-interfaces"};
+  const char *app_name{"subscriber"};
+};
+
+class SysrepoTest {
+ public:
+  explicit SysrepoTest(const bm::DevMgr *dev_mgr);
+  ~SysrepoTest();
+  bool connect();
+  void refresh_ports();
+  void provide_oper_state(sr_val_t **values, size_t *values_cnt);
+
+ private:
+  void add_iface(const std::string &name);
+
+  const bm::DevMgr *dev_mgr;  // non-owning pointer
+  sr_conn_ctx_t *connection{NULL};
+  sr_session_ctx_t *session{NULL};
+  sr_subscription_ctx_t *subscription{NULL};
+  const char *module_name{"openconfig-interfaces"};
+  const char *app_name{"test"};
+};
+
+}  // namespace sswitch_grpc
+
+#endif  // SIMPLE_SWITCH_GRPC_SWITCH_SYSREPO_H_


### PR DESCRIPTION
This leverages PI support for gNMI and OpenConfig, so you need a recent
version of the PI. Just like for the PI project, sysrepo needs to be
installed and you need to run configure (for simple_switch_grpc) with
--with-sysrepo.

The code registers a subscriber for config updates and an operational
state provider with sysrepo. As of now we do not react to config updates
as we only seek to support gNMI Subscribe requests. We still assume that
dataplane ports are configured through an external mechanism (most
likely, through the command-line when starting simple_switch_grpc).