### PR TITLE
Optionally enable the Thrift server in simple_switch_grpc

### DIFF
--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -12,6 +12,10 @@ if WITH_SYSREPO
 AM_CPPFLAGS += -DWITH_SYSREPO
 endif
 
+if WITH_THRIFT
+AM_CPPFLAGS += -DWITH_THRIFT
+endif
+
 bin_PROGRAMS = simple_switch_grpc
 
 simple_switch_grpc_SOURCES = main.cpp
@@ -41,6 +45,12 @@ libbm_grpc_dataplane.la \
 -lpifeproto -lpigrpcserver -lpi \
 $(GRPC_LIBS) $(PROTOBUF_LIBS)
 
+if WITH_THRIFT
+libsimple_switch_grpc_la_LIBADD += \
+$(builddir)/../../src/bm_runtime/libbmruntime.la \
+$(builddir)/../../thrift_src/libruntimestubs.la \
+$(builddir)/../simple_switch/libsimpleswitch_thrift.la
+endif
 
 # dataplane_interface.proto
 

--- a/targets/simple_switch_grpc/README.md
+++ b/targets/simple_switch_grpc/README.md
@@ -1,8 +1,8 @@
 # SimpleSwitchGrpc
 
 This is an alternative version of the simple_switch target, which does not use
-the Thrift runtime server for table programming. Instead it starts a gRPC server
-which implements
+the Thrift runtime server for table programming (unless required, see below).
+Instead it starts a gRPC server which implements
 [p4untime.proto](https://github.com/p4lang/PI/blob/master/proto/p4/p4runtime.proto).
 
 To compile, make sure you build the bmv2 code first, then run `./autogen.sh`,
@@ -76,3 +76,22 @@ This model augments `interfaces/interface`.
 #### openconfig-platform
 
 TBD
+
+## Enabling the Thrift server
+
+**Experimental feature, use at your own risk!**
+
+Enabling the Thrift runtime server (as in `simple_switch`) along the gRPC one,
+can be useful to execute the BMv2 debugger and CLI, which otherwise would not
+work on this target.
+
+The Thrift server can be enabled by passing the `--with-thrift` argument to
+`configure`.
+
+**Warning:** because the capabilities of the Thrift server overlap with those of
+the gRPC/P4 Runtime one (e.g. a table management API is exposed by both), there
+could be inconsistency issues when using both servers to write state to the
+switch. For example, if one tries to insert a table entry using Thrift, the same
+cannot be read using P4 Runtime. In general, to avoid such issues, we suggest to
+use the Thrift server only to read state, or to write state that is not managed
+by P4 Runtime.

--- a/targets/simple_switch_grpc/configure.ac
+++ b/targets/simple_switch_grpc/configure.ac
@@ -78,6 +78,12 @@ AM_COND_IF([WITH_SYSREPO], [
                  [AC_MSG_ERROR([Missing libsysrepo])])
 ])
 
+AC_ARG_WITH([thrift],
+    AS_HELP_STRING([--with-thrift],
+                   [Enable runtime Thrift server @<:@default=no@:>@]),
+    [with_thrift="$withval"], [with_thrift=no])
+AM_CONDITIONAL([WITH_THRIFT], [test "$with_thrift" = yes])
+
 # Generate makefiles
 AC_CONFIG_FILES([Makefile
                  tests/Makefile])
@@ -85,3 +91,8 @@ AC_CONFIG_FILES([Makefile
 AC_CONFIG_FILES([tests/example.run], [chmod +x tests/example.run])
 
 AC_OUTPUT
+
+AS_ECHO("")
+AS_ECHO("Features recap ......................")
+AS_ECHO("With Sysrepo .................. : $with_sysrepo")
+AS_ECHO("With Thrift ................... : $with_thrift")

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -50,6 +50,15 @@
 #include "switch_sysrepo.h"
 #endif  // WITH_SYSREPO
 
+#ifdef WITH_THRIFT
+#include <bm/SimpleSwitch.h>
+#include <bm/bm_runtime/bm_runtime.h>
+
+namespace sswitch_runtime {
+    shared_ptr<SimpleSwitchIf> get_handler(SimpleSwitch *sw);
+}  // namespace sswitch_runtime
+#endif  // WITH_THRIFT
+
 namespace sswitch_grpc {
 
 namespace {
@@ -305,6 +314,15 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
   for (const auto &p : saved_interfaces)
     sysrepo_driver->add_iface(p.first, p.second);
 #endif  // WITH_SYSREPO
+
+#ifdef WITH_THRIFT
+  int thrift_port = simple_switch->get_runtime_port();
+  bm_runtime::start_server(simple_switch.get(), thrift_port);
+  using ::sswitch_runtime::SimpleSwitchIf;
+  using ::sswitch_runtime::SimpleSwitchProcessor;
+  bm_runtime::add_service<SimpleSwitchIf, SimpleSwitchProcessor>(
+          "simple_switch", sswitch_runtime::get_handler(simple_switch.get()));
+#endif  // WITH_THRIFT
 
   simple_switch->start_and_return();
 

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -43,7 +43,8 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
         SimpleSwitchGrpcBaseTest::cpu_port,
         SimpleSwitchGrpcBaseTest::dp_grpc_server_addr);
     bm::OptionsParser parser;
-    const char *argv[] = {"test", "--device-id", "3", start_json};
+    const char *argv[] = {"test", "--device-id", "3", "--thrift-port",
+                          "45459", start_json};
     auto argc = static_cast<int>(sizeof(argv) / sizeof(char *));
     parser.parse(argc, const_cast<char **>(argv), nullptr);
     ASSERT_EQ(0, runner.init_and_start(parser));


### PR DESCRIPTION
This patch allows building simple_switc_grpc with support for the Thrift server (as in simple_switch) along with the gRPC one. I found useful running the Thrift server to execute the BMv2 debugger, the BMv2 CLI (handy to debug the result of a P4Runtime write operation), and for control/configuration capabilities not supported yet by P4Runtime/gNMI (e.g. for application/control plane prototyping).

To enable the Thrift server, when building simple_switc_grpc:
```
./configure --with-thrift
```

I have the feeling that because the Thrift-based API partially overlaps with PI (e.g. table management with P4Runtime or port configuration with gNMI), when using the Thrift one to write state, one could end up in troubles by leaving PI in an inconsistent state. I might be wrong, but as long as the Thrift one is used only to read state, or to write state not managed by PI, there should be no issues.

I did some testing using P4Runtime and the Thrift-based API together, and everything works as expected, however, when running `make check`, the example.run test fails with the following error:

```
FAIL: example.run
=================

Sleeping 10 seconds...
lt-example: example.cpp:78: int sswitch_grpc::testing::{anonymous}::test(): Assertion `response.update_case() == p4::StreamMessageResponse::kArbitration' failed.
./example.run: line 9: 28114 Aborted                 (core dumped) ./example
FAIL example.run (exit status: 134)
``` 

I'm not sure why and I might not be able to debug this issue further, I'd appreciate some help. Are there other issues in running the Thrift server along with the gRPC one?
