### PR TITLE
Fix simple_switch_grpc direct counter GTest

### DIFF
--- a/targets/simple_switch_grpc/tests/test_grpc_counter.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_counter.cpp
@@ -110,7 +110,6 @@ TEST_F(SimpleSwitchGrpcTest_Counter, CounterHit) {
     read_request.set_device_id(device_id);
     auto read_entity = read_request.add_entities();
     auto direct_counter_entry = read_entity->mutable_direct_counter_entry();
-    direct_counter_entry->set_counter_id(dc_id);
     auto table_entry = direct_counter_entry->mutable_table_entry();
     table_entry->set_table_id(t_id);
     auto match = table_entry->add_match();


### PR DESCRIPTION
Because PSA mandates that a given table can have at most one of each
direct resource, we have remove the id from the DirectCounterEntry &
DirectMeterEntry messages in P4Runtime (the id can be inferred from the
table id, included in the TableEntry field). As a result one of the
simple_switch_grpc unit tests had to be updated to fix a compialtion
issue.