### PR TITLE
Fix simple_switch_grpc transmit fn

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -326,8 +326,12 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
                                         buf, static_cast<size_t>(len));
       if (status != PI_STATUS_SUCCESS)
         bm::Logger::get()->error("Error when transmitting packet-in");
-    } else {
+    } else if (dp_service != nullptr) {
+      // need pkt_id for gRPC dp service, so we have to call the my_transmit_fn
+      // directly
       dp_service->my_transmit_fn(port_num, pkt_id, buf, len);
+    } else {
+      simple_switch->transmit_fn(port_num, buf, len);
     }
   };
   simple_switch->set_transmit_fn(transmit_fn);


### PR DESCRIPTION
Because of a recent change, simple_switch_grpc would crash upon
transmitting a packet except when using the gRPC dataplane service. This
fix modifies the transmit function to treat outgoing packets differently
based on whether the gRPC dataplane service is used (in which case the
packet id needs to be passed along) or some other DevMgrIface
implementation is used.

Fixes #582