### PR TITLE
Enable arith for stacks used in parser primitives

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -469,6 +469,8 @@ P4Objects::add_primitive_to_action(const Json::Value &cfg_primitive,
       const auto header_stack_name = cfg_parameter["value"].asString();
       auto header_stack_id = get_header_stack_id_cfg(header_stack_name);
       action_fn->parameter_push_back_header_stack(header_stack_id);
+
+      phv_factory.enable_all_stack_field_arith(header_stack_id);
     } else if (type == "expression") {
       // TODO(Antonin): should this make the field case (and other) obsolete
       // maybe if we can optimize this case

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -323,6 +323,10 @@ TEST(P4Objects, ParseVset) {
 
 extern bool WITH_VALGRIND;  // defined in main.cpp
 
+// We are being more conservative in how we enable arithmetic on header stack
+// fields now, since the introduction of the assign_stack core primitive. This
+// test therefore had to be changed, as arith is enabled on all stack fields.
+// TODO(antonin): remove old code from test
 TEST(P4Objects, HeaderStackArith) {
   std::unique_ptr<PHV> phv;
 
@@ -347,13 +351,14 @@ TEST(P4Objects, HeaderStackArith) {
   ASSERT_NO_THROW(h1_f1.get_int());
   ASSERT_NO_THROW(h0_f1.get_int());
 
-  (void) h0_f2; (void) h1_f2;
-#ifndef NDEBUG
-  if (!WITH_VALGRIND) {
-    ASSERT_DEATH(h0_f2.get_int(), "Assertion .*failed");
-    ASSERT_DEATH(h1_f2.get_int(), "Assertion .*failed");
-  }
-#endif
+// #ifndef NDEBUG
+  //   if (!WITH_VALGRIND) {
+  //     ASSERT_DEATH(h0_f2.get_int(), "Assertion .*failed");
+  //     ASSERT_DEATH(h1_f2.get_int(), "Assertion .*failed");
+  //   }
+// #endif
+  ASSERT_NO_THROW(h0_f2.get_int());
+  ASSERT_NO_THROW(h1_f2.get_int());
 }
 
 TEST(P4Objects, Errors) {


### PR DESCRIPTION
Fixes this issue: https://github.com/p4lang/p4c/issues/1128#issuecomment-358834344