### PR TITLE
Update simple_switch_grpc tests to use new P4Runtime proto package names

### DIFF
--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -28,6 +28,8 @@
 
 #include "base_test.h"
 
+namespace p4v1 = ::p4::v1;
+
 namespace sswitch_grpc {
 
 namespace testing {
@@ -41,28 +43,28 @@ SimpleSwitchGrpcBaseTest::SimpleSwitchGrpcBaseTest(
     const char *p4info_proto_txt_path)
     : p4runtime_channel(grpc::CreateChannel(
           grpc_server_addr, grpc::InsecureChannelCredentials())),
-      p4runtime_stub(p4::P4Runtime::NewStub(p4runtime_channel)) {
+      p4runtime_stub(p4v1::P4Runtime::NewStub(p4runtime_channel)) {
   p4info = parse_p4info(p4info_proto_txt_path);
 }
 
 void
 SimpleSwitchGrpcBaseTest::SetUp() {
   stream = p4runtime_stub->StreamChannel(&stream_context);
-  p4::StreamMessageRequest request;
+  p4v1::StreamMessageRequest request;
   auto arbitration = request.mutable_arbitration();
   arbitration->set_device_id(device_id);
   set_election_id(arbitration->mutable_election_id());
   stream->Write(request);
-  p4::StreamMessageResponse response;
+  p4v1::StreamMessageResponse response;
   stream->Read(&response);
-  ASSERT_EQ(response.update_case(), p4::StreamMessageResponse::kArbitration);
+  ASSERT_EQ(response.update_case(), p4v1::StreamMessageResponse::kArbitration);
   ASSERT_EQ(response.arbitration().status().code(), ::google::rpc::Code::OK);
 }
 
 void
 SimpleSwitchGrpcBaseTest::TearDown() {
   stream->WritesDone();
-  p4::StreamMessageResponse response;
+  p4v1::StreamMessageResponse response;
   while (stream->Read(&response)) { }
   auto status = stream->Finish();
   EXPECT_TRUE(status.ok());
@@ -70,10 +72,10 @@ SimpleSwitchGrpcBaseTest::TearDown() {
 
 void
 SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
-  p4::SetForwardingPipelineConfigRequest request;
+  p4v1::SetForwardingPipelineConfigRequest request;
   request.set_device_id(device_id);
   request.set_action(
-      p4::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+      p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
   set_election_id(request.mutable_election_id());
   auto config = request.mutable_config();
   p4::tmp::P4DeviceConfig device_config;
@@ -84,7 +86,7 @@ SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
        std::istreambuf_iterator<char>());
   device_config.SerializeToString(config->mutable_p4_device_config());
 
-  p4::SetForwardingPipelineConfigResponse rep;
+  p4v1::SetForwardingPipelineConfigResponse rep;
   ClientContext context;
   config->set_allocated_p4info(&p4info);
   auto status = p4runtime_stub->SetForwardingPipelineConfig(
@@ -94,15 +96,15 @@ SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
 }
 
 void
-SimpleSwitchGrpcBaseTest::set_election_id(p4::Uint128 *election_id) const {
+SimpleSwitchGrpcBaseTest::set_election_id(p4v1::Uint128 *election_id) const {
   election_id->set_high(0);
   election_id->set_low(1);
 }
 
 grpc::Status
 SimpleSwitchGrpcBaseTest::Write(ClientContext *context,
-                                p4::WriteRequest &request,
-                                p4::WriteResponse *response) const {
+                                p4v1::WriteRequest &request,
+                                p4v1::WriteResponse *response) const {
   set_election_id(request.mutable_election_id());
   return p4runtime_stub->Write(context, request, response);
 }

--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -21,8 +21,8 @@
 #ifndef SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_
 #define SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_
 
-#include <p4/config/p4info.grpc.pb.h>
-#include <p4/p4runtime.grpc.pb.h>
+#include <p4/config/v1/p4info.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
 
 #include <gtest/gtest.h>
 
@@ -59,20 +59,20 @@ class SimpleSwitchGrpcBaseTest : public ::testing::Test {
 
   void update_json(const char *json_path);
 
-  void set_election_id(p4::Uint128 *election_id) const;
+  void set_election_id(p4::v1::Uint128 *election_id) const;
 
   // calls p4runtime_stub->Write, with the appropriate election_id
   grpc::Status Write(ClientContext *context,
-                     p4::WriteRequest &request,
-                     p4::WriteResponse *response) const;
+                     p4::v1::WriteRequest &request,
+                     p4::v1::WriteResponse *response) const;
 
   std::shared_ptr<grpc::Channel> p4runtime_channel;
-  std::unique_ptr<p4::P4Runtime::Stub> p4runtime_stub;
-  using ReaderWriter = ::grpc::ClientReaderWriter<p4::StreamMessageRequest,
-                                                  p4::StreamMessageResponse>;
+  std::unique_ptr<p4::v1::P4Runtime::Stub> p4runtime_stub;
+  using ReaderWriter = ::grpc::ClientReaderWriter<
+      p4::v1::StreamMessageRequest, p4::v1::StreamMessageResponse>;
   ClientContext stream_context;
   std::unique_ptr<ReaderWriter> stream{nullptr};
-  p4::config::P4Info p4info{};
+  p4::config::v1::P4Info p4info{};
 };
 
 }  // namespace testing

--- a/targets/simple_switch_grpc/tests/test_basic.cpp
+++ b/targets/simple_switch_grpc/tests/test_basic.cpp
@@ -20,7 +20,7 @@
 
 #include <grpc++/grpc++.h>
 
-#include <p4/p4runtime.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
 
 #include <gtest/gtest.h>
 
@@ -30,6 +30,8 @@
 #include <string>
 
 #include "base_test.h"
+
+namespace p4v1 = ::p4::v1;
 
 namespace sswitch_grpc {
 
@@ -60,7 +62,7 @@ TEST_F(SimpleSwitchGrpcTest_Basic, Entries) {
   auto p0_id = get_param_id(p4info, "set_nhop", "nhop_ipv4");
   auto p1_id = get_param_id(p4info, "set_nhop", "port");
 
-  p4::Entity entity;
+  p4v1::Entity entity;
   auto table_entry = entity.mutable_table_entry();
   table_entry->set_table_id(t_id);
   auto match = table_entry->add_match();
@@ -84,27 +86,27 @@ TEST_F(SimpleSwitchGrpcTest_Basic, Entries) {
 
   // add entry
   {
-    p4::WriteRequest request;
+    p4v1::WriteRequest request;
     request.set_device_id(device_id);
     auto update = request.add_updates();
-    update->set_type(p4::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     update->set_allocated_entity(&entity);
     ClientContext context;
-    p4::WriteResponse rep;
+    p4v1::WriteResponse rep;
     auto status = Write(&context, request, &rep);
     EXPECT_TRUE(status.ok());
     update->release_entity();
   }
 
   auto read_one = [this, &table_entry] () {
-    p4::ReadRequest request;
+    p4v1::ReadRequest request;
     request.set_device_id(device_id);
     auto entity = request.add_entities();
     entity->set_allocated_table_entry(table_entry);
     ClientContext context;
-    std::unique_ptr<grpc::ClientReader<p4::ReadResponse> > reader(
+    std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
         p4runtime_stub->Read(&context, request));
-    p4::ReadResponse rep;
+    p4v1::ReadResponse rep;
     reader->Read(&rep);
     auto status = reader->Finish();
     EXPECT_TRUE(status.ok());
@@ -121,13 +123,13 @@ TEST_F(SimpleSwitchGrpcTest_Basic, Entries) {
 
   // remove entry
   {
-    p4::WriteRequest request;
+    p4v1::WriteRequest request;
     request.set_device_id(device_id);
     auto update = request.add_updates();
-    update->set_type(p4::Update_Type_DELETE);
+    update->set_type(p4v1::Update_Type_DELETE);
     update->set_allocated_entity(&entity);
     ClientContext context;
-    p4::WriteResponse rep;
+    p4v1::WriteResponse rep;
     auto status = Write(&context, request, &rep);
     EXPECT_TRUE(status.ok());
     update->release_entity();

--- a/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
@@ -21,7 +21,6 @@
 #include <grpc++/grpc++.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
-#include <p4/p4runtime.grpc.pb.h>
 
 #include <gtest/gtest.h>
 

--- a/targets/simple_switch_grpc/tests/test_meter.cpp
+++ b/targets/simple_switch_grpc/tests/test_meter.cpp
@@ -21,7 +21,7 @@
 #include <grpc++/grpc++.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
-#include <p4/p4runtime.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
 
 #include <gtest/gtest.h>
 
@@ -29,6 +29,8 @@
 #include <string>
 
 #include "base_test.h"
+
+namespace p4v1 = ::p4::v1;
 
 namespace sswitch_grpc {
 
@@ -62,7 +64,7 @@ TEST_F(SimpleSwitchGrpcTest_Meter, ReadDefault) {
   auto mf_id = get_mf_id(p4info, "ingress.t_redirect", "sm.ingress_port");
   auto a_id = get_action_id(p4info, "ingress.port_redirect");
 
-  p4::TableEntry table_entry;
+  p4v1::TableEntry table_entry;
   table_entry.set_table_id(t_id);
   auto match = table_entry.add_match();
   match->set_field_id(mf_id);
@@ -73,29 +75,29 @@ TEST_F(SimpleSwitchGrpcTest_Meter, ReadDefault) {
   action->set_action_id(a_id);
 
   {
-    p4::WriteRequest write_request;
+    p4v1::WriteRequest write_request;
     write_request.set_device_id(device_id);
     auto update = write_request.add_updates();
-    update->set_type(p4::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     auto entity = update->mutable_entity();
     entity->mutable_table_entry()->CopyFrom(table_entry);
-    p4::WriteResponse write_response;
+    p4v1::WriteResponse write_response;
     ClientContext context;
     auto status = Write(&context, write_request, &write_response);
     EXPECT_TRUE(status.ok());
   }
 
   {
-    p4::ReadRequest read_request;
+    p4v1::ReadRequest read_request;
     read_request.set_device_id(device_id);
     auto read_entity = read_request.add_entities();
     table_entry.mutable_meter_config();  // make sure meter config is read
     read_entity->mutable_table_entry()->CopyFrom(table_entry);
 
     ClientContext context;
-    std::unique_ptr<grpc::ClientReader<p4::ReadResponse> > reader(
+    std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
         p4runtime_stub->Read(&context, read_request));
-    p4::ReadResponse read_response;
+    p4v1::ReadResponse read_response;
     reader->Read(&read_response);
     auto status = reader->Finish();
     EXPECT_TRUE(status.ok());

--- a/targets/simple_switch_grpc/tests/test_packet_io.cpp
+++ b/targets/simple_switch_grpc/tests/test_packet_io.cpp
@@ -20,7 +20,7 @@
 
 #include <grpc++/grpc++.h>
 
-#include <p4/p4runtime.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
 #include <PI/proto/pi_server.h>
 
 #include <gtest/gtest.h>
@@ -29,6 +29,8 @@
 #include <string>
 
 #include "base_test.h"
+
+namespace p4v1 = ::p4::v1;
 
 namespace sswitch_grpc {
 
@@ -52,7 +54,7 @@ class SimpleSwitchGrpcTest_PacketIO : public SimpleSwitchGrpcBaseTest {
 
 TEST_F(SimpleSwitchGrpcTest_PacketIO, SendAndReceiveCPUPacket) {
   std::string payload(10, '\xab');
-  p4::StreamMessageRequest request;
+  p4v1::StreamMessageRequest request;
 
   ClientContext context;
   auto stream = p4runtime_stub->StreamChannel(&context);
@@ -71,10 +73,10 @@ TEST_F(SimpleSwitchGrpcTest_PacketIO, SendAndReceiveCPUPacket) {
   packet_out->set_payload(payload);
   stream->Write(request);
 
-  p4::StreamMessageResponse response;
+  p4v1::StreamMessageResponse response;
   size_t packet_count = 0;
   while (stream->Read(&response)) {
-    if (response.update_case() == p4::StreamMessageResponse::kPacket) {
+    if (response.update_case() == p4v1::StreamMessageResponse::kPacket) {
       const auto &packet_in = response.packet();
       EXPECT_EQ(packet_in.payload(), payload);
       packet_count++;

--- a/targets/simple_switch_grpc/tests/test_ternary.cpp
+++ b/targets/simple_switch_grpc/tests/test_ternary.cpp
@@ -21,7 +21,7 @@
 #include <grpc++/grpc++.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
-#include <p4/p4runtime.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
 
 #include <google/protobuf/util/message_differencer.h>
 
@@ -31,6 +31,8 @@
 #include <string>
 
 #include "base_test.h"
+
+namespace p4v1 = ::p4::v1;
 
 namespace sswitch_grpc {
 
@@ -62,9 +64,9 @@ class SimpleSwitchGrpcTest_Ternary : public SimpleSwitchGrpcBaseTest {
     a_s2_id = get_action_id(p4info, "ingress.send_2");
   }
 
-  p4::Entity make_entry(const std::string &v, const std::string &mask,
+  p4v1::Entity make_entry(const std::string &v, const std::string &mask,
                         int32_t priority, int a_id) const {
-    p4::Entity entity;
+    p4v1::Entity entity;
     auto table_entry = entity.mutable_table_entry();
     table_entry->set_table_id(t_id);
     auto match = table_entry->add_match();
@@ -79,25 +81,25 @@ class SimpleSwitchGrpcTest_Ternary : public SimpleSwitchGrpcBaseTest {
     return entity;
   }
 
-  grpc::Status add_entry(const p4::Entity &entry) const {
-    p4::WriteRequest request;
+  grpc::Status add_entry(const p4v1::Entity &entry) const {
+    p4v1::WriteRequest request;
     request.set_device_id(device_id);
     auto update = request.add_updates();
-    update->set_type(p4::Update_Type_INSERT);
+    update->set_type(p4v1::Update_Type_INSERT);
     update->mutable_entity()->CopyFrom(entry);
     ClientContext context;
-    p4::WriteResponse rep;
+    p4v1::WriteResponse rep;
     return Write(&context, request, &rep);
   }
 
-  grpc::Status read_entry(const p4::Entity &entry,
-                          p4::ReadResponse *rep) const {
-    p4::ReadRequest request;
+  grpc::Status read_entry(const p4v1::Entity &entry,
+                          p4v1::ReadResponse *rep) const {
+    p4v1::ReadRequest request;
     request.set_device_id(device_id);
     auto *entity = request.add_entities();
     entity->CopyFrom(entry);
     ClientContext context;
-    std::unique_ptr<grpc::ClientReader<p4::ReadResponse> > reader(
+    std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
         p4runtime_stub->Read(&context, request));
     reader->Read(rep);
     return reader->Finish();
@@ -136,7 +138,7 @@ TEST_F(SimpleSwitchGrpcTest_Ternary, ReadEntry) {
     EXPECT_TRUE(status.ok());
   }
   {
-    p4::ReadResponse rep;
+    p4v1::ReadResponse rep;
     auto status = read_entry(entity, &rep);
     EXPECT_TRUE(status.ok());
     ASSERT_EQ(1u, rep.entities().size());

--- a/targets/simple_switch_grpc/tests/utils.cpp
+++ b/targets/simple_switch_grpc/tests/utils.cpp
@@ -28,11 +28,13 @@
 #include <streambuf>
 #include <string>
 
+namespace p4configv1 = ::p4::config::v1;
+
 namespace sswitch_grpc {
 
 namespace testing {
 
-int get_table_id(const p4::config::P4Info &p4info,
+int get_table_id(const p4configv1::P4Info &p4info,
                  const std::string &t_name) {
   for (const auto &table : p4info.tables()) {
     const auto &pre = table.preamble();
@@ -41,7 +43,7 @@ int get_table_id(const p4::config::P4Info &p4info,
   return 0;
 }
 
-int get_action_id(const p4::config::P4Info &p4info,
+int get_action_id(const p4configv1::P4Info &p4info,
                   const std::string &a_name) {
   for (const auto &action : p4info.actions()) {
     const auto &pre = action.preamble();
@@ -50,7 +52,7 @@ int get_action_id(const p4::config::P4Info &p4info,
   return 0;
 }
 
-int get_mf_id(const p4::config::P4Info &p4info,
+int get_mf_id(const p4configv1::P4Info &p4info,
               const std::string &t_name, const std::string &mf_name) {
   for (const auto &table : p4info.tables()) {
     const auto &pre = table.preamble();
@@ -61,7 +63,7 @@ int get_mf_id(const p4::config::P4Info &p4info,
   return -1;
 }
 
-int get_param_id(const p4::config::P4Info &p4info,
+int get_param_id(const p4configv1::P4Info &p4info,
                  const std::string &a_name, const std::string &param_name) {
   for (const auto &action : p4info.actions()) {
     const auto &pre = action.preamble();
@@ -72,8 +74,8 @@ int get_param_id(const p4::config::P4Info &p4info,
   return -1;
 }
 
-p4::config::P4Info parse_p4info(const char *path) {
-  p4::config::P4Info p4info;
+p4configv1::P4Info parse_p4info(const char *path) {
+  p4configv1::P4Info p4info;
   std::ifstream istream(path);
   assert(istream.good());
   // p4info.ParseFromIstream(&istream);

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -21,7 +21,7 @@
 #ifndef SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_
 #define SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_
 
-#include <p4/config/p4info.grpc.pb.h>
+#include <p4/config/v1/p4info.grpc.pb.h>
 
 #include <string>
 
@@ -29,17 +29,19 @@ namespace sswitch_grpc {
 
 namespace testing {
 
-int get_table_id(const p4::config::P4Info &p4info, const std::string &t_name);
+int get_table_id(const p4::config::v1::P4Info &p4info,
+                 const std::string &t_name);
 
-int get_action_id(const p4::config::P4Info &p4info, const std::string &a_name);
+int get_action_id(const p4::config::v1::P4Info &p4info,
+                  const std::string &a_name);
 
-int get_mf_id(const p4::config::P4Info &p4info,
+int get_mf_id(const p4::config::v1::P4Info &p4info,
               const std::string &t_name, const std::string &mf_name);
 
-int get_param_id(const p4::config::P4Info &p4info,
+int get_param_id(const p4::config::v1::P4Info &p4info,
                  const std::string &a_name, const std::string &param_name);
 
-p4::config::P4Info parse_p4info(const char *path);
+p4::config::v1::P4Info parse_p4info(const char *path);
 
 }  // namespace testing
 


### PR DESCRIPTION
p4 and p4.config have been renamed p4.v1 and p4.config.v1 to follow best
practices in deploying protobuf / gRPC cloud services (package name
should include major version number if non-backward compatible changes
are likely to be introduced in the future).

To be consistent with the P4Runtime server implementation code, we use
namespace aliases p4v1 and p4configv1 in implementation files.