### PR TITLE
Ensure all received packets have been processed

### DIFF
--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -270,6 +270,11 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   //! be using. See switch.h documentation for more information.
   int do_swap();
 
+  //! Utility function which prevents new Packet instances from being
+  //! created and blocks until all existing Packet instances have been
+  //! destroyed in all contexts
+  void block_until_no_more_packets();
+
   //! Construct and return a Packet instance for the given \p cxt_id.
   std::unique_ptr<Packet> new_packet_ptr(cxt_id_t cxt_id, int ingress_port,
                                          packet_id_t id, int ingress_length,
@@ -895,7 +900,7 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   std::string notifications_addr{};
   std::shared_ptr<TransportIface> notifications_transport{nullptr};
 
-  mutable boost::shared_mutex ongoing_swap_mutex{};
+  mutable boost::shared_mutex process_packet_mutex{};
 
   std::string current_config{"{}"};  // empty JSON config
   bool config_loaded{false};

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -96,6 +96,8 @@ class DataplaneInterfaceServiceImpl
       if (!pkt_handler) continue;
       pkt_handler(request.port(), packet.data(), packet.size(), pkt_cookie);
     }
+    auto &runner = sswitch_grpc::SimpleSwitchGrpcRunner::get_instance();
+    runner.block_until_all_packets_processed();
     Lock lock(mutex);
     active = false;
     return Status::OK;
@@ -282,6 +284,11 @@ SimpleSwitchGrpcRunner::shutdown() {
 void
 SimpleSwitchGrpcRunner::mirroring_mapping_add(int mirror_id, int egress_port) {
   simple_switch->mirroring_mapping_add(mirror_id, egress_port);
+}
+
+void
+SimpleSwitchGrpcRunner::block_until_all_packets_processed() {
+  simple_switch->block_until_no_more_packets();
 }
 
 SimpleSwitchGrpcRunner::~SimpleSwitchGrpcRunner() {

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -68,6 +68,7 @@ class SimpleSwitchGrpcRunner {
   // TODO(dushyantarora): Remove this API once P4Runtime supports configuring
   // mirroring sessions
   void mirroring_mapping_add(int mirror_id, int egress_port);
+  void block_until_all_packets_processed();
 
  private:
   SimpleSwitchGrpcRunner(int max_port = 512, bool enable_swap = false,

--- a/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
@@ -62,8 +62,8 @@ TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, SendAndReceive) {
   request.set_device_id(device_id);
   request.set_port(9);
   request.set_packet(std::string(10, '\xab'));
-  ClientContext context;
-  auto stream = dataplane_stub->PacketStream(&context);
+  ClientContext context1;
+  auto stream = dataplane_stub->PacketStream(&context1);
   stream->Write(request);
   p4::bm::PacketStreamResponse response;
   stream->Read(&response);
@@ -72,6 +72,17 @@ TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, SendAndReceive) {
   EXPECT_EQ(request.packet(), response.packet());
   stream->WritesDone();
   auto status = stream->Finish();
+  EXPECT_TRUE(status.ok());
+
+  ClientContext context2;
+  stream = dataplane_stub->PacketStream(&context2);
+  stream->Write(request);
+  stream->WritesDone();
+  stream->Read(&response);
+  EXPECT_EQ(request.device_id(), response.device_id());
+  EXPECT_EQ(request.port(), response.port());
+  EXPECT_EQ(request.packet(), response.packet());
+  status = stream->Finish();
   EXPECT_TRUE(status.ok());
 }
 


### PR DESCRIPTION
before returning from PacketStream rpc. The current implementation returns immediately if the client calls stream->WritesDone() even if there are packets being processed by simple_switch (we set active to false at the end of rpc and check for active in transmit_fn). While if the client does not call WritesDone() and waits in stream->Read() it might be blocked forever (say if the packet is dropped). Another corner case which might happen is if the client calls WritesDone() and before the packet is processed a new client connection sets active to true and resets this->stream. Now the transmit_fn will send old reply to new stream request.
In order to fix these issues we need to somehow ensure all the packets have been processed by simple_switch before returning from PacketStream rpc. For this end I added a utility function: SwitchWContexts::block_until_no_more_packets() which we call now via SimpleSwitchGrpcRunner instance before PacketStream rpc returns.