### PR TITLE
Support "default-default" entry for tables with ability to reset

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -546,7 +546,7 @@ attributes for these objects are:
     - `action_id`: the id of the default action
     - `action_const`: an optional boolean value which is `true` iff the control
     plane is not allowed to change the default action function. Default value is
-    `false`.
+    `false`. It can only be set to `true` for `simple` tables.
     - `action_data`: an optional JSON array where each entry is the hexstring
     value for an action argument. The size of the array needs to match the
     number of parameters expected by the action function with id `action_id`.

--- a/include/bm/bm_sim/action_entry.h
+++ b/include/bm/bm_sim/action_entry.h
@@ -46,8 +46,8 @@ struct ActionEntry {
     return out;
   }
 
-  ActionEntry(const ActionEntry &other) = delete;
-  ActionEntry &operator=(const ActionEntry &other) = delete;
+  ActionEntry(const ActionEntry &other) = default;
+  ActionEntry &operator=(const ActionEntry &other) = default;
 
   ActionEntry(ActionEntry &&other) /*noexcept*/ = default;
   ActionEntry &operator=(ActionEntry &&other) /*noexcept*/ = default;

--- a/include/bm/bm_sim/action_profile.h
+++ b/include/bm/bm_sim/action_profile.h
@@ -111,7 +111,8 @@ class ActionProfile : public NamedP4Object {
 
   ActionProfile(const std::string &name, p4object_id_t id, bool with_selection);
 
-  ActionEntry &lookup(const Packet &pkt, const IndirectIndex &index);
+  const ActionEntry &lookup(const Packet &pkt,
+                            const IndirectIndex &index) const;
 
   bool has_selection() const;
 

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -185,6 +185,9 @@ class Context final {
                         ActionData action_data);
 
   MatchErrorCode
+  mt_reset_default_entry(const std::string &table_name);
+
+  MatchErrorCode
   mt_delete_entry(const std::string &table_name,
                   entry_handle_t handle);
 
@@ -268,6 +271,9 @@ class Context final {
   MatchErrorCode
   mt_indirect_set_default_member(const std::string &table_name,
                                  mbr_hdl_t mbr);
+
+  MatchErrorCode
+  mt_indirect_reset_default_entry(const std::string &table_name);
 
   MatchErrorCode
   mt_indirect_ws_add_entry(const std::string &table_name,

--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -463,6 +463,7 @@ class MatchTableIndirect : public MatchTableAbstract {
   std::unique_ptr<MatchUnitAbstract<IndirectIndex> > match_unit;
   ActionProfile *action_profile{nullptr};
   bool default_set{false};
+  ActionEntry empty_action{};  // for lookups yielding empty groups
 };
 
 class MatchTableIndirectWS : public MatchTableIndirect {

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -79,6 +79,10 @@ class RuntimeInterface {
                         ActionData action_data) = 0;
 
   virtual MatchErrorCode
+  mt_reset_default_entry(cxt_id_t cxt_id,
+                         const std::string &table_name) = 0;
+
+  virtual MatchErrorCode
   mt_delete_entry(cxt_id_t cxt_id,
                   const std::string &table_name,
                   entry_handle_t handle) = 0;
@@ -186,6 +190,10 @@ class RuntimeInterface {
   mt_indirect_set_default_member(cxt_id_t cxt_id,
                                  const std::string &table_name,
                                  mbr_hdl_t mbr) = 0;
+
+  virtual MatchErrorCode
+  mt_indirect_reset_default_entry(cxt_id_t cxt_id,
+                                  const std::string &table_name) = 0;
 
   virtual MatchErrorCode
   mt_indirect_ws_add_entry(cxt_id_t cxt_id,

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -353,6 +353,12 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   }
 
   MatchErrorCode
+  mt_reset_default_entry(cxt_id_t cxt_id,
+                         const std::string &table_name) override {
+    return contexts.at(cxt_id).mt_reset_default_entry(table_name);
+  }
+
+  MatchErrorCode
   mt_delete_entry(cxt_id_t cxt_id,
                   const std::string &table_name,
                   entry_handle_t handle) override {
@@ -506,6 +512,12 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
                                  const std::string &table_name,
                                  mbr_hdl_t mbr) override {
     return contexts.at(cxt_id).mt_indirect_set_default_member(table_name, mbr);
+  }
+
+  MatchErrorCode
+  mt_indirect_reset_default_entry(cxt_id_t cxt_id,
+                                  const std::string &table_name) override {
+    return contexts.at(cxt_id).mt_indirect_reset_default_entry(table_name);
   }
 
   MatchErrorCode

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -251,6 +251,16 @@ public:
     }
   }
 
+  void bm_mt_reset_default_entry(const int32_t cxt_id, const std::string& table_name) {
+    Logger::get()->trace("bm_mt_reset_default_entry");
+    auto error_code = switch_->mt_reset_default_entry(cxt_id, table_name);
+    if(error_code != MatchErrorCode::SUCCESS) {
+      InvalidTableOperation ito;
+      ito.code = get_exception_code(error_code);
+      throw ito;
+    }
+  }
+
   void bm_mt_delete_entry(const int32_t cxt_id, const std::string& table_name, const BmEntryHandle entry_handle) {
     Logger::get()->trace("bm_table_delete_entry");
     MatchErrorCode error_code = switch_->mt_delete_entry(
@@ -432,6 +442,17 @@ public:
     Logger::get()->trace("bm_mt_indirect_set_default_member");
     MatchErrorCode error_code = switch_->mt_indirect_set_default_member(
         cxt_id, table_name, mbr_handle);
+    if(error_code != MatchErrorCode::SUCCESS) {
+      InvalidTableOperation ito;
+      ito.code = get_exception_code(error_code);
+      throw ito;
+    }
+  }
+
+  void bm_mt_indirect_reset_default_entry(const int32_t cxt_id, const std::string& table_name) {
+    Logger::get()->trace("bm_mt_indirect_reset_default_entry");
+    auto error_code = switch_->mt_indirect_reset_default_entry(
+        cxt_id, table_name);
     if(error_code != MatchErrorCode::SUCCESS) {
       InvalidTableOperation ito;
       ito.code = get_exception_code(error_code);

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -449,7 +449,7 @@ ActionProfile::get_member(mbr_hdl_t mbr, Member *member) const {
 std::vector<ActionProfile::Member>
 ActionProfile::get_members() const {
   ReadLock lock = lock_read();
-  std::vector<Member> members(get_num_members());
+  std::vector<Member> members(num_members);
   size_t idx = 0;
   for (const auto h : mbr_handles) {
     MatchErrorCode rc = get_member_(h, &members[idx++]);
@@ -480,7 +480,7 @@ ActionProfile::get_group(grp_hdl_t grp, Group *group) const {
 std::vector<ActionProfile::Group>
 ActionProfile::get_groups() const {
   ReadLock lock = lock_read();
-  std::vector<Group> groups(get_num_groups());
+  std::vector<Group> groups(num_groups);
   size_t idx = 0;
   for (const auto h : grp_handles) {
     MatchErrorCode rc = get_group_(h, &groups[idx++]);
@@ -502,6 +502,18 @@ ActionProfile::get_num_members_in_group(grp_hdl_t grp, size_t *nb) const {
   return MatchErrorCode::SUCCESS;
 }
 
+size_t
+ActionProfile::get_num_members() const {
+  ReadLock lock = lock_read();
+  return num_members;
+}
+
+size_t
+ActionProfile::get_num_groups() const {
+  ReadLock lock = lock_read();
+  return num_groups;
+}
+
 void
 ActionProfile::set_group_selector(GroupSelectionIface *selector) {
   WriteLock lock = lock_write();
@@ -515,6 +527,7 @@ ActionProfile::group_is_empty(grp_hdl_t grp) const {
 
 void
 ActionProfile::reset_state() {
+  WriteLock lock = lock_write();
   index_ref_count = IndirectIndexRefCount();
   mbr_handles.clear();
   action_entries.clear();
@@ -526,6 +539,7 @@ ActionProfile::reset_state() {
 
 void
 ActionProfile::serialize(std::ostream *out) const {
+  ReadLock lock = lock_read();
   (*out) << action_entries.size() << "\n";
   (*out) << num_members << "\n";
   for (const auto h : mbr_handles) {
@@ -542,6 +556,7 @@ ActionProfile::serialize(std::ostream *out) const {
 
 void
 ActionProfile::deserialize(std::istream *in, const P4Objects &objs) {
+  ReadLock lock = lock_read();
   size_t action_entries_size; (*in) >> action_entries_size;
   action_entries.resize(action_entries_size);
   (*in) >> num_members;

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -164,8 +164,8 @@ ActionProfile::ActionProfile(const std::string &name, p4object_id_t id,
     : NamedP4Object(name, id),
       with_selection(with_selection) { }
 
-ActionEntry &
-ActionProfile::lookup(const Packet &pkt, const IndirectIndex &index) {
+const ActionEntry &
+ActionProfile::lookup(const Packet &pkt, const IndirectIndex &index) const {
   assert(index.is_mbr() || with_selection);
 
   mbr_hdl_t mbr;

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -698,6 +698,12 @@ MatchTableIndirect::lookup(const Packet &pkt,
   }
 
   const IndirectIndex &index = (*hit) ? *res.value : default_index;
+  if (index.is_grp() && action_profile->group_is_empty(index.get_grp())) {
+    BMLOG_ERROR_PKT(
+        pkt, "Lookup in table '{}' yielded empty group", get_name());
+    return empty_action;
+  }
+
   const auto &entry = action_profile->lookup(pkt, index);
   // Unfortunately this has to be done at this stage and cannot be done when
   // inserting a member because for 2 match tables sharing the same action

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -815,8 +815,10 @@ MatchTableIndirect::set_default_member(mbr_hdl_t mbr) {
     if (!action_profile->is_valid_mbr(mbr)) {
       rc = MatchErrorCode::INVALID_MBR_HANDLE;
     } else {
+      if (default_set) action_profile->ref_count_decrease(default_index);
       default_index = IndirectIndex::make_mbr_index(mbr);
       default_set = true;
+      action_profile->ref_count_increase(default_index);
     }
   }
 
@@ -834,6 +836,8 @@ MatchErrorCode
 MatchTableIndirect::reset_default_entry() {
   {
     auto lock = lock_write();
+    auto lock_impl = lock_impl_write();
+    if (default_set) action_profile->ref_count_decrease(default_index);
     default_set = false;
   }
 
@@ -1065,7 +1069,10 @@ MatchTableIndirectWS::set_default_group(grp_hdl_t grp) {
     if (!action_profile->is_valid_grp(grp)) {
       rc = MatchErrorCode::INVALID_GRP_HANDLE;
     } else {
+      if (default_set) action_profile->ref_count_decrease(default_index);
       default_index = IndirectIndex::make_grp_index(grp);
+      default_set = true;
+      action_profile->ref_count_increase(default_index);
       default_set = true;
     }
   }

--- a/targets/simple_switch/tests/CLI_tests/testdata/table_dump_extra.in
+++ b/targets/simple_switch/tests/CLI_tests/testdata/table_dump_extra.in
@@ -1,3 +1,5 @@
 table_dump empty_key
 table_set_default empty_key _nop
 table_dump empty_key
+table_reset_default empty_key
+table_dump empty_key

--- a/targets/simple_switch/tests/CLI_tests/testdata/table_dump_extra.out
+++ b/targets/simple_switch/tests/CLI_tests/testdata/table_dump_extra.out
@@ -17,3 +17,11 @@ Dumping default entry
 Action entry: _nop - 
 ==========
 ????
+????
+==========
+TABLE ENTRIES
+==========
+Dumping default entry
+EMPTY
+==========
+????

--- a/tests/test_ageing.cpp
+++ b/tests/test_ageing.cpp
@@ -129,9 +129,11 @@ class AgeingTest : public ::testing::Test {
     Field &f = pkt.get_phv()->get_field(this->testHeader1, 0);
     f.set(key);
     bool hit;
+    const ControlFlowNode *next_node;
+    (void) next_node;
     // lookup is enough to update timestamp (done in match unit),
     // no need for apply_action
-    table->lookup(pkt, &hit, handle);
+    table->lookup(pkt, &hit, handle, &next_node);
     return hit;
   }
 

--- a/tests/test_tables.cpp
+++ b/tests/test_tables.cpp
@@ -1873,6 +1873,27 @@ TEST_F(TableIndirectWS, DefaultGroup) {
   EXPECT_FALSE(hit);
 }
 
+// It can be quite complicated to prevent the control-plane from referencing
+// empty groups (is it even desirable?). We must at least make sure that we do
+// not crash. In the current implementation, I believe the table apply is a
+// no-op.
+TEST_F(TableIndirectWS, EmptyGroup) {
+  MatchErrorCode rc;
+  grp_hdl_t grp;
+  entry_handle_t lookup_handle;
+  bool hit;
+
+  auto pkt = get_pkt(64);
+
+  rc = action_profile.create_group(&grp);
+  EXPECT_EQ(MatchErrorCode::SUCCESS, rc);
+
+  rc = table->set_default_group(grp);
+  EXPECT_EQ(rc, MatchErrorCode::SUCCESS);
+
+  lookup(pkt, &hit, &lookup_handle);
+}
+
 TEST_F(TableIndirectWS, CustomGroupSelection) {
   using GroupSelectionIface = ActionProfile::GroupSelectionIface;
   using hash_t = ActionProfile::hash_t;

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -309,7 +309,7 @@ service Standard {
   void bm_mt_clear_entries(
     1:i32 cxt_id,
     2:string table_name,
-    3:bool reset_default_entry  // TODO(antonin): not implemented yet
+    3:bool reset_default_entry
   ) throws (1:InvalidTableOperation ouch),
 
   // direct tables
@@ -328,6 +328,11 @@ service Standard {
     2:string table_name,
     3:string action_name,
     4:BmActionData action_data
+  ) throws (1:InvalidTableOperation ouch),
+
+  void bm_mt_reset_default_entry(
+    1:i32 cxt_id,
+    2:string table_name
   ) throws (1:InvalidTableOperation ouch),
 
   void bm_mt_delete_entry(
@@ -455,6 +460,11 @@ service Standard {
     1:i32 cxt_id,
     2:string table_name,
     3:BmMemberHandle mbr_handle
+  ) throws (1:InvalidTableOperation ouch),
+
+  void bm_mt_indirect_reset_default_entry(
+    1:i32 cxt_id,
+    2:string table_name
   ) throws (1:InvalidTableOperation ouch),
 
   // indirect tables with selector

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -950,6 +950,22 @@ class RuntimeAPI(cmd.Cmd):
     def complete_table_set_default(self, text, line, start_index, end_index):
         return self._complete_table_and_action(text, line)
 
+    @handle_bad_input
+    def do_table_reset_default(self, line):
+        "Reset default entry for a match table: table_reset_default <table name>"
+        args = line.split()
+
+        self.exactly_n_args(args, 1)
+
+        table_name = args[0]
+
+        table = self.get_res("table", table_name, ResType.table)
+
+        self.client.bm_mt_reset_default_entry(0, table.name)
+
+    def complete_table_reset_default(self, text, line, start_index, end_index):
+        return self._complete_tables(text)
+
     def parse_runtime_data(self, action, action_params):
         if len(action_params) != action.num_params():
             raise UIn_Error(
@@ -1395,6 +1411,22 @@ class RuntimeAPI(cmd.Cmd):
         self.client.bm_mt_indirect_ws_set_default_group(0, table_name, handle)
 
     def complete_table_indirect_set_default_with_group(self, text, line, start_index, end_index):
+        return self._complete_tables(text)
+
+    @handle_bad_input
+    def do_table_indirect_reset_default(self, line):
+        "Reset default entry for indirect match table: table_indirect_reset_default <table name>"
+        args = line.split()
+
+        self.exactly_n_args(args, 1)
+
+        table_name = args[0]
+
+        table = self.get_res("table", table_name, ResType.table)
+
+        self.client.bm_mt_indirect_reset_default_entry(0, table.name)
+
+    def complete_table_indirect_reset_default(self, text, line, start_index, end_index):
         return self._complete_tables(text)
 
     @handle_bad_input


### PR DESCRIPTION
This commit introduces the following:
  * support for compile-time default entry for indirect tables; until
  now only direct tables could have compile-time default entries. Unlike
  a control-plane provided default entry, the compile-time default entry
  for indirect tables uses action + action data (not member / group
  handle)
  * ability to reset default entry to initial compile-time default entry
  (aka default-default entry). The Thrift IDL has been updated as well
  as the runtime_CLI, with support in P4 Runtime to follow.

These changes should be able to accomodate both P4_14 & P4_16 and both
bmv2 compilers.

I believe I also found a possible race condition when indirect match
tables share the same action profile and it should be fixed now.