### PR TITLE
Support stacks and union stacks with extract_VL

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -10,7 +10,7 @@ on each attribute.
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.15*.
+The version described in this document is *2.16*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -322,9 +322,9 @@ In the `parser_ops` array, the format of the `parameters` array depends on the
   - `extract_VL`: introduced for P4_16, where the expression to dynamically
   compute the length of a variable-length field is an argument to the extract
   built-in rather than a property of the header. For this operation, we require
-  2 parameters, the first one of type `regular` and the second one of type
-  `expression` (to compute the length in bits of the variable-length field in
-  the header).
+  2 parameters. The first one follows the same rules as `extract`'s first and
+  only parameter. The second one must be of type `expression` (to compute the
+  length in bits of the variable-length field in the header).
   - `set`: takes exactly 2 parameters; the first one needs to be of type `field`
   with the appropriate value. The second one can be of type `field`, `hexstr`,
   `lookahead` or `expression`, with the appropriate value (see

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -230,8 +230,15 @@ class ParseState : public NamedP4Object {
                       const ArithExpression &field_length_expr,
                       size_t max_header_bytes);
   void add_extract_to_stack(header_stack_id_t header_stack);
+  void add_extract_to_stack_VL(header_stack_id_t header_stack,
+                               const ArithExpression &field_length_expr,
+                               size_t max_header_bytes);
   void add_extract_to_union_stack(header_union_stack_id_t header_union_stack,
                                   size_t header_offset);
+  void add_extract_to_union_stack_VL(header_union_stack_id_t header_union_stack,
+                                     size_t header_offset,
+                                     const ArithExpression &field_length_expr,
+                                     size_t max_header_bytes);
 
   void add_set_from_field(header_id_t dst_header, int dst_offset,
                           header_id_t src_header, int src_offset);


### PR DESCRIPTION
Until now we only supported "regular" extractions to plain headers. We
also added some GTests to test these more advanced cases.

The JSON documentation was updated to reflect this change, and the
version number was bumped up to 2.16

Fixes #506