### PR TITLE
Make Dataplane grpc server single threaded with single completion queue

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -179,6 +179,12 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
   if (!dp_grpc_server_addr.empty()) {
     auto service = new DataplaneInterfaceServiceImpl(parser.device_id);
     grpc::ServerBuilder builder;
+    builder.SetSyncServerOption(
+      grpc::ServerBuilder::SyncServerOption::NUM_CQS, 1);
+    builder.SetSyncServerOption(
+      grpc::ServerBuilder::SyncServerOption::MIN_POLLERS, 1);
+    builder.SetSyncServerOption(
+      grpc::ServerBuilder::SyncServerOption::MAX_POLLERS, 1);
     builder.AddListeningPort(dp_grpc_server_addr,
                              grpc::InsecureServerCredentials(),
                              &dp_grpc_server_port);


### PR DESCRIPTION
I noticed that MultipleClients test fixture in targets/simple_switch_grpc/test_grpc_dp.cpp is flaky. The test opens two stream channels with the dataplane interface grpc server. It expects the second channel to return RESOURCE_EXHAUSTED error. However, since the EventManager in grpc server spawns multiple threads per completion queue it sometimes schedules stream2's thread before stream1. stream2 blocks on Read() in a while loop causing the test to never finish. I changed the server to have a single thread with single completion queue. This is in tune with the grpc server requirements since it wants to process only 1 client connection at a time.