### PR TITLE
Remove dependency on empty.proto in simple_switch_grpc

### DIFF
--- a/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
+++ b/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
@@ -16,8 +16,6 @@ syntax = "proto3";
 
 // This package and its contents are a work-in-progress.
 
-import "google/protobuf/empty.proto";
-
 package p4.bm;
 
 service DataplaneInterface {
@@ -29,7 +27,7 @@ service DataplaneInterface {
   // ports are valid and "UP"). This is useful in the context of testing, to
   // simulate port-up / port-down events.
   rpc SetPortOperStatus(SetPortOperStatusRequest)
-      returns (google.protobuf.Empty) {
+      returns (SetPortOperStatusResponse) {
   }
 }
 
@@ -56,3 +54,5 @@ message SetPortOperStatusRequest {
   uint32 port = 2;
   PortOperStatus oper_status = 3;
 }
+
+message SetPortOperStatusResponse { }

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -84,8 +84,6 @@ class DataplaneInterfaceServiceImpl
  private:
   using Lock = std::lock_guard<std::mutex>;
 
-  using Empty = google::protobuf::Empty;
-
   Status PacketStream(ServerContext *context,
                       ServerReaderWriter *stream) override {
     {
@@ -117,9 +115,10 @@ class DataplaneInterfaceServiceImpl
     return Status::OK;
   }
 
-  Status SetPortOperStatus(ServerContext *context,
-                           const p4::bm::SetPortOperStatusRequest *request,
-                           Empty *response) override {
+  Status SetPortOperStatus(
+      ServerContext *context,
+      const p4::bm::SetPortOperStatusRequest *request,
+      p4::bm::SetPortOperStatusResponse *response) override {
     (void) context;
     (void) response;
     Lock lock(mutex);

--- a/targets/simple_switch_grpc/tests/test_gnmi.cpp
+++ b/targets/simple_switch_grpc/tests/test_gnmi.cpp
@@ -160,7 +160,7 @@ class SimpleSwitchGrpcTest_gNMI : public SimpleSwitchGrpcBaseTest {
     req.set_port(port);
     req.set_oper_status(oper_status);
     ClientContext context;
-    google::protobuf::Empty rep;
+    p4::bm::SetPortOperStatusResponse rep;
     return dataplane_stub->SetPortOperStatus(&context, req, &rep);
   }
 


### PR DESCRIPTION
Fixes #545.
I do not observe a linking error on my system, where
google::protobuf::Empty is part of libprotobuf. It is possible that it
is not the case on other systems or with different versions (more
recent?) of protobuf.
