### PR TITLE
Setting specific priority queue depth or rate

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -183,6 +183,12 @@ SimpleSwitch::set_egress_queue_depth(int port, const size_t depth_pkts) {
 }
 
 int
+SimpleSwitch::set_egress_priority_queue_depth(int port, size_t priority, const size_t depth_pkts) {
+  egress_buffers.set_capacity(port, priority, depth_pkts);
+  return 0;
+}
+
+int
 SimpleSwitch::set_all_egress_queue_depths(const size_t depth_pkts) {
   for (int i = 0; i < max_port; i++) {
     set_egress_queue_depth(i, depth_pkts);
@@ -193,6 +199,12 @@ SimpleSwitch::set_all_egress_queue_depths(const size_t depth_pkts) {
 int
 SimpleSwitch::set_egress_queue_rate(int port, const uint64_t rate_pps) {
   egress_buffers.set_rate(port, rate_pps);
+  return 0;
+}
+
+int
+SimpleSwitch::set_egress_priority_queue_rate(int port, size_t priority,  const uint64_t rate_pps) {
+  egress_buffers.set_rate(port, priority, rate_pps);
   return 0;
 }
 

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -100,9 +100,11 @@ class SimpleSwitch : public Switch {
   }
 
   int set_egress_queue_depth(int port, const size_t depth_pkts);
+  int set_egress_priority_queue_depth(int port, size_t priority, const size_t depth_pkts);
   int set_all_egress_queue_depths(const size_t depth_pkts);
 
   int set_egress_queue_rate(int port, const uint64_t rate_pps);
+  int set_egress_priority_queue_rate(int port, size_t priority, const uint64_t rate_pps);
   int set_all_egress_queue_rates(const uint64_t rate_pps);
 
   // returns the number of microseconds elapsed since the switch started

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -37,41 +37,69 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
                                         standard_client, mc_client)
         self.sswitch_client = sswitch_client
 
+    @runtime_CLI.handle_bad_input
     def do_set_queue_depth(self, line):
-        "Set depth of one / all egress queue(s): set_queue_depth <nb_pkts> [<egress_port>]"
+        "Set depth of one / all egress queue(s): set_queue_depth <nb_pkts> [<egress_port>] [<priority>]"
         args = line.split()
-        depth = int(args[0])
-        if len(args) > 1:
-            port = int(args[1])
-            self.sswitch_client.set_egress_queue_depth(port, depth)
-        else:
-            self.sswitch_client.set_all_egress_queue_depths(depth)
 
+        self.at_least_n_args(args, 1)
+
+        try:
+            depth = int(args[0])
+            if len(args) > 2:
+                port = int(args[1])
+                priority = int(args[2])
+                self.sswitch_client.set_egress_priority_queue_depth(port, priority, depth)
+            elif len(args) > 1:
+                port = int(args[1])
+                self.sswitch_client.set_egress_queue_depth(port, rate)
+            else:
+                self.sswitch_client.set_all_egress_queue_depths(depth)
+
+        except ValueError:
+            print "Invalid depth, port or priority value"
+
+    @runtime_CLI.handle_bad_input
     def do_set_queue_rate(self, line):
-        "Set rate of one / all egress queue(s): set_queue_rate <rate_pps> [<egress_port>]"
+        "Set rate of one / all egress queue(s): set_queue_rate <rate_pps> [<egress_port>] [<priority>]"
         args = line.split()
-        rate = int(args[0])
-        if len(args) > 1:
-            port = int(args[1])
-            self.sswitch_client.set_egress_queue_rate(port, rate)
-        else:
-            self.sswitch_client.set_all_egress_queue_rates(rate)
-
+        
+        self.at_least_n_args(args,1)
+        
+        try:
+            rate = int(args[0])
+            if len(args) > 2:
+                port = int(args[1])
+                priority = int(args[2])
+                self.sswitch_client.set_egress_priority_queue_rate(port, priority, rate)
+            elif len(args) > 1:
+                port = int(args[1])
+                self.sswitch_client.set_egress_queue_rate(port, rate)
+            else:
+                self.sswitch_client.set_all_egress_queue_rates(rate)
+        except ValueError:
+            print "Invalid rate, port or priority value"
+    
+    @runtime_CLI.handle_bad_input
     def do_mirroring_add(self, line):
         "Add mirroring mapping: mirroring_add <mirror_id> <egress_port>"
         args = line.split()
+        self.at_least_n_args(args,2)
         mirror_id, egress_port = int(args[0]), int(args[1])
         self.sswitch_client.mirroring_mapping_add(mirror_id, egress_port)
 
+    @runtime_CLI.handle_bad_input
     def do_mirroring_delete(self, line):
         "Delete mirroring mapping: mirroring_delete <mirror_id>"
         mirror_id = int(line)
         self.sswitch_client.mirroring_mapping_delete(mirror_id)
 
+    @runtime_CLI.handle_bad_input
     def do_get_time_elapsed(self, line):
         "Get time elapsed (in microseconds) since the switch started: get_time_elapsed"
         print self.sswitch_client.get_time_elapsed_us()
 
+    @runtime_CLI.handle_bad_input
     def do_get_time_since_epoch(self, line):
         "Get time elapsed (in microseconds) since the switch clock's epoch: get_time_since_epoch"
         print self.sswitch_client.get_time_since_epoch_us()

--- a/targets/simple_switch/thrift/simple_switch.thrift
+++ b/targets/simple_switch/thrift/simple_switch.thrift
@@ -28,8 +28,10 @@ service SimpleSwitch {
   i32 mirroring_mapping_get_egress_port(1:i32 mirror_id);
 
   i32 set_egress_queue_depth(1:i32 port_num, 2:i32 depth_pkts);
+  i32 set_egress_priority_queue_depth(1:i32 port_num, 2:i32 priority, 3:i32 depth_pkts);
   i32 set_all_egress_queue_depths(1:i32 depth_pkts);
   i32 set_egress_queue_rate(1:i32 port_num, 2:i64 rate_pps);
+  i32 set_egress_priority_queue_rate(1:i32 port_num, 2:i32 priority, 3:i64 rate_pps);
   i32 set_all_egress_queue_rates(1:i64 rate_pps);
 
   // these methods are here as an experiment, prefer get_time_elapsed_us() when

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -71,6 +71,15 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
                                            static_cast<uint32_t>(depth_pkts));
   }
 
+  int32_t set_egress_priority_queue_depth(const int32_t port_num,
+				 const int32_t priority,
+                                 const int32_t depth_pkts) {
+    bm::Logger::get()->trace("set_egress_priority_queue_depth");
+    return switch_->set_egress_priority_queue_depth(port_num,
+					   priority,
+                                           static_cast<uint32_t>(depth_pkts));
+  }
+
   int32_t set_all_egress_queue_depths(const int32_t depth_pkts) {
     bm::Logger::get()->trace("set_all_egress_queue_depths");
     return switch_->set_all_egress_queue_depths(
@@ -81,6 +90,15 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
                                 const int64_t rate_pps) {
     bm::Logger::get()->trace("set_egress_queue_rate");
     return switch_->set_egress_queue_rate(port_num,
+                                          static_cast<uint64_t>(rate_pps));
+  }
+
+  int32_t set_egress_priority_queue_rate(const int32_t port_num,
+				const int32_t priority,
+                                const int64_t rate_pps) {
+    bm::Logger::get()->trace("set_egress_priority_queue_rate");
+    return switch_->set_egress_priority_queue_rate(port_num,
+					  priority,
                                           static_cast<uint64_t>(rate_pps));
   }
 


### PR DESCRIPTION
Add a method to set the depth or rate of priority queues in the simple switch. At the moment the `sswitch_CLI.py` is using `set_egress_queue_depth/rate` to  set the rate/depth of a given port but there was not way to set if for an individual priority queue. 

This patch adds:
- `set_egress_priority_queue_depth/rate` in the `simple_switch` implementation
-  Updated `thrift` files
-  Modified `do_set_queue_depth/rate` from `sswitch_CLI.py` so they call the new functions when a priority is provided. Also added exception catchers when the parameters are not integers. 