### PR TITLE
Copy the field lists between cloned and original packet after parsing

### DIFF
--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -153,8 +153,9 @@ class SimpleSwitch : public Switch {
   // TODO(antonin): switch to pass by value?
   void enqueue(int egress_port, std::unique_ptr<Packet> &&pkt);
 
-  std::unique_ptr<Packet> copy_ingress_pkt(
+  void copy_field_list_and_set_type(
       const std::unique_ptr<Packet> &pkt,
+      const std::unique_ptr<Packet> &pkt_copy,
       PktInstanceType copy_type, p4object_id_t field_list_id);
 
   void check_queueing_metadata();


### PR DESCRIPTION
has been done on cloned packet. This is needed because the copied field_list fields can get overwritten during parsing. 
To give an example this fix will prevent something like this:

```
struct M {
  bit<9> port;
};

parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
    state start { 
      meta = {0};
      transition accept;
    }
}

control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
    apply {
        meta.port = smeta.egress_spec;
        clone3(CloneType.I2E, 64, {meta.port});
    }
};
```
The cloned pack will have metadata value meta.port = 0 in current implementation instead of the value of smeta.egress_spec