### PR TITLE
Make P4_16 stack implementation the default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_ARG_ENABLE([Werror],
 AC_ARG_ENABLE([WP4-16-stacks],
     AS_HELP_STRING([--enable-WP4-16-stacks],
                    [Implement stacks strictly as per the P4_16 specification instead of legacy behavior]),
-    [enable_WP4_16_stacks="$enableval"], [enable_WP4_16_stacks=no])
+    [enable_WP4_16_stacks="$enableval"], [enable_WP4_16_stacks=yes])
 
 AS_IF([test "$enable_WP4_16_stacks" = "yes"],
       [MY_CPPFLAGS="$MY_CPPFLAGS -DBM_WP4_16_STACKS"])


### PR DESCRIPTION
As previously announced, we are making the P4_16-conformant
implementation for header stacks the default in prevision of the bmv2
1.11.0 release.

As a remainder, the new implementation differs from the old one in the
following ways: push_front and pop_front shift the entire stack (not
just until the next index), and pushed headers are marked as invalid
instead of valid.

The legacy implementation can be toggled by passing the
`--disable-WP4-16-stacks` flag to configure.

We recommend that exsiting P4_14 compilers inject an instruction to make
pushed header valid if they want to achieve a similar behavior as the
legacy implementation.

Fixes #557