### PR TITLE
Adding mirroring_mapping_add API to switch runner

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -273,6 +273,11 @@ SimpleSwitchGrpcRunner::shutdown() {
   PIGrpcServerShutdown();
 }
 
+int
+SimpleSwitchGrpcRunner::mirroring_mapping_add(int mirror_id, int egress_port) {
+  simple_switch->mirroring_mapping_add(mirror_id, egress_port);
+}
+
 SimpleSwitchGrpcRunner::~SimpleSwitchGrpcRunner() {
   PIGrpcServerCleanup();
 }

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -65,6 +65,9 @@ class SimpleSwitchGrpcRunner {
   int get_dp_grpc_server_port() {
     return dp_grpc_server_port;
   }
+  // TODO(dushyantarora): Remove this API once P4Runtime supports configuring
+  // mirroring sessions
+  int mirroring_mapping_add(int mirror_id, int egress_port);
 
  private:
   SimpleSwitchGrpcRunner(int max_port = 512, bool enable_swap = false,


### PR DESCRIPTION
Tests can use this API to mirroring session id to a physical port