### PR TITLE
Style fix: The first value in enum should be labeled unspecified to a…

### DIFF
--- a/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
+++ b/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
@@ -46,8 +46,9 @@ message PacketStreamResponse {
 }
 
 enum PortOperStatus {
-  OPER_STATUS_DOWN = 0;
-  OPER_STATUS_UP = 1;
+  OPER_STATUS_UNKNOWN = 0;
+  OPER_STATUS_DOWN = 1;
+  OPER_STATUS_UP = 2;
 }
 
 message SetPortOperStatusRequest {


### PR DESCRIPTION
…void breaking clients if the desired default behavior changes.