### PR TITLE
Support OC interface counters in sysrepo state provider

### DIFF
--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -73,6 +73,18 @@ class DevMgrIface : public PacketDispatcherIface {
     PortExtras extra{};
   };
 
+  struct PortStats {
+    uint64_t in_packets;
+    uint64_t in_octets;
+    uint64_t out_packets;
+    uint64_t out_octets;
+
+    static PortStats make(uint64_t in_packets, uint64_t in_octets,
+                          uint64_t out_packets, uint64_t out_octets) {
+      return {in_packets, in_octets, out_packets, out_octets};
+    }
+  };
+
   virtual ~DevMgrIface();
 
   ReturnCode port_add(const std::string &iface_name, port_t port_num,
@@ -99,6 +111,10 @@ class DevMgrIface : public PacketDispatcherIface {
 
   std::map<port_t, PortInfo> get_port_info() const;
 
+  PortStats get_port_stats(port_t port) const;
+  // clear and return stats (before clear)
+  PortStats clear_port_stats(port_t port);
+
  protected:
   std::unique_ptr<PortMonitorIface> p_monitor{nullptr};
 
@@ -118,6 +134,9 @@ class DevMgrIface : public PacketDispatcherIface {
   virtual bool port_is_up_(port_t port_num) const = 0;
 
   virtual std::map<port_t, PortInfo> get_port_info_() const = 0;
+
+  virtual PortStats get_port_stats_(port_t port) const;
+  virtual PortStats clear_port_stats_(port_t port);
 };
 
 // TODO(antonin): should DevMgr and DevMgrIface somehow inherit from a common
@@ -168,6 +187,9 @@ class DevMgr : public PacketDispatcherIface {
   bool port_is_up(port_t port_num) const;
 
   std::map<port_t, DevMgrIface::PortInfo> get_port_info() const;
+
+  DevMgrIface::PortStats get_port_stats(port_t port_num) const;
+  DevMgrIface::PortStats clear_port_stats(port_t port_num);
 
   //! Transmits a data packet out of port \p port_num
   void transmit_fn(int port_num, const char *buffer, int len);

--- a/src/BMI/BMI/bmi_port.h
+++ b/src/BMI/BMI/bmi_port.h
@@ -20,11 +20,20 @@
 
 #ifndef _BMI_PORT_
 #define _BMI_PORT_
+
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct bmi_port_s bmi_port_t;
 
 typedef struct bmi_port_mgr_s bmi_port_mgr_t;
+
+typedef struct bmi_port_stats_s {
+  uint64_t in_packets;
+  uint64_t in_octets;
+  uint64_t out_packets;
+  uint64_t out_octets;
+} bmi_port_stats_t;
 
 /* the client must make a copy of the buffer memory, this memory cannot be
    modified and is no longer garanteed to be valid after the function
@@ -34,7 +43,7 @@ typedef void (*bmi_packet_handler_t)(int port_num, const char *buffer, int len, 
 int bmi_port_create_mgr(bmi_port_mgr_t **port_mgr);
 
 /* Start running the port manager on its own thread */
-int bmi_start_mgr(bmi_port_mgr_t* port_mgr);
+int bmi_start_mgr(bmi_port_mgr_t *port_mgr);
 
 int bmi_set_packet_handler(bmi_port_mgr_t *port_mgr,
 			   bmi_packet_handler_t packet_handler,
@@ -46,12 +55,24 @@ int bmi_port_send(bmi_port_mgr_t *port_mgr,
 int bmi_port_interface_add(bmi_port_mgr_t *port_mgr,
 			   const char *ifname, int port_num,
 			   const char *pcap_input_dump,
-			   const char* pcap_output_dump);
+			   const char *pcap_output_dump);
 
 int bmi_port_interface_remove(bmi_port_mgr_t *port_mgr, int port_num);
 
 int bmi_port_destroy_mgr(bmi_port_mgr_t *port_mgr);
 
-int bmi_port_interface_is_up(bmi_port_mgr_t *port_mgr, int port_num, bool *is_up);
+int bmi_port_interface_is_up(bmi_port_mgr_t *port_mgr,
+                             int port_num,
+                             bool *is_up);
+
+int bmi_port_get_stats(bmi_port_mgr_t *port_mgr,
+                       int port_num,
+                       bmi_port_stats_t *port_stats);
+
+/* use port_stats == NULL if you are not interested in the stats value before
+   the clear */
+int bmi_port_clear_stats(bmi_port_mgr_t *port_mgr,
+                         int port_num,
+                         bmi_port_stats_t *port_stats);
 
 #endif

--- a/src/bm_sim/dev_mgr.cpp
+++ b/src/bm_sim/dev_mgr.cpp
@@ -156,6 +156,28 @@ DevMgrIface::get_port_info() const {
   return get_port_info_();
 }
 
+DevMgrIface::PortStats
+DevMgrIface::get_port_stats(port_t port) const {
+  return get_port_stats_(port);
+}
+
+DevMgrIface::PortStats
+DevMgrIface::get_port_stats_(port_t port) const {  // default implementation
+  UNUSED(port);
+  return {};  // value-initialized to 0s
+}
+
+DevMgrIface::PortStats
+DevMgrIface::clear_port_stats(port_t port) {
+  return clear_port_stats_(port);
+}
+
+DevMgrIface::PortStats
+DevMgrIface::clear_port_stats_(port_t port) {  // default implementation
+  UNUSED(port);
+  return {};  // value-initialized to 0s
+}
+
 PacketDispatcherIface::ReturnCode
 DevMgrIface::register_status_cb(const PortStatus &type,
                                 const PortStatusCb &port_cb) {
@@ -243,6 +265,18 @@ std::map<DevMgrIface::port_t, DevMgrIface::PortInfo>
 DevMgr::get_port_info() const {
   assert(pimp);
   return pimp->get_port_info();
+}
+
+DevMgrIface::PortStats
+DevMgr::get_port_stats(port_t port_num) const {
+  assert(pimp);
+  return pimp->get_port_stats(port_num);
+}
+
+DevMgrIface::PortStats
+DevMgr::clear_port_stats(port_t port_num) {
+  assert(pimp);
+  return pimp->clear_port_stats(port_num);
 }
 
 std::string

--- a/src/bm_sim/dev_mgr_bmi.cpp
+++ b/src/bm_sim/dev_mgr_bmi.cpp
@@ -132,6 +132,20 @@ class BmiDevMgrImp : public DevMgrIface {
     return info;
   }
 
+  PortStats get_port_stats_(port_t port) const override {
+    bmi_port_stats_t port_stats;
+    bmi_port_get_stats(port_mgr, port, &port_stats);
+    return {port_stats.in_packets, port_stats.in_octets,
+          port_stats.out_packets, port_stats.out_octets};
+  }
+
+  PortStats clear_port_stats_(port_t port) override {
+    bmi_port_stats_t port_stats;
+    bmi_port_clear_stats(port_mgr, port, &port_stats);
+    return {port_stats.in_packets, port_stats.in_octets,
+          port_stats.out_packets, port_stats.out_octets};
+  }
+
  private:
   using Mutex = std::mutex;
   using Lock = std::lock_guard<std::mutex>;

--- a/targets/simple_switch_grpc/README.md
+++ b/targets/simple_switch_grpc/README.md
@@ -52,8 +52,16 @@ For simple_switch_grpc, we require that the interface name follow this pattern:
 | `state/admin-status` | Yes |
 | `state/oper-status` | Yes |
 | `state/last-change` | No |
-| `state/counters` | Planned |
+| `state/counters` | Yes |
 | `subinterfaces` | No |
+
+About `state/counters`:
+  * error counters (e.g. `in-discards`) are always set to 0.
+  * all packets sent and received are counted as `unicast-pkts`;
+  `broadcast-pkts` and `multicast-pkts` will therefore always be 0.
+  * `carrier-transitions` and `last-change` may not be very accurate as their
+  implementation is somewhat naive.
+  * counters are cleared when the interface is deleted.
 
 #### openconfig-if-ethernet (`ethernet`)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,6 +11,7 @@ libtestutils_la_LIBADD = $(top_builddir)/src/bm_sim/libbmsim.la
 
 AM_CPPFLAGS += \
 -I$(top_srcdir)/src/bm_sim \
+-I$(top_srcdir)/src/BMI \
 -isystem $(top_srcdir)/third_party/gtest/include \
 -isystem $(top_srcdir)/third_party/jsoncpp/include \
 -DTESTDATADIR=\"$(abs_srcdir)/testdata\"

--- a/tests/bmi_stubs.c
+++ b/tests/bmi_stubs.c
@@ -20,44 +20,69 @@
 
 #include <stdbool.h>
 
-typedef void bmi_port_mgr_t;
+#include "BMI/bmi_port.h"
 
-int bmi_start_mgr(bmi_port_mgr_t* port_mgr) {
-  (void) port_mgr;
+// BMI stubs to avoid having to link with BMI and its deps for unit tests.
+
+#define UNUSED(x) (void)(x)
+
+int bmi_start_mgr(bmi_port_mgr_t *port_mgr) {
+  UNUSED(port_mgr);
   return 0;
 }
 
 int bmi_port_create_mgr(bmi_port_mgr_t **port_mgr) {
-  (void) port_mgr;
+  UNUSED(port_mgr);
   return 0;
 }
 
-int bmi_set_packet_handler(bmi_port_mgr_t *port_mgr) {
-  (void) port_mgr;
+int bmi_set_packet_handler(bmi_port_mgr_t *port_mgr,
+                           bmi_packet_handler_t packet_handler,
+                           void *cookie) {
+  UNUSED(port_mgr); UNUSED(packet_handler); UNUSED(cookie);
   return 0;
 }
 
-int bmi_port_send(bmi_port_mgr_t *port_mgr) {
-  (void) port_mgr;
+int bmi_port_send(bmi_port_mgr_t *port_mgr, int port_num,
+                  const char *buffer, int len) {
+  UNUSED(port_mgr); UNUSED(port_num); UNUSED(buffer); UNUSED(len);
   return 0;
 }
 
-int bmi_port_interface_add(bmi_port_mgr_t *port_mgr) {
-  (void) port_mgr;
+int bmi_port_interface_add(bmi_port_mgr_t *port_mgr,
+                           const char *ifname, int port_num,
+                           const char *pcap_input_dump,
+                           const char *pcap_output_dump) {
+  UNUSED(port_mgr); UNUSED(ifname); UNUSED(port_num);
+  UNUSED(pcap_input_dump); UNUSED(pcap_output_dump);
   return 0;
 }
 
 int bmi_port_interface_remove(bmi_port_mgr_t *port_mgr, int port_num) {
-  (void) port_mgr;
+
+  UNUSED(port_mgr); UNUSED(port_num);
   return 0;
 }
 
 int bmi_port_destroy_mgr(bmi_port_mgr_t *port_mgr) {
-  (void) port_mgr;
+  UNUSED(port_mgr);
   return 0;
 }
 
-int bmi_port_interface_is_up(bmi_port_mgr_t* port_mgr, int port_num, bool *is_up) {
-  (void) port_mgr;
+int bmi_port_interface_is_up(bmi_port_mgr_t *port_mgr,
+                             int port_num, bool *is_up) {
+  UNUSED(port_mgr); UNUSED(port_num); UNUSED(is_up);
+  return 0;
+}
+
+int bmi_port_get_stats(bmi_port_mgr_t *port_mgr,
+                       int port_num, bmi_port_stats_t *port_stats) {
+  UNUSED(port_mgr); UNUSED(port_num); UNUSED(port_stats);
+  return 0;
+}
+
+int bmi_port_clear_stats(bmi_port_mgr_t *port_mgr,
+                         int port_num, bmi_port_stats_t *port_stats) {
+  UNUSED(port_mgr); UNUSED(port_num); UNUSED(port_stats);
   return 0;
 }

--- a/tests/stress_tests/Makefile.am
+++ b/tests/stress_tests/Makefile.am
@@ -1,4 +1,5 @@
 AM_CPPFLAGS += \
+-I$(top_srcdir)/src/BMI \
 -isystem $(top_srcdir)/third_party \
 -DTESTDATADIR=\"$(abs_srcdir)/testdata\"
 LDADD = \


### PR DESCRIPTION
We now support openconfig-interfaces counters in the sysrepo state
provider for simple_switch_grpc.

In order to achieve this, we updated the bm::DevMgrIface to support
querying and clearing port stats (packets & octets). We also considered
implementing this functionality in bm::DevMgr, but decided it was better
to let each DevMgrIface implementation support stats in its preferred
way.

Both the BMI DevMgr and the DataplaneInterface gRPC service (for
simple_switch_grpc) support stats. For BMI, the implementation is quite
naive and uses a mutex to protect the stat counters. This may be
improved in the future with CAS.

The simple_switch_grpc README has been updated to indicate the
additional OpenConfig support.