### PR TITLE
Fix extraction function for variable-length fields

### DIFF
--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -22,7 +22,6 @@
 #include <bm/bm_sim/headers.h>
 
 #include <algorithm>  // for std::swap
-
 #include "extract.h"
 
 namespace bm {
@@ -81,7 +80,7 @@ int
 Field::extract_VL(const char *data, int hdr_offset, int computed_nbits) {
   nbits = computed_nbits;
   nbytes = (nbits + 7) / 8;
-  mask = (1 << nbits); mask -= 1;
+  mask = 1; mask <<= nbits; mask -= 1;
   bytes.resize(nbytes);
   if (is_signed) {
     assert(nbits > 1);


### PR DESCRIPTION
For VL fields, the bitwidth is dynamic and only known at extract
time. Which means that extract_VL is in charge of computing the Bignum
mask for the Field, which is then used to ensure that the field stays in
the correct range. However, we were using an incorrect expression to
compute the mask, which was causing it to be always 0 for bitwidths >=
32.

Fixes issue #538