### PR TITLE
show log if register_read out of range

### DIFF
--- a/include/bm/bm_sim/stateful.h
+++ b/include/bm/bm_sim/stateful.h
@@ -113,6 +113,7 @@ class RegisterArray : public NamedP4Object {
       bm::Logger::get()->critical(
         "Access register `{}` out of range, size={},index={}",
         name, size(), idx);
+      assert(idx < size());
     }
     return registers[idx];
   }
@@ -123,6 +124,7 @@ class RegisterArray : public NamedP4Object {
       bm::Logger::get()->critical(
         "Access register `{}` out of range, size={},index={}",
         name, size(), idx);
+      assert(idx < size());
     }
     return registers[idx];
   }

--- a/include/bm/bm_sim/stateful.h
+++ b/include/bm/bm_sim/stateful.h
@@ -45,6 +45,7 @@
 
 #include "data.h"
 #include "bignum.h"
+#include "logger.h"
 #include "named_p4object.h"
 #include "short_alloc.h"
 
@@ -108,13 +109,19 @@ class RegisterArray : public NamedP4Object {
 
   //! Access the register at position \p idx, asserts if bad \p idx
   Register &operator[](size_t idx) {
-    assert(idx < size());
+    if (idx >= size()) {
+      bm::Logger::get()->critical(
+        "Access register `{}` out of range, size={},index={}", name, size(), idx);
+    }
     return registers[idx];
   }
 
   //! @copydoc operator[]
   const Register &operator[](size_t idx) const {
-    assert(idx < size());
+    if (idx >= size()) {
+      bm::Logger::get()->critical(
+        "Access register `{}` out of range, size={},index={}", name, size(), idx);
+    }
     return registers[idx];
   }
 

--- a/include/bm/bm_sim/stateful.h
+++ b/include/bm/bm_sim/stateful.h
@@ -111,7 +111,8 @@ class RegisterArray : public NamedP4Object {
   Register &operator[](size_t idx) {
     if (idx >= size()) {
       bm::Logger::get()->critical(
-        "Access register `{}` out of range, size={},index={}", name, size(), idx);
+        "Access register `{}` out of range, size={},index={}",
+        name, size(), idx);
     }
     return registers[idx];
   }
@@ -120,7 +121,8 @@ class RegisterArray : public NamedP4Object {
   const Register &operator[](size_t idx) const {
     if (idx >= size()) {
       bm::Logger::get()->critical(
-        "Access register `{}` out of range, size={},index={}", name, size(), idx);
+        "Access register `{}` out of range, size={},index={}",
+        name, size(), idx);
     }
     return registers[idx];
   }


### PR DESCRIPTION
I am new to C++, and I want to fix #503 

This PR prevent bmv2 quit because of access register_array out of range.
Instead, I just log critical.