### PR TITLE
Fix simple_switch_grpc tests after P4 Runtime update

### DIFF
--- a/targets/simple_switch_grpc/tests/example.cpp
+++ b/targets/simple_switch_grpc/tests/example.cpp
@@ -114,7 +114,7 @@ test() {
   auto match = table_entry->add_match();
   match->set_field_id(mf_id);
   auto lpm = match->mutable_lpm();
-  lpm->set_value(std::string("\x0a\x00\x00\x01", 4));  // 10.0.0.1
+  lpm->set_value(std::string("\x0a\x00\x00\x00", 4));  // 10.0.0.0/16
   lpm->set_prefix_len(16);
   auto table_action = table_entry->mutable_action();
   auto action = table_action->mutable_action();

--- a/targets/simple_switch_grpc/tests/test_basic.cpp
+++ b/targets/simple_switch_grpc/tests/test_basic.cpp
@@ -66,7 +66,7 @@ TEST_F(SimpleSwitchGrpcTest_Basic, Entries) {
   auto match = table_entry->add_match();
   match->set_field_id(mf_id);
   auto lpm = match->mutable_lpm();
-  lpm->set_value(std::string("\x0a\x00\x00\x01", 4));  // 10.0.0.1
+  lpm->set_value(std::string("\x0a\x00\x00\x00", 4));  // 10.0.0.0/16
   lpm->set_prefix_len(16);
   auto table_action = table_entry->mutable_action();
   auto action = table_action->mutable_action();


### PR DESCRIPTION
P4 Runtime now has more stringent requirements regarding formatting of
ternary match fields (don't care bits have to be set to 0) so we had to
update the simple_switch_grpc tests.