### PR TITLE
Update minor version number for JSON format in parser

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -42,7 +42,7 @@ using std::string;
 namespace {
 
 constexpr int required_major_version = 2;
-constexpr int max_minor_version = 12;
+constexpr int max_minor_version = 18;
 // not needed for now
 // constexpr int min_minor_version = 0;
 


### PR DESCRIPTION
Apparently the version number hasn't been updated for a while, and the only
reason why this hasn't been a problem is because we haven't updated the version
number output by the different compilers as well.

The version number is now set to 2.18, which is consistent with the documentation.