### PR TITLE
Add build hook for dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM p4lang/pi:latest
-LABEL maintainer="Seth Fowler <seth.fowler@barefootnetworks.com>"
+ARG PARENT_VERSION=latest
+FROM p4lang/pi:${PARENT_VERSION}
+LABEL maintainer="Antonin Bas <antonin@barefootnetworks.com>"
 
 # Default to using 2 make jobs, which is a good default for CI. If you're
 # building locally or you know there are more cores available, you may want to

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,3 @@
+Hooks for dockerhub build.
+See [docker
+documentation](https://docs.docker.com/docker-cloud/builds/advanced/#override-build-test-or-push-commands).

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Overrides the default build command with one that sets PARENT_VERSION arg to
+# the appropriate value. behavioral-model:latest will be built from pi:latest,
+# while behavioral-model:stable will be built from pi:stable. Thanks to this we
+# don't have to duplicate the Dockerfile for the sake of dockerhub.
+
+# dockerhub uses DOCKER_TAG and not CACHE_TAG
+echo "DOCKER_TAG: $DOCKER_TAG"
+# echo "CACHE_TAG: $CACHE_TAG"
+# dockerhub seems to be using BUILD_PATH and not DOCKERFILE_PATH (which is
+# empty)
+echo "BUILD_PATH: $BUILD_PATH"
+# echo "DOCKERFILE_PATH: $DOCKERFILE_PATH"
+echo "IMAGE_NAME: $IMAGE_NAME"
+DOCKERFILE_PATH_OPTION=
+if [ "$BUILD_PATH" != "/" ]; then
+    # remove leading '/'
+    DOCKERFILE_PATH_OPTION="-f ${BUILD_PATH:1}"
+fi
+docker build --build-arg PARENT_VERSION=$DOCKER_TAG $DOCKERFILE_PATH_OPTION -t $IMAGE_NAME .


### PR DESCRIPTION
Thanks to this hook, behavioral-model:latest will be built from
pi:latest and behavioral-model:stable will be built from pi:stable.