### PR TITLE
Add option --load-modules to simple_switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,32 @@ AC_LINK_IFELSE(
 
 AM_CONDITIONAL([WITH_PCAP_FIX], [test "$pcap_fix" = "yes"])
 
+# Check for dlopen and dlfcn.h
+AC_ARG_ENABLE(modules,
+    AS_HELP_STRING([--enable-modules],
+                   [Allow loading third-party modules at runtime]))
+modules_enabled=no
+AS_IF([test "x$enable_modules" != "xno"], [
+  AC_MSG_CHECKING(for dlopen())
+  AC_CHECK_HEADERS(dlfcn.h, [
+    AC_SEARCH_LIBS([dlopen], [dl], [
+      MY_CPPFLAGS="$MY_CPPFLAGS -DBM_HAVE_DLOPEN -DBM_ENABLE_MODULES"
+      modules_enabled=yes
+    ], [
+      AC_MSG_RESULT(no)
+      AS_IF([test "x$enable_modules" == "xyes"], [
+        AC_MSG_ERROR([Cannot enable modules without dlopen])
+      ])
+    ])
+  ],[
+    AC_MSG_RESULT(no)
+    AS_IF([test "x$enable_modules" == "xyes"], [
+      AC_MSG_ERROR([Cannot enable modules without dlfcn.h])
+    ])
+  ])
+])
+AM_CONDITIONAL([ENABLE_MODULES], [test "x$modules_enabled" == "xyes"])
+
 # C++ libraries are harder (http://nerdland.net/2009/07/detecting-c-libraries-with-autotools/),
 # so use headers to check
 AC_CHECK_HEADER([boost/thread.hpp], [], [AC_MSG_ERROR([Boost threading headers not found])])

--- a/include/bm/bm_sim/target_parser.h
+++ b/include/bm/bm_sim/target_parser.h
@@ -57,7 +57,7 @@ class TargetParserBasicStore;
 
 //! A basic target-specific command-line options parser, which should be enough
 //! for many targets.
-class TargetParserBasic final : public TargetParserIface {
+class TargetParserBasic : public TargetParserIface {
  public:
   //! Return codes for this class
   enum class ReturnCode {

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -75,6 +75,10 @@ libsimpleswitch.la \
 libsimpleswitch_thrift.la
 
 simple_switch_SOURCES = main.cpp
+simple_switch_LDFLAGS =
+if ENABLE_MODULES
+simple_switch_LDFLAGS += -rdynamic
+endif
 
 lib_LTLIBRARIES = libsimpleswitch_thrift.la
 

--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -20,7 +20,9 @@
 
 /* Switch instance */
 
-#include <dlfcn.h>
+#ifdef BM_HAVE_DLOPEN
+#  include <dlfcn.h>
+#endif  // BM_HAVE_DLOPEN
 #include <bm/SimpleSwitch.h>
 #include <bm/bm_runtime/bm_runtime.h>
 #include <bm/bm_sim/target_parser.h>
@@ -36,21 +38,54 @@ SimpleSwitch *simple_switch;
 
 std::string load_modules_option = "load-modules";
 
-class TargetParserModules : public bm::TargetParserBasic {
+class SimpleSwitchParser : public bm::TargetParserBasic {
  public:
-  TargetParserModules() {
+  SimpleSwitchParser() {
     add_flag_option("enable-swap",
                     "enable JSON swapping at runtime");
+#ifdef BM_ENABLE_MODULES
+    add_string_option(load_modules_option,
+                      "load the given .so files as modules");
+#endif  // BM_ENABLE_MODULES
   }
 
   int parse(const std::vector<std::string> &more_options,
                     std::ostream *errstream) override {
     int result = ::bm::TargetParserBasic::parse(more_options, errstream);
+#ifdef BM_ENABLE_MODULES
+    load_modules(errstream);
+#endif  // BM_ENABLE_MODULES
     set_enable_swap();
     return result;
   }
 
  protected:
+#ifdef BM_ENABLE_MODULES
+  int load_modules(std::ostream *errstream) {
+    std::string modules;
+    ReturnCode retval = get_string_option(load_modules_option, &modules);
+    if (retval == ReturnCode::OPTION_NOT_PROVIDED) {
+      return 0;
+    }
+    if (retval != ReturnCode::SUCCESS) {
+      return -1;  // Unexpected error
+    }
+    std::istringstream iss(modules);
+    std::string module;
+    while (std::getline(iss, module, ',')) {
+#  ifdef BM_HAVE_DLOPEN
+      if (!dlopen(module.c_str(), RTLD_NOW | RTLD_GLOBAL)) {
+        *errstream << "WARNING: Skipping module: " << module << ": "
+                   << dlerror() << std::endl;
+      }
+#  else  // BM_HAVE_DLOPEN
+      #error modules enabled, but no loading method available
+#  endif  // BM_HAVE_DLOPEN
+    }
+    return 0;
+  }
+#endif  // BM_ENABLE_MODULES
+
   void set_enable_swap() {
     bool enable_swap = false;
     if (get_flag_option("enable-swap", &enable_swap) != ReturnCode::SUCCESS)
@@ -59,7 +94,7 @@ class TargetParserModules : public bm::TargetParserBasic {
   }
 };
 
-TargetParserModules *simple_switch_parser;
+SimpleSwitchParser *simple_switch_parser;
 }  // namespace
 
 namespace sswitch_runtime {
@@ -69,7 +104,7 @@ shared_ptr<SimpleSwitchIf> get_handler(SimpleSwitch *sw);
 int
 main(int argc, char* argv[]) {
   simple_switch = new SimpleSwitch();
-  simple_switch_parser = new TargetParserModules();
+  simple_switch_parser = new SimpleSwitchParser();
   int status = simple_switch->init_from_command_line_options(
       argc, argv, simple_switch_parser);
   if (status != 0) std::exit(status);


### PR DESCRIPTION
Add option --load-modules to allow loading external code as .so files.
This allows externs to be registered, e.g. using REGISTER_PRIMITIVE or
BM_REGISTER_EXTERN_METHOD from external code, with changing
behavioral-model's code.

The .so files are comma-delimited, e.g. -- --load-modules
file1.so,file2.so .