### PR TITLE
Add new core assignment primitives for stacks

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -10,7 +10,7 @@ on each attribute.
 
 ## Current bmv2 JSON format version
 
-The version described in this document is *2.16*.
+The version described in this document is *2.17*.
 
 The major version number will be increased by the compiler only when
 backward-compatibility of the JSON format is broken. After a major version
@@ -464,8 +464,8 @@ primitive `_my_extern_type_methodA`, with the first parameter being `{"type":
 representation for `x` and `y`.
 
 bmv2 supports the following core primitives:
-- `assign`, `assign_VL` (for variable-length fields), `assign_header` and
-`assign_union`.
+- `assign`, `assign_VL` (for variable-length fields), `assign_header`,
+`assign_union`, `assign_header_stack` and `assign_union_stack`.
 - `push` and `pop` for stack (header stack or header union stack) manipulation.
 - `_jump`: takes one parameter which must resolve to an integral value
 `offset`. When it is executed, we jump to the primitive call at index `offset`

--- a/include/bm/bm_sim/core/primitives.h
+++ b/include/bm/bm_sim/core/primitives.h
@@ -48,6 +48,16 @@ struct assign_union
   void operator ()(HeaderUnion &dst, const HeaderUnion &src);
 };
 
+struct assign_header_stack
+    : public ActionPrimitive<HeaderStack &, const HeaderStack &> {
+  void operator ()(HeaderStack &dst, const HeaderStack &src);
+};
+
+struct assign_union_stack
+    : public ActionPrimitive<HeaderUnionStack &, const HeaderUnionStack &> {
+  void operator ()(HeaderUnionStack &dst, const HeaderUnionStack &src);
+};
+
 struct push : public ActionPrimitive<StackIface &, const Data &> {
   void operator ()(StackIface &stack, const Data &num);
 };

--- a/include/bm/bm_sim/stacks.h
+++ b/include/bm/bm_sim/stacks.h
@@ -88,6 +88,16 @@ class StackIface {
   virtual void reset() = 0;
 };
 
+// Forward declarations for core action primitives which need to have access to
+// the stack's internal state (i.e. "next"). These are declared as friends in
+// the Stack class definition.
+namespace core {
+
+struct assign_header_stack;
+struct assign_union_stack;
+
+}  // namespace core
+
 // We use CRTP for Stack class to implement either legacy behavior or strict
 // P4_16 behavior by providing different implementations of push_front and
 // pop_front.
@@ -95,12 +105,16 @@ class StackIface {
 //! Stack is used to represent header and union stacks in P4. The Stack class
 //! itself does not store any union / header / field data itself, but stores
 //! references to the HeaderUnion / Header instances which constitute the stack,
-//! as well as the stack internal state (e.g. number of valid headers in the
+//! as well as the stack's internal state (e.g. number of valid headers in the
 //! stack).
 template <typename T, typename ShiftImpl>
 class Stack : public StackIface, public NamedP4Object {
  public:
   friend class PHV;
+  // These core action primitives are friends as they need to have access to the
+  // stack's internal state.
+  friend struct core::assign_header_stack;
+  friend struct core::assign_union_stack;
 
   Stack(const std::string &name, p4object_id_t id);
 

--- a/src/bm_sim/core/primitives.cpp
+++ b/src/bm_sim/core/primitives.cpp
@@ -32,6 +32,10 @@ REGISTER_PRIMITIVE(assign_header);
 
 REGISTER_PRIMITIVE(assign_union);
 
+REGISTER_PRIMITIVE(assign_header_stack);
+
+REGISTER_PRIMITIVE(assign_union_stack);
+
 REGISTER_PRIMITIVE(push);
 
 REGISTER_PRIMITIVE(pop);
@@ -58,6 +62,23 @@ assign_union::operator ()(HeaderUnion &dst, const HeaderUnion &src) {
   // naive implementation which iterates over all headers in the union
   for (size_t i = 0; i < dst.get_num_headers(); i++)
     assign_header()(dst.at(i), src.at(i));
+}
+
+void
+assign_header_stack::operator ()(HeaderStack &dst, const HeaderStack &src) {
+  assert(dst.get_depth() == src.get_depth());
+  dst.next = src.next;
+  for (size_t i = 0; i < dst.get_depth(); i++)
+    assign_header()(dst.at(i), src.at(i));
+}
+
+void
+assign_union_stack::operator ()(HeaderUnionStack &dst,
+                                const HeaderUnionStack &src) {
+  assert(dst.get_depth() == src.get_depth());
+  dst.next = src.next;
+  for (size_t i = 0; i < dst.get_depth(); i++)
+    assign_union()(dst.at(i), src.at(i));
 }
 
 void


### PR DESCRIPTION
Added assign_header_stack for header stack assignment and
assign_union_stack for header union stack assignment. Stack copies are
valid in P4_16. It is not possible for the compiler to generate
equivalent code by copying each stack element individually as stack have
internal state (the next "pointer"). Having dedicated bmv2 primitives is
also more efficient.

The JSON documentation was updated to reflect this change, and the
version number was bumped up to 2.17