### PR TITLE
Respect P4Runtime priority order in simple_switch_grpc

### DIFF
--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -34,7 +34,8 @@ example_SOURCES = example.cpp utils.h utils.cpp
 test_gtest_SOURCES = \
 $(common_source) main.cpp \
 test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp \
-test_counter.cpp test_meter.cpp
+test_counter.cpp test_meter.cpp \
+test_ternary.cpp
 if WITH_SYSREPO
 test_gtest_SOURCES += test_gnmi.cpp
 endif
@@ -52,4 +53,5 @@ simple_router.json simple_router.proto.txt \
 packet_io.p4 packet_io.json packet_io.proto.txt \
 loopback.p4 loopback.json loopback.proto.txt \
 counter.p4 counter.json counter.proto.txt \
-meter.p4 meter.json meter.proto.txt
+meter.p4 meter.json meter.proto.txt \
+ternary.p4 ternary.json ternary.proto.txt

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -102,7 +102,7 @@ SimpleSwitchGrpcBaseTest::set_election_id(p4::Uint128 *election_id) const {
 grpc::Status
 SimpleSwitchGrpcBaseTest::Write(ClientContext *context,
                                 p4::WriteRequest &request,
-                                p4::WriteResponse *response) {
+                                p4::WriteResponse *response) const {
   set_election_id(request.mutable_election_id());
   return p4runtime_stub->Write(context, request, response);
 }

--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -64,7 +64,7 @@ class SimpleSwitchGrpcBaseTest : public ::testing::Test {
   // calls p4runtime_stub->Write, with the appropriate election_id
   grpc::Status Write(ClientContext *context,
                      p4::WriteRequest &request,
-                     p4::WriteResponse *response);
+                     p4::WriteResponse *response) const;
 
   std::shared_ptr<grpc::Channel> p4runtime_channel;
   std::unique_ptr<p4::P4Runtime::Stub> p4runtime_stub;

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -50,6 +50,8 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
     argv.push_back("--thrift-port");
     argv.push_back("45459");
 #endif  // WITH_THRIFT
+    // you can uncomment this when debugging
+    // argv.push_back("--log-console");
     argv.push_back(start_json);
     auto argc = static_cast<int>(argv.size());
     parser.parse(argc, const_cast<char **>(argv.data()), nullptr);

--- a/targets/simple_switch_grpc/tests/test_ternary.cpp
+++ b/targets/simple_switch_grpc/tests/test_ternary.cpp
@@ -1,0 +1,178 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/p4runtime.grpc.pb.h>
+
+#include <google/protobuf/util/message_differencer.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "base_test.h"
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+using google::protobuf::util::MessageDifferencer;
+
+constexpr char ternary_json[] = TESTDATADIR "/ternary.json";
+constexpr char ternary_proto[] = TESTDATADIR "/ternary.proto.txt";
+
+class SimpleSwitchGrpcTest_Ternary : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_Ternary()
+      : SimpleSwitchGrpcBaseTest(ternary_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(ternary_json);
+    t_id = get_table_id(p4info, "ingress.ter");
+    mf_id = get_mf_id(p4info, "ingress.ter", "h.hdr.f1");
+    a_nop_id = get_action_id(p4info, "NoAction");
+    a_s1_id = get_action_id(p4info, "ingress.send_1");
+    a_s2_id = get_action_id(p4info, "ingress.send_2");
+  }
+
+  p4::Entity make_entry(const std::string &v, const std::string &mask,
+                        int32_t priority, int a_id) const {
+    p4::Entity entity;
+    auto table_entry = entity.mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    auto match = table_entry->add_match();
+    match->set_field_id(mf_id);
+    auto ternary = match->mutable_ternary();
+    ternary->set_value(v);
+    ternary->set_mask(mask);
+    table_entry->set_priority(priority);
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(a_id);
+    return entity;
+  }
+
+  grpc::Status add_entry(const p4::Entity &entry) const {
+    p4::WriteRequest request;
+    request.set_device_id(device_id);
+    auto update = request.add_updates();
+    update->set_type(p4::Update_Type_INSERT);
+    update->mutable_entity()->CopyFrom(entry);
+    ClientContext context;
+    p4::WriteResponse rep;
+    return Write(&context, request, &rep);
+  }
+
+  grpc::Status read_entry(const p4::Entity &entry,
+                          p4::ReadResponse *rep) const {
+    p4::ReadRequest request;
+    request.set_device_id(device_id);
+    auto *entity = request.add_entities();
+    entity->CopyFrom(entry);
+    ClientContext context;
+    std::unique_ptr<grpc::ClientReader<p4::ReadResponse> > reader(
+        p4runtime_stub->Read(&context, request));
+    reader->Read(rep);
+    return reader->Finish();
+  }
+
+  grpc::Status send_and_receive(const std::string &pkt, int ig_port,
+                                p4::bm::PacketStreamResponse *rcv_pkt) {
+    static uint64_t id = 1;
+    p4::bm::PacketStreamRequest request;
+    request.set_id(id++);
+    request.set_device_id(device_id);
+    request.set_port(ig_port);
+    request.set_packet(pkt);
+    ClientContext context;
+    auto stream = dataplane_stub->PacketStream(&context);
+    stream->Write(request);
+    stream->Read(rcv_pkt);
+    stream->WritesDone();
+    return stream->Finish();
+  }
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+  int t_id;
+  int mf_id;
+  int a_nop_id;
+  int a_s1_id;
+  int a_s2_id;
+};
+
+TEST_F(SimpleSwitchGrpcTest_Ternary, ReadEntry) {
+  int priority = 128;
+  auto entity = make_entry("\xaa\xbb", "\xff\xff", priority, a_s1_id);
+  {
+    auto status = add_entry(entity);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    p4::ReadResponse rep;
+    auto status = read_entry(entity, &rep);
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(1u, rep.entities().size());
+    EXPECT_TRUE(MessageDifferencer::Equals(entity, rep.entities().Get(0)));
+  }
+}
+
+TEST_F(SimpleSwitchGrpcTest_Ternary, PriorityOrder) {
+  int priority_lo = 128, priority_hi = 333;
+  int ig_port = 3;
+  std::string pkt("\xaa\xbb");
+  p4::bm::PacketStreamResponse rcv_pkt;
+  auto entity_lo = make_entry("\xaa\xbb", "\xff\xff", priority_lo, a_s1_id);
+  {
+    auto status = add_entry(entity_lo);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    auto status = send_and_receive(pkt, ig_port, &rcv_pkt);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(1, rcv_pkt.port());
+  }
+  auto entity_hi = make_entry("\xaa\x0b", "\xff\x0f", priority_hi, a_s2_id);
+  {
+    auto status = add_entry(entity_hi);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    auto status = send_and_receive(pkt, ig_port, &rcv_pkt);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(2, rcv_pkt.port());
+  }
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/testdata/ternary.json
+++ b/targets/simple_switch_grpc/tests/testdata/ternary.json
@@ -1,0 +1,314 @@
+{
+  "program" : "ternary.p4",
+  "__meta__" : {
+    "version" : [2, 7],
+    "compiler" : "https://github.com/p4lang/p4c"
+  },
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "Hdr",
+      "id" : 1,
+      "fields" : [
+        ["f1", 16, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 2,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 32, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["recirculate_flag", 32, false],
+        ["_padding", 5, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr",
+      "id" : 2,
+      "header_type" : "Hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "hdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "ternary.p4",
+        "line" : 55,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : ["hdr"]
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "NoAction",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "ingress.send_1",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0001"
+            }
+          ],
+          "source_info" : {
+            "filename" : "ternary.p4",
+            "line" : 41,
+            "column" : 22,
+            "source_fragment" : "sm.egress_spec = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "ingress.send_2",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0002"
+            }
+          ],
+          "source_info" : {
+            "filename" : "ternary.p4",
+            "line" : 42,
+            "column" : 22,
+            "source_fragment" : "sm.egress_spec = 2"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "ternary.p4",
+        "line" : 40,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "ingress.ter",
+      "tables" : [
+        {
+          "name" : "ingress.ter",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "ternary.p4",
+            "line" : 43,
+            "column" : 10,
+            "source_fragment" : "ter"
+          },
+          "key" : [
+            {
+              "match_type" : "ternary",
+              "name" : "h.hdr.f1",
+              "target" : ["hdr", "f1"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "ternary",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0, 1, 2],
+          "actions" : ["NoAction", "ingress.send_1", "ingress.send_2"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "NoAction" : null,
+            "ingress.send_1" : null,
+            "ingress.send_2" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : false,
+            "action_data" : [],
+            "action_entry_const" : false
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "ternary.p4",
+        "line" : 51,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.recirculate_flag",
+      ["standard_metadata", "recirculate_flag"]
+    ]
+  ]
+}

--- a/targets/simple_switch_grpc/tests/testdata/ternary.p4
+++ b/targets/simple_switch_grpc/tests/testdata/ternary.p4
@@ -1,0 +1,59 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header Hdr {
+    bit<16> f1;
+}
+
+struct Headers {
+    Hdr hdr;
+}
+
+struct Meta { }
+
+parser p(packet_in b, out Headers h,
+         inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.hdr);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action send_1() { sm.egress_spec = 1; }
+    action send_2() { sm.egress_spec = 2; }
+    table ter {
+        key = { h.hdr.f1 : ternary; }
+        actions = { NoAction; send_1; send_2; }
+        default_action = NoAction();
+    }
+    apply { ter.apply(); }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply { }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply { b.emit(h.hdr); }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/targets/simple_switch_grpc/tests/testdata/ternary.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/ternary.proto.txt
@@ -1,0 +1,44 @@
+tables {
+  preamble {
+    id: 33596279
+    name: "ingress.ter"
+    alias: "ter"
+  }
+  match_fields {
+    id: 1
+    name: "h.hdr.f1"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16800567
+  }
+  action_refs {
+    id: 16806341
+  }
+  action_refs {
+    id: 16813617
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16806341
+    name: "ingress.send_1"
+    alias: "send_1"
+  }
+}
+actions {
+  preamble {
+    id: 16813617
+    name: "ingress.send_2"
+    alias: "send_2"
+  }
+}


### PR DESCRIPTION
In P4Runtime, a higher numerical priority value corresponds to a higher
logical priority. For historical reasons it is the opposite in the bmv2
ternary match implementation.

In this commit, we invert the priority value in the PI implementation,
in order to match the P4Runtime specification.

Fixes #581