### PR TITLE
Added new test_grpc_counters test in simple_switch_grpc target

### DIFF
--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -25,7 +25,8 @@ common_source = utils.h utils.cpp base_test.h base_test.cpp
 example_SOURCES = example.cpp utils.h utils.cpp
 test_gtest_SOURCES = \
 $(common_source) main.cpp \
-test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp
+test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp \
+test_grpc_counter.cpp 
 
 LDADD = \
 $(top_builddir)/libsimple_switch_grpc.la \

--- a/targets/simple_switch_grpc/tests/test_grpc_counter.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_counter.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2017, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "base_test.h"
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+constexpr char counter_json[] = TESTDATADIR "/counter.json";
+constexpr char counter_proto[] = TESTDATADIR "/counter.proto.txt";
+
+class SimpleSwitchGrpcTest_Counter : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_Counter()
+      : SimpleSwitchGrpcBaseTest(counter_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(counter_json);
+  }
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+};
+
+TEST_F(SimpleSwitchGrpcTest_Counter, CounterHit) {
+  auto t_id = get_table_id(p4info, "t_redirect");
+  auto mf_id = get_mf_id(p4info, "t_redirect", "sm.packet_length");
+  auto a_id = get_action_id(p4info, "port_redirect");
+  auto dc_id = get_direct_counter_id(p4info, "cntr");
+
+  auto write_one_entry = [t_id, mf_id, a_id, this]
+                         (const std::string &key_string) {
+    p4::WriteRequest write_request;
+    write_request.set_device_id(device_id);
+    auto update = write_request.add_updates();
+    update->set_type(p4::Update_Type_INSERT);
+    auto entity = update->mutable_entity();
+    auto table_entry = entity->mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    table_entry->set_priority(100);
+    auto match = table_entry->add_match();
+    match->set_field_id(mf_id);
+    auto exact = match->mutable_exact();
+    exact->set_value(key_string);
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(a_id);
+
+    p4::WriteResponse write_response;
+    ClientContext context;
+    auto status = Write(&context, write_request, &write_response);
+    EXPECT_TRUE(status.ok());
+  };
+  write_one_entry(std::string("\x00\x00\x00\x0a", 4));
+  write_one_entry(std::string("\x00\x00\x00\x05", 4));
+
+  auto send_one_packet = [this](const std::string &payload) {
+    p4::bm::PacketStreamRequest packet_request;
+    packet_request.set_device_id(device_id);
+    packet_request.set_port(1);
+    packet_request.set_packet(payload);
+
+    ClientContext context;
+    auto stream = dataplane_stub->PacketStream(&context);
+    stream->Write(packet_request);
+    p4::bm::PacketStreamResponse packet_response;
+    stream->Read(&packet_response);
+    EXPECT_EQ(packet_request.device_id(), packet_response.device_id());
+    EXPECT_EQ(packet_request.port(), packet_response.port());
+    EXPECT_EQ(packet_request.packet(), packet_response.packet());
+    stream->WritesDone();
+    auto status = stream->Finish();
+    EXPECT_TRUE(status.ok());
+  };
+  send_one_packet(std::string(10, '\xab'));
+  send_one_packet(std::string(5, '\xab'));
+
+  auto read_one_counter = [dc_id, t_id, mf_id, a_id, this]
+                          (const std::string &key_string,
+                           int packet_count, int byte_count) {
+    p4::ReadRequest read_request;
+    read_request.set_device_id(device_id);
+    auto read_entity = read_request.add_entities();
+    auto direct_counter_entry = read_entity->mutable_direct_counter_entry();
+    direct_counter_entry->set_counter_id(dc_id);
+    auto table_entry = direct_counter_entry->mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    table_entry->set_priority(100);
+    auto match = table_entry->add_match();
+    match->set_field_id(mf_id);
+    auto exact = match->mutable_exact();
+    exact->set_value(key_string);
+
+    ClientContext context;
+    std::unique_ptr<grpc::ClientReader<p4::ReadResponse> > reader(
+    p4runtime_stub->Read(&context, read_request));
+    p4::ReadResponse read_response;
+    reader->Read(&read_response);
+    auto status = reader->Finish();
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(read_response.entities_size(), 1);
+    EXPECT_TRUE(read_response.entities(0).has_direct_counter_entry());
+    EXPECT_EQ(
+      read_response.entities(0).direct_counter_entry().data().packet_count(),
+      packet_count);
+    EXPECT_EQ(
+      read_response.entities(0).direct_counter_entry().data().byte_count(),
+      byte_count);
+  };
+  read_one_counter(std::string("\x00\x00\x00\x0a", 4), 1, 10);
+  read_one_counter(std::string("\x00\x00\x00\x05", 4), 1, 5);
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/testdata/counter.json
+++ b/targets/simple_switch_grpc/tests/testdata/counter.json
@@ -1,0 +1,258 @@
+{
+  "program" : "counter/counter.p4i",
+  "__meta__" : {
+    "version" : [2, 7],
+    "compiler" : "https://github.com/p4lang/p4c"
+  },
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 1, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["_padding", 4, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "counter.p4",
+        "line" : 38,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [
+    {
+      "name" : "cntr",
+      "id" : 0,
+      "is_direct" : true,
+      "binding" : "t_redirect"
+    }
+  ],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "NoAction",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "port_redirect",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "ingress_port"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "counter.p4",
+            "line" : 45,
+            "column" : 8,
+            "source_fragment" : "sm.egress_spec = sm.ingress_port"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "counter.p4",
+        "line" : 42,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "t_redirect",
+      "tables" : [
+        {
+          "name" : "t_redirect",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "counter.p4",
+            "line" : 48,
+            "column" : 10,
+            "source_fragment" : "t_redirect"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "target" : ["standard_metadata", "packet_length"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : true,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1, 0],
+          "actions" : ["port_redirect", "NoAction"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "port_redirect" : null,
+            "NoAction" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : false,
+            "action_data" : [],
+            "action_entry_const" : false
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "counter.p4",
+        "line" : 34,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ]
+  ]
+}

--- a/targets/simple_switch_grpc/tests/testdata/counter.p4
+++ b/targets/simple_switch_grpc/tests/testdata/counter.p4
@@ -1,0 +1,54 @@
+// Copyright (c) 2017, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <core.p4>
+#include <v1model.p4>
+
+struct Headers {}
+
+struct Meta {}
+
+parser p(packet_in b, out Headers h,
+         inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {}
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {}
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    direct_counter(CounterType.packets_and_bytes) cntr;
+    action port_redirect() {
+        sm.egress_spec = sm.ingress_port;
+        cntr.count();
+    }
+    table t_redirect {
+        key = { sm.packet_length : exact; }
+        actions = { port_redirect; }
+        counters = cntr;
+    }
+    apply { t_redirect.apply(); }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/targets/simple_switch_grpc/tests/testdata/counter.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/counter.proto.txt
@@ -1,0 +1,47 @@
+tables {
+  preamble {
+    id: 33591959
+    name: "t_redirect"
+    alias: "t_redirect"
+  }
+  match_fields {
+    id: 1
+    name: "sm.packet_length"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16795932
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly()"
+  }
+  direct_resource_ids: 302022540
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16795932
+    name: "port_redirect"
+    alias: "port_redirect"
+  }
+}
+direct_counters {
+  preamble {
+    id: 302022540
+    name: "cntr"
+    alias: "cntr"
+  }
+  spec {
+    unit: BOTH
+  }
+  direct_table_id: 33591959
+}

--- a/targets/simple_switch_grpc/tests/utils.cpp
+++ b/targets/simple_switch_grpc/tests/utils.cpp
@@ -49,6 +49,15 @@ int get_action_id(const p4::config::P4Info &p4info,
   return 0;
 }
 
+int get_direct_counter_id(const p4::config::P4Info &p4info,
+                          const std::string &direct_counter_name) {
+  for (const auto &direct_counters : p4info.direct_counters()) {
+    const auto &pre = direct_counters.preamble();
+    if (pre.name() == direct_counter_name) return pre.id();
+  }
+  return 0;
+}
+
 int get_mf_id(const p4::config::P4Info &p4info,
               const std::string &t_name, const std::string &mf_name) {
   for (const auto &table : p4info.tables()) {

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -39,6 +39,9 @@ int get_mf_id(const p4::config::P4Info &p4info,
 int get_param_id(const p4::config::P4Info &p4info,
                  const std::string &a_name, const std::string &param_name);
 
+int get_direct_counter_id(const p4::config::P4Info &p4info,
+                          const std::string &direct_counter_name);
+
 p4::config::P4Info parse_p4info(const char *path);
 
 }  // namespace testing


### PR DESCRIPTION
This test verifies the counters by writing table entries, sending
dataplane packets, and then reading back the table entries.