### PR TITLE
Add --thrift-port conditionally in simple_switch_grpc gtests

### DIFF
--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -15,6 +15,10 @@ if WITH_SYSREPO
 AM_CPPFLAGS += -DWITH_SYSREPO
 endif
 
+if WITH_THRIFT
+AM_CPPFLAGS += -DWITH_THRIFT
+endif
+
 # I am putting all the tests in the same binary (test_gtest) to use a single
 # switch instance (this way there is no need to worry about allocating
 # non-conflicting port-numbers and device ids). The drawback is that the tests

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "base_test.h"
 #include "switch_runner.h"
 
@@ -43,10 +45,14 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
         SimpleSwitchGrpcBaseTest::cpu_port,
         SimpleSwitchGrpcBaseTest::dp_grpc_server_addr);
     bm::OptionsParser parser;
-    const char *argv[] = {"test", "--device-id", "3", "--thrift-port",
-                          "45459", start_json};
-    auto argc = static_cast<int>(sizeof(argv) / sizeof(char *));
-    parser.parse(argc, const_cast<char **>(argv), nullptr);
+    std::vector<const char *> argv = {"test", "--device-id", "3"};
+#ifdef WITH_THRIFT
+    argv.push_back("--thrift-port");
+    argv.push_back("45459");
+#endif  // WITH_THRIFT
+    argv.push_back(start_json);
+    auto argc = static_cast<int>(argv.size());
+    parser.parse(argc, const_cast<char **>(argv.data()), nullptr);
     ASSERT_EQ(0, runner.init_and_start(parser));
   }
 


### PR DESCRIPTION
Otherwise option parsing will fail when both bmv2 and simple_switch_grpc
are compiled with --without-thrift.