### PR TITLE
Updated install_deps.sh for Ubuntu 18.04

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 set -e
+# Check whether running Ubuntu >= 18.04
+if test `lsb_release -rs` = '18.04';
+then
+    echo "Detected Ubuntu 18.04, using libssl1.0-dev"
+    LIBSSL="libssl1.0-dev"
+else
+    LIBSSL="libssl-dev"
+fi
 sudo apt-get install -y \
     automake \
     cmake \
@@ -18,7 +26,7 @@ sudo apt-get install -y \
     bison \
     pkg-config \
     g++ \
-    libssl-dev \
+    $LIBSSL \
     libffi-dev \
     python-dev \
     python-pip \


### PR DESCRIPTION
Updated dependencies to compile on 18.04

Thrift will not compile with libssl-dev as provided in 18.04 which is version 1.1.0. By adding a check into install_deps.sh, the right version is installed. 

Tests pass when running with make check. 