### PR TITLE
Added new id field to PacketStreamRequest and PacketStreamResponse messages in dataplane_interface.proto

### DIFF
--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -69,7 +69,8 @@ class SimpleSwitch : public Switch {
  public:
   using mirror_id_t = int;
 
-  using TransmitFn = std::function<void(int, const char *, int)>;
+  using TransmitFn = std::function<void(port_t, packet_id_t,
+                                        const char *, int)>;
 
  private:
   using clock = std::chrono::high_resolution_clock;
@@ -111,10 +112,16 @@ class SimpleSwitch : public Switch {
   // returns the number of microseconds elasped since the clock's epoch
   uint64_t get_time_since_epoch_us() const;
 
+  // returns the packet id of most recently received packet. Not thread-safe.
+  static packet_id_t get_packet_id() {
+    return (packet_id-1);
+  }
+
   void set_transmit_fn(TransmitFn fn);
 
  private:
   static constexpr size_t nb_egress_threads = 4u;
+  static packet_id_t packet_id;
 
   enum PktInstanceType {
     PKT_INSTANCE_TYPE_NORMAL,

--- a/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
+++ b/targets/simple_switch_grpc/p4/bm/dataplane_interface.proto
@@ -32,15 +32,20 @@ service DataplaneInterface {
 }
 
 message PacketStreamRequest {
-  uint64 device_id = 1;
-  uint32 port = 2;
-  bytes packet = 3;
+  // Non-zero id will be reflected in PacketStreamResponse::id.
+  // Client is responsible for making sure id is unique in order to correctly
+  // correlate PacketStreamResponse(s) to a PacketStreamRequest.
+  uint64 id = 1;
+  uint64 device_id = 2;
+  uint32 port = 3;
+  bytes packet = 4;
 }
 
 message PacketStreamResponse {
-  uint64 device_id = 1;
-  uint32 port = 2;
-  bytes packet = 3;
+  uint64 id = 1;
+  uint64 device_id = 2;
+  uint32 port = 3;
+  bytes packet = 4;
 }
 
 enum PortOperStatus {

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -44,6 +44,8 @@ namespace sswitch_grpc {
 
 class SysrepoDriver;
 
+class DataplaneInterfaceServiceImpl;
+
 class SimpleSwitchGrpcRunner {
  public:
   // there is no real need for a singleton here, except for the fact that we use
@@ -86,6 +88,7 @@ class SimpleSwitchGrpcRunner {
   bm::DevMgrIface::port_t cpu_port;
   std::string dp_grpc_server_addr;
   int dp_grpc_server_port;
+  DataplaneInterfaceServiceImpl *dp_service;
   std::unique_ptr<grpc::Server> dp_grpc_server;
 #ifdef WITH_SYSREPO
   std::unique_ptr<SysrepoDriver> sysrepo_driver;

--- a/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
@@ -59,6 +59,7 @@ class SimpleSwitchGrpcTest_GrpcDataplane : public SimpleSwitchGrpcBaseTest {
 
 TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, SendAndReceive) {
   p4::bm::PacketStreamRequest request;
+  request.set_id(42);
   request.set_device_id(device_id);
   request.set_port(9);
   request.set_packet(std::string(10, '\xab'));
@@ -67,6 +68,7 @@ TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, SendAndReceive) {
   stream->Write(request);
   p4::bm::PacketStreamResponse response;
   stream->Read(&response);
+  EXPECT_EQ(response.id(), request.id());
   EXPECT_EQ(request.device_id(), response.device_id());
   EXPECT_EQ(request.port(), response.port());
   EXPECT_EQ(request.packet(), response.packet());
@@ -79,6 +81,7 @@ TEST_F(SimpleSwitchGrpcTest_GrpcDataplane, SendAndReceive) {
   stream->Write(request);
   stream->WritesDone();
   stream->Read(&response);
+  EXPECT_EQ(response.id(), request.id());
   EXPECT_EQ(request.device_id(), response.device_id());
   EXPECT_EQ(request.port(), response.port());
   EXPECT_EQ(request.packet(), response.packet());


### PR DESCRIPTION
This will allow clients to send multiple packets and be able to correlate output packets to input packets; thus improving testing and debuggability.