### PR TITLE
Implement P4_16 conformant stack support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,14 @@ AC_ARG_ENABLE([Werror],
     AS_HELP_STRING([--enable-Werror], [Make all compiler warnings fatal]),
     [enable_Werror="$enableval"], [enable_Werror=no])
 
+AC_ARG_ENABLE([WP4-16-stacks],
+    AS_HELP_STRING([--enable-WP4-16-stacks],
+                   [Implement stacks strictly as per the P4_16 specification instead of legacy behavior]),
+    [enable_WP4_16_stacks="$enableval"], [enable_WP4_16_stacks=no])
+
+AS_IF([test "$enable_WP4_16_stacks" = "yes"],
+      [MY_CPPFLAGS="$MY_CPPFLAGS -DBM_WP4_16_STACKS"])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/tests/test_header_stacks.cpp
+++ b/tests/test_header_stacks.cpp
@@ -23,11 +23,66 @@
 #include <bm/bm_sim/phv.h>
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
-using namespace bm;
+namespace bm {
+
+namespace testing {
+
+// Because we want to test both implementations, we cannot use
+// PHVFactory::push_back_header_stack. We therefore subclass
+// bm::detail::StackLegacy<bm::Header> to access the set_next_element method and
+// build the header stacks ourselves.
+
+class HeaderStackLegacy : public detail::StackLegacy<Header> {
+ public:
+  HeaderStackLegacy(const std::string &name, p4object_id_t id)
+      : detail::StackLegacy<bm::Header>(name, id) { }
+
+  void set_next_header(Header &hdr) {  // NOLINT(runtime/references)
+    this->set_next_element(hdr);
+  }
+};
+
+// if PushValid is true, emulate legacy behavior by making pushed headers valid
+template <bool PushValid>
+class HeaderStackP4_16 : public detail::StackP4_16<Header> {
+ public:
+  HeaderStackP4_16(const std::string &name, p4object_id_t id)
+      : detail::StackP4_16<bm::Header>(name, id) { }
+
+  void set_next_header(Header &hdr) {  // NOLINT(runtime/references)
+    this->set_next_element(hdr);
+  }
+
+  template <bool B = PushValid>
+  typename std::enable_if<B, size_t>::type push_front() {
+    auto s = detail::StackP4_16<Header>::push_front();
+    this->at(0).mark_valid();
+    return s;
+  }
+
+  template <bool B = PushValid>
+  typename std::enable_if<B, size_t>::type push_front(size_t num) {
+    auto s = detail::StackP4_16<Header>::push_front(num);
+    for (size_t i = 0; i < s; i++) this->at(i).mark_valid();
+    return s;
+  }
+
+  template <bool B = PushValid>
+  typename std::enable_if<!B, size_t>::type push_front() {
+    return detail::StackP4_16<Header>::push_front();
+  }
+
+  template <bool B = PushValid>
+  typename std::enable_if<!B, size_t>::type push_front(size_t num) {
+    return detail::StackP4_16<Header>::push_front(num);
+  }
+};
 
 // Google Test fixture for header stack tests
+template <typename HSType>
 class HeaderStackTest : public ::testing::Test {
  protected:
   PHVFactory phv_factory;
@@ -37,44 +92,57 @@ class HeaderStackTest : public ::testing::Test {
   header_id_t testHeader_0{0}, testHeader_1{1}, testHeader_2{2};
 
   header_stack_id_t testHeaderStack{0};
+  HSType stack;
 
   size_t stack_depth{3};
 
   HeaderStackTest()
-      : testHeaderType("test_t", 0) {
+      : testHeaderType("test_t", 0),
+        stack("test_stack", testHeaderStack) {
     testHeaderType.push_back_field("f16", 16);
     testHeaderType.push_back_field("f48", 48);
     phv_factory.push_back_header("test_0", testHeader_0, testHeaderType);
     phv_factory.push_back_header("test_1", testHeader_1, testHeaderType);
     phv_factory.push_back_header("test_2", testHeader_2, testHeaderType);
 
-    const std::vector<header_id_t> headers =
-      {testHeader_0, testHeader_1, testHeader_2};
-    phv_factory.push_back_header_stack("test_stack", testHeaderStack,
-                                       testHeaderType, headers);
+    // Cannot use this if we want to test both stack implementations
+    // independently of whether preprocessor flag BM_WP4_16_STACKS is used.
+
+    // const std::vector<header_id_t> headers =
+    //   {testHeader_0, testHeader_1, testHeader_2};
+    // phv_factory.push_back_header_stack("test_stack", testHeaderStack,
+    //                                    testHeaderType, headers);
   }
 
   virtual void SetUp() {
     phv = phv_factory.create();
+    for (auto header_id : {testHeader_0, testHeader_1, testHeader_2})
+      stack.set_next_header(phv->get_header(header_id));
   }
 
   // virtual void TearDown() {}
 };
 
-TEST_F(HeaderStackTest, Basic) {
-  const HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+using HeaderStackTypes =
+    ::testing::Types<HeaderStackLegacy, HeaderStackP4_16<true> >;
 
-  ASSERT_EQ(stack_depth, stack.get_depth());
+TYPED_TEST_CASE(HeaderStackTest, HeaderStackTypes);
+
+TYPED_TEST(HeaderStackTest, Basic) {
+  auto &stack = this->stack;
+
+  ASSERT_EQ(this->stack_depth, stack.get_depth());
 
   ASSERT_EQ(0u, stack.get_count());
 }
 
-TEST_F(HeaderStackTest, PushBack) {
-  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+TYPED_TEST(HeaderStackTest, PushBack) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
 
-  const Header &h0 = phv->get_header(testHeader_0);
-  const Header &h1 = phv->get_header(testHeader_1);
-  const Header &h2 = phv->get_header(testHeader_2);
+  const auto &h0 = phv->get_header(this->testHeader_0);
+  const auto &h1 = phv->get_header(this->testHeader_1);
+  const auto &h2 = phv->get_header(this->testHeader_2);
 
   ASSERT_FALSE(h0.is_valid());
   ASSERT_FALSE(h1.is_valid());
@@ -82,23 +150,24 @@ TEST_F(HeaderStackTest, PushBack) {
 
   ASSERT_EQ(0u, stack.get_count());
 
-  for (size_t i = 0; i < stack_depth; i++) {
+  for (size_t i = 0; i < this->stack_depth; i++) {
     ASSERT_EQ(1u, stack.push_back());
     ASSERT_EQ(i + 1, stack.get_count());
   }
 
   ASSERT_EQ(0u, stack.push_back());
-  ASSERT_EQ(stack_depth, stack.get_count());
+  ASSERT_EQ(this->stack_depth, stack.get_count());
 
   ASSERT_TRUE(h0.is_valid());
   ASSERT_TRUE(h1.is_valid());
   ASSERT_TRUE(h2.is_valid());
 }
 
-TEST_F(HeaderStackTest, PopBack) {
-  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+TYPED_TEST(HeaderStackTest, PopBack) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
 
-  const Header &h0 = phv->get_header(testHeader_0);
+  const auto &h0 = phv->get_header(this->testHeader_0);
 
   ASSERT_FALSE(h0.is_valid());
   ASSERT_EQ(1u, stack.push_back());
@@ -110,18 +179,19 @@ TEST_F(HeaderStackTest, PopBack) {
   ASSERT_EQ(0u, stack.pop_back());  // empty so nothing to pop
 }
 
-TEST_F(HeaderStackTest, PushFront) {
-  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+TYPED_TEST(HeaderStackTest, PushFront) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
 
-  Header &h0 = phv->get_header(testHeader_0);
-  Header &h1 = phv->get_header(testHeader_1);
-  Header &h2 = phv->get_header(testHeader_2);
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
 
   ASSERT_FALSE(h0.is_valid());
 
-  Field &f0_0 = h0.get_field(0);
-  Field &f1_0 = h1.get_field(0);
-  Field &f2_0 = h2.get_field(0);
+  auto &f0_0 = h0.get_field(0);
+  auto &f1_0 = h1.get_field(0);
+  auto &f2_0 = h2.get_field(0);
 
   unsigned int v0 = 10u; unsigned int v1 = 11u; unsigned int v2 = 12u;
 
@@ -158,15 +228,16 @@ TEST_F(HeaderStackTest, PushFront) {
   ASSERT_EQ(v2, f1_0.get_uint());
 }
 
-TEST_F(HeaderStackTest, PushFrontNum) {
-  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+TYPED_TEST(HeaderStackTest, PushFrontNum) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
 
-  Header &h0 = phv->get_header(testHeader_0);
-  Header &h1 = phv->get_header(testHeader_1);
-  Header &h2 = phv->get_header(testHeader_2);
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
 
-  Field &f0_0 = h0.get_field(0);
-  Field &f2_0 = h2.get_field(0);
+  auto &f0_0 = h0.get_field(0);
+  auto &f2_0 = h2.get_field(0);
 
   unsigned int v0 = 10u;
 
@@ -185,21 +256,22 @@ TEST_F(HeaderStackTest, PushFrontNum) {
   ASSERT_EQ(v0, f2_0.get_uint());
 }
 
-TEST_F(HeaderStackTest, PopFront) {
-  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+TYPED_TEST(HeaderStackTest, PopFront) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
 
   ASSERT_EQ(2u, stack.push_front(2));  // add 2 headers
 
-  Header &h0 = phv->get_header(testHeader_0);
-  Header &h1 = phv->get_header(testHeader_1);
-  Header &h2 = phv->get_header(testHeader_2);
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
 
   ASSERT_TRUE(h0.is_valid());
   ASSERT_TRUE(h1.is_valid());
   ASSERT_FALSE(h2.is_valid());
 
-  Field &f0_0 = h0.get_field(0);
-  Field &f1_0 = h1.get_field(0);
+  auto &f0_0 = h0.get_field(0);
+  auto &f1_0 = h1.get_field(0);
 
   const unsigned int v0 = 10u; const unsigned int v1 = 11u;
   const std::string v1_hex("0x000b");
@@ -220,26 +292,30 @@ TEST_F(HeaderStackTest, PopFront) {
   ASSERT_FALSE(h1.is_valid());
   ASSERT_FALSE(h0.is_valid());
 
-  ASSERT_EQ(0u, stack.pop_front());  // empty so nothing popped
+  // not true for P4_16 stacks for which we always shift independently of the
+  // value of next
+  // ASSERT_EQ(0u, stack.pop_front());  // empty so nothing popped
+  stack.pop_front();
   ASSERT_EQ(0u, stack.get_count());
 }
 
-TEST_F(HeaderStackTest, PopFrontNum) {
-  HeaderStack &stack = phv->get_header_stack(testHeaderStack);
+TYPED_TEST(HeaderStackTest, PopFrontNum) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
 
   ASSERT_EQ(3u, stack.push_front(3));  // add 3 headers
 
-  Header &h0 = phv->get_header(testHeader_0);
-  Header &h1 = phv->get_header(testHeader_1);
-  Header &h2 = phv->get_header(testHeader_2);
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
 
   ASSERT_TRUE(h0.is_valid());
   ASSERT_TRUE(h1.is_valid());
   ASSERT_TRUE(h2.is_valid());
 
-  Field &f0_0 = h0.get_field(0);
-  Field &f1_0 = h1.get_field(0);
-  Field &f2_0 = h2.get_field(0);
+  auto &f0_0 = h0.get_field(0);
+  auto &f1_0 = h1.get_field(0);
+  auto &f2_0 = h2.get_field(0);
 
   unsigned int v0 = 10u; unsigned int v1 = 11u; unsigned int v2 = 12u;
   f0_0.set(v0); f1_0.set(v1); f2_0.set(v2);
@@ -259,9 +335,62 @@ TEST_F(HeaderStackTest, PopFrontNum) {
   ASSERT_FALSE(h2.is_valid());
   ASSERT_EQ(v2, f0_0.get_uint());
 
-  ASSERT_EQ(1u, stack.pop_front(2));
+  // not true for P4_16 stacks for which we always shift independently of the
+  // value of next
+  // ASSERT_EQ(1u, stack.pop_front(2));
+  stack.pop_front(2);
   ASSERT_EQ(0u, stack.get_count());
   ASSERT_FALSE(h0.is_valid());
   ASSERT_FALSE(h1.is_valid());
   ASSERT_FALSE(h2.is_valid());
 }
+
+// inheritance to reuse members, constructor, etc
+class HeaderStackP4_16Test
+    : public HeaderStackTest<HeaderStackP4_16<false> > { };
+
+TEST_F(HeaderStackP4_16Test, PushFront) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
+
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
+
+  h1.mark_valid();
+  EXPECT_EQ(1u, stack.push_front());
+  EXPECT_FALSE(h0.is_valid());  // push doesn't make valid
+  EXPECT_FALSE(h1.is_valid());
+  EXPECT_TRUE(h2.is_valid());
+
+  h0.mark_valid();
+  EXPECT_EQ(2u, stack.push_front(2));
+  EXPECT_FALSE(h0.is_valid());
+  EXPECT_FALSE(h1.is_valid());
+  EXPECT_TRUE(h2.is_valid());
+}
+
+TEST_F(HeaderStackP4_16Test, PopFront) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
+
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
+
+  h0.mark_valid(); h2.mark_valid();
+  EXPECT_EQ(1u, stack.pop_front());
+  EXPECT_FALSE(h0.is_valid());
+  EXPECT_TRUE(h1.is_valid());
+  EXPECT_FALSE(h2.is_valid());
+
+  h2.mark_valid();
+  EXPECT_EQ(2u, stack.pop_front(2));
+  EXPECT_TRUE(h0.is_valid());
+  EXPECT_FALSE(h1.is_valid());
+  EXPECT_FALSE(h2.is_valid());
+}
+
+}  // namespace testing
+
+}  // namespace bm

--- a/tests/test_phv.cpp
+++ b/tests/test_phv.cpp
@@ -101,15 +101,18 @@ TEST_F(PHVTest, CopyHeadersWithStack) {
 
   auto &stack = phv->get_header_stack(testHeaderStack);
   ASSERT_EQ(1u, stack.push_back());
-  ASSERT_TRUE(phv->get_header(testHeader1).is_valid());
-
-  ASSERT_FALSE(phv_2->get_header(testHeader1).is_valid());
+  // needs to work for both legacy stacks and P4_16 stacks, so we explicitly
+  // mark the header valid
+  phv->get_header(testHeader1).mark_valid();
+  EXPECT_TRUE(phv->get_header(testHeader1).is_valid());
+  EXPECT_FALSE(phv_2->get_header(testHeader1).is_valid());
+  EXPECT_EQ(stack.get_count(), 1u);
 
   phv_2->copy_headers(*phv);
 
   const auto &stack_2 = phv_2->get_header_stack(testHeaderStack);
-  ASSERT_EQ(stack_2.get_count(), stack.get_count());
-  ASSERT_TRUE(phv_2->get_header(testHeader1).is_valid());
+  EXPECT_EQ(stack_2.get_count(), stack.get_count());
+  EXPECT_TRUE(phv_2->get_header(testHeader1).is_valid());
 }
 
 TEST_F(PHVTest, CopyHeadersWithUnion) {


### PR DESCRIPTION
For header stacks and header union stacks. We support both behaviors at
the moment (legacy and P4_16). The legacy implementation is the default
one and will be the default for the 1.10 release. The P4_16 conformant
behavior can be toggled by using the `--enable-WP4-16-stacks` configure
flag. The plan is to have the new implementation be the default after
the 1.10 release.

The new implementation differs from the legacy one as follows:
push_front and pop_front shift the entire stack (not just until the next
index), and pushed headers are marked as invalid instead of valid.

We have tried to minimize the amount of code guarded by ifdef
directives. We used the CRTP to implement both behaviors and both
implementations are always compiled. We have unit tests for both
implementations as well.