### PR TITLE
Show node name in log when evaluating conditions

### DIFF
--- a/src/bm_sim/conditionals.cpp
+++ b/src/bm_sim/conditionals.cpp
@@ -43,10 +43,10 @@ Conditional::operator()(Packet *pkt) const {
   // + The full expression even if it spans multiple lines.
   // + The current values of all variables involved in evaluating the
   //   expression.
-  BMLOG_TRACE_SI_PKT(*pkt, get_source_info(), "Condition \"{}\" is {}",
+  BMLOG_TRACE_SI_PKT(*pkt, get_source_info(), "Condition \"{}\" ({}) is {}",
                      (get_source_info() == nullptr) ? get_name() :
                      get_source_info()->get_source_fragment(),
-                     result);
+                     get_name(), result);
   DEBUGGER_NOTIFY_UPDATE_V(
       Debugger::PacketId::make(pkt->get_packet_id(), pkt->get_copy_id()),
       Debugger::FIELD_COND, result);


### PR DESCRIPTION
I have found that there are P4 programs with 'if' statements inside of
controls that are called multiple times from ingress or egress, where
the p4c-bm2-ss inlining it performs causes multiple condition nodes to
be created with exactly the same source info.

I have a use case where distinguishing exactly which node is being
evaluated is useful to know.