### PR TITLE
Fix for register reset

### DIFF
--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1982,6 +1982,8 @@ class RuntimeAPI(cmd.Cmd):
         args = line.split()
         self.exactly_n_args(args, 1)
         register_name = args[0]
+        register = self.get_res("register", register_name,
+                                ResType.register_array)
         self.client.bm_register_reset(0, register.name)
 
     def complete_register_reset(self, text, line, start_index, end_index):


### PR DESCRIPTION
Currently register reset throws a:
File "/usr/local/lib/python2.7/dist-packages/runtime_CLI.py", line 1985, in do_register_reset
    self.client.bm_register_reset(0, register.name)
NameError: global name 'register' is not defined
The fix follows does the same thing as the other register operations.