### PR TITLE
Cleanup code in simple_switch and simple_switch_grpc targets

### DIFF
--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -99,10 +99,10 @@ class SimpleSwitch : public Switch {
     return get_mirroring_mapping(mirror_id, port);
   }
 
-  int set_egress_queue_depth(port_t port, const size_t depth_pkts);
+  int set_egress_queue_depth(size_t port, const size_t depth_pkts);
   int set_all_egress_queue_depths(const size_t depth_pkts);
 
-  int set_egress_queue_rate(port_t port, const uint64_t rate_pps);
+  int set_egress_queue_rate(size_t port, const uint64_t rate_pps);
   int set_all_egress_queue_rates(const uint64_t rate_pps);
 
   // returns the number of microseconds elapsed since the switch started

--- a/targets/simple_switch_grpc/tests/utils.cpp
+++ b/targets/simple_switch_grpc/tests/utils.cpp
@@ -49,15 +49,6 @@ int get_action_id(const p4::config::P4Info &p4info,
   return 0;
 }
 
-int get_direct_counter_id(const p4::config::P4Info &p4info,
-                          const std::string &direct_counter_name) {
-  for (const auto &direct_counters : p4info.direct_counters()) {
-    const auto &pre = direct_counters.preamble();
-    if (pre.name() == direct_counter_name) return pre.id();
-  }
-  return 0;
-}
-
 int get_mf_id(const p4::config::P4Info &p4info,
               const std::string &t_name, const std::string &mf_name) {
   for (const auto &table : p4info.tables()) {

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -39,9 +39,6 @@ int get_mf_id(const p4::config::P4Info &p4info,
 int get_param_id(const p4::config::P4Info &p4info,
                  const std::string &a_name, const std::string &param_name);
 
-int get_direct_counter_id(const p4::config::P4Info &p4info,
-                          const std::string &direct_counter_name);
-
 p4::config::P4Info parse_p4info(const char *path);
 
 }  // namespace testing


### PR DESCRIPTION
1) Create one extra queue for cpu_port if it is greater than max_port: queue id max_port.
2) Added check for invalid port in SimpleSwitch::enqueue()
3) Cleaned up unused function in simple_switch_grpc/tests/utils.cpp