### PR TITLE
Implement PI multicast functions

### DIFF
--- a/PI/Makefile.am
+++ b/PI/Makefile.am
@@ -8,6 +8,7 @@ src/pi_act_prof_imp.cpp \
 src/pi_counter_imp.cpp \
 src/pi_meter_imp.cpp \
 src/pi_learn_imp.cpp \
+src/pi_mc_imp.cpp \
 src/common.h \
 src/common.cpp \
 src/action_helpers.h \

--- a/PI/src/common.h
+++ b/PI/src/common.h
@@ -48,7 +48,8 @@ static inline const pi_p4info_t *get_device_info(size_t dev_id) {
   return pi_get_device_p4info(dev_id);
 }
 
-static inline pi_status_t convert_error_code(bm::MatchErrorCode error_code) {
+template<typename T>
+static inline pi_status_t convert_error_code(T error_code) {
   return static_cast<pi_status_t>(
       PI_STATUS_TARGET_ERROR + static_cast<int>(error_code));
 }

--- a/PI/src/pi_mc_imp.cpp
+++ b/PI/src/pi_mc_imp.cpp
@@ -1,0 +1,218 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/simple_pre.h>
+#include <bm/bm_sim/simple_pre_lag.h>
+#include <bm/bm_sim/switch.h>
+
+#include <PI/pi_mc.h>
+#include <PI/target/pi_mc_imp.h>
+
+#include <algorithm>  // for std::reverse
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "common.h"
+
+using ::bm::McSimplePre;
+using ::bm::McSimplePreLAG;
+
+namespace {
+
+// returns nullptr if the switch doesn't have a registered PRE
+std::shared_ptr<McSimplePre> get_pre() {
+  // simple_switch and simple_switch_grpc useMcSimplePreLAG but we do not
+  // support LAG functionality at the moment in PI, so we only need a
+  // McSimplePre pointer.
+  {
+    // TODO(antonin): we should be able to call get_component here; however the
+    // add_component method in the Switch class actually hides the base class
+    // method and instead registers the PRE as a context component. This needs
+    // to be fixes, probably by removing add_component and get_component in the
+    // Switch class.
+    auto pre = pibmv2::switch_->get_cxt_component<McSimplePreLAG>(0);
+    if (pre != nullptr) return pre;
+  }
+  return pibmv2::switch_->get_cxt_component<McSimplePre>(0);
+}
+
+// From https://stackoverflow.com/a/17251989/4538702
+template <typename T, typename V>
+bool type_can_fit_value(const V value) {
+  const auto botT = intmax_t(std::numeric_limits<T>::min());
+  const auto botV = intmax_t(std::numeric_limits<V>::min());
+  const auto topT = uintmax_t(std::numeric_limits<T>::max());
+  const auto topV = uintmax_t(std::numeric_limits<V>::max());
+  return !((botT > botV && value < static_cast<V>(botT)) ||
+           (topT < topV && value > static_cast<V>(topT)));
+}
+
+// TODO(antonin): Unfortunately ports outside of the supported range
+// (PORT_MAP_SIZE) will simply be silently ignored when building the PortMap
+// object.
+McSimplePre::PortMap convert_map(const pi_mc_port_t *eg_ports,
+                                 size_t eg_ports_count) {
+  std::string output;
+  for (size_t i = 0; i < eg_ports_count; i++) {
+    output.resize(eg_ports[i] + 1, '0');
+    output[eg_ports[i]] = '1';
+  }
+  std::reverse(output.begin(), output.end());
+  return McSimplePre::PortMap(output);
+}
+
+}  // namespace
+
+extern "C" {
+
+pi_status_t _pi_mc_session_init(pi_mc_session_handle_t *session_handle) {
+  *session_handle = 0;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_session_cleanup(pi_mc_session_handle_t session_handle) {
+  (void)session_handle;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_create(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_id_t grp_id,
+                              pi_mc_grp_handle_t *grp_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  McSimplePre::mgrp_hdl_t grp_h;
+  auto rc = pre->mc_mgrp_create(grp_id, &grp_h);
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  // This relies on knowledge of how the bmv2 PRE is implemented: even though
+  // McSimplePre::mgrp_hdl_t is uintptr_t, the PRE always sets the handle to the
+  // provided group id value.
+  assert(type_can_fit_value<pi_mc_grp_handle_t>(grp_h));
+  *grp_handle = grp_h;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_delete(pi_mc_session_handle_t session_handle,
+                              pi_dev_id_t dev_id,
+                              pi_mc_grp_handle_t grp_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  auto rc = pre->mc_mgrp_destroy(grp_handle);
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_create(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_rid_t rid,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports,
+                               pi_mc_node_handle_t *node_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  McSimplePre::l1_hdl_t node_h;
+  auto rc = pre->mc_node_create(
+      rid, convert_map(eg_ports, eg_ports_count), &node_h);
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  // This relies on knowledge of how the bmv2 PRE is implemented: even though
+  // McSimplePre::l1_hdl_t is uintptr_t, the PRE always uses the smallest
+  // available value for node handles.
+  assert(type_can_fit_value<pi_mc_node_handle_t>(node_h));
+  *node_handle = node_h;
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_modify(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle,
+                               size_t eg_ports_count,
+                               const pi_mc_port_t *eg_ports) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  auto rc = pre->mc_node_update(
+      node_handle, convert_map(eg_ports, eg_ports_count));
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_node_delete(pi_mc_session_handle_t session_handle,
+                               pi_dev_id_t dev_id,
+                               pi_mc_node_handle_t node_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  auto rc = pre->mc_node_destroy(node_handle);
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_attach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  auto rc = pre->mc_node_associate(grp_handle, node_handle);
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_mc_grp_detach_node(pi_mc_session_handle_t session_handle,
+                                   pi_dev_id_t dev_id,
+                                   pi_mc_grp_handle_t grp_handle,
+                                   pi_mc_node_handle_t node_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  auto pre = get_pre();
+  if (pre == nullptr) return PI_STATUS_TARGET_ERROR;
+
+  auto rc = pre->mc_node_dissociate(grp_handle, node_handle);
+  if (rc != McSimplePre::McReturnCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
+}
+
+}

--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -27,7 +27,6 @@
 #include <PI/pi.h>
 
 #include <algorithm>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <vector>

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -35,7 +35,8 @@ test_gtest_SOURCES = \
 $(common_source) main.cpp \
 test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp \
 test_counter.cpp test_meter.cpp \
-test_ternary.cpp
+test_ternary.cpp \
+test_multicast.cpp
 if WITH_SYSREPO
 test_gtest_SOURCES += test_gnmi.cpp
 endif
@@ -54,4 +55,5 @@ packet_io.p4 packet_io.json packet_io.proto.txt \
 loopback.p4 loopback.json loopback.proto.txt \
 counter.p4 counter.json counter.proto.txt \
 meter.p4 meter.json meter.proto.txt \
-ternary.p4 ternary.json ternary.proto.txt
+ternary.p4 ternary.json ternary.proto.txt \
+multicast.p4 multicast.json multicast.proto.txt

--- a/targets/simple_switch_grpc/tests/test_multicast.cpp
+++ b/targets/simple_switch_grpc/tests/test_multicast.cpp
@@ -1,0 +1,253 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <google/rpc/status.pb.h>
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "base_test.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+using ::grpc::Status;
+
+// The multicast program parsers the first 16 bits of the packet and sets the
+// multicast group metadata field to the parsed value. On egress, the first 16
+// bits of the packet are replaced with the multicast rid.
+constexpr char multicast_json[] = TESTDATADIR "/multicast.json";
+constexpr char multicast_proto[] = TESTDATADIR "/multicast.proto.txt";
+
+class SimpleSwitchGrpcTest_Multicast : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_Multicast()
+      : SimpleSwitchGrpcBaseTest(multicast_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(multicast_json);
+  }
+
+  using GroupEntry = ::p4v1::MulticastGroupEntry;
+
+  Status create_group(const GroupEntry &group) {
+    return write_group(group, p4v1::Update_Type_INSERT);
+  }
+
+  Status modify_group(const GroupEntry &group) {
+    return write_group(group, p4v1::Update_Type_MODIFY);
+  }
+
+  Status delete_group(const GroupEntry &group) {
+    return write_group(group, p4v1::Update_Type_DELETE);
+  }
+
+  struct Replica {
+    int32_t port;
+    int32_t rid;
+
+    Replica(int32_t port, int32_t rid)
+        : port(port), rid(rid) { }
+
+    bool operator <(const Replica &other) const {
+      if (rid == other.rid) return port < other.port;
+      return rid < other.rid;
+    }
+
+    bool operator ==(const Replica &other) const {
+      return (rid == other.rid) && (port == other.port);
+    }
+
+    bool operator !=(const Replica &other) const {
+      return !(*this == other);
+    }
+  };
+
+  struct ReplicaMgr {
+    explicit ReplicaMgr(GroupEntry *group)
+        : group(group) { }
+
+    ReplicaMgr &push_back(const Replica &replica) {
+      auto r = group->add_replicas();
+      r->set_egress_port(replica.port);
+      r->set_instance(replica.rid);
+      return *this;
+    }
+
+    void pop_back() {
+      group->mutable_replicas()->RemoveLast();
+    }
+
+    size_t size() const { return group->replicas_size(); }
+
+    std::set<Replica> as_set() const {
+      std::set<Replica> s;
+      for (const auto &r : group->replicas())
+        s.emplace(r.egress_port(), r.instance());
+      return s;
+    }
+
+    GroupEntry *group;
+  };
+
+  using StreamType = grpc::ClientReaderWriter<p4::bm::PacketStreamRequest,
+                                              p4::bm::PacketStreamResponse>;
+
+  // For the sake of simplicity we use a synchronous gRPC client which means we
+  // cannot give a deadline for the Read call. We therefore wrap the Read call
+  // in a std::future object and use std::future::wait_for() to specify a
+  // timeout. When the timeout expires the Read call is not cancelled. However,
+  // as soon as the client calls WritesDone on the stream, Read will return
+  // false and the future will complete.
+  std::future<bool> &ReadFuture(StreamType *stream,
+                                p4::bm::PacketStreamResponse *rep) {
+    futures.emplace_back(std::async(
+        std::launch::async, [stream, rep]{ return stream->Read(rep); }));
+    return futures.back();
+  }
+
+  void send_packet(StreamType *stream, int16_t group_id, int32_t port = 1) {
+    p4::bm::PacketStreamRequest packet_request;
+    packet_request.set_device_id(device_id);
+    packet_request.set_port(port);
+    unsigned char payload[2];
+    payload[0] = (group_id >> 8) & 0xff;
+    payload[1] = group_id & 0xff;
+    packet_request.set_packet(
+        reinterpret_cast<char *>(payload), sizeof(payload));
+    stream->Write(packet_request);
+  }
+
+  std::set<Replica> receive_packets(StreamType *stream, size_t count) {
+    std::set<Replica> received;
+    for (size_t i = 0; i < count; i++) {
+      p4::bm::PacketStreamResponse rep;
+      auto &f = ReadFuture(stream, &rep);
+      if (f.wait_for(timeout) != std::future_status::ready) break;
+      auto rid = static_cast<int32_t>(
+          static_cast<unsigned char>(rep.packet()[0] << 8) +
+          static_cast<unsigned char>(rep.packet()[1]));
+      received.emplace(rep.port(), rid);
+    }
+    return received;
+  }
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+  using milliseconds = std::chrono::milliseconds;
+  const milliseconds timeout{500};
+
+ private:
+  Status write_group(const GroupEntry &group, p4v1::Update_Type type) {
+    p4v1::WriteRequest request;
+    request.set_device_id(device_id);
+    auto *update = request.add_updates();
+    update->set_type(type);
+    auto *entity = update->mutable_entity();
+    auto *pre_entry = entity->mutable_packet_replication_engine_entry();
+    pre_entry->mutable_multicast_group_entry()->CopyFrom(group);
+    p4v1::WriteResponse response;
+    ClientContext context;
+    return Write(&context, request, &response);
+  }
+
+  std::vector<std::future<bool> > futures;
+};
+
+TEST_F(SimpleSwitchGrpcTest_Multicast, 2Rids3Ports) {
+  ClientContext context;
+  auto stream = dataplane_stub->PacketStream(&context);
+
+  int16_t group_id = 10;
+  GroupEntry group;
+  group.set_multicast_group_id(group_id);
+  ReplicaMgr replicas(&group);
+
+  // we use ASSERT_EQ instead of EXPECT_EQ to ensure that the test is killed in
+  // case of failure; otherwise because of ReadFuture (our poor-man async read)
+  // we would proceed through the test with outstanding Read calls which would
+  // cause issues anyway.
+
+  Replica r1(1, 1), r2(2, 2);
+  replicas.push_back(r1).push_back(r2);
+  {
+    auto status = create_group(group);
+    EXPECT_TRUE(status.ok());
+    send_packet(stream.get(), group_id);
+    auto received = receive_packets(stream.get(), replicas.size());
+    ASSERT_EQ(replicas.as_set(), received);
+  }
+
+  Replica r3(3, r1.rid);
+  replicas.push_back(r3);
+  {
+    auto status = modify_group(group);
+    EXPECT_TRUE(status.ok());
+    send_packet(stream.get(), group_id);
+    auto received = receive_packets(stream.get(), replicas.size());
+    ASSERT_EQ(replicas.as_set(), received);
+  }
+
+  replicas.pop_back();
+  {
+    auto status = modify_group(group);
+    EXPECT_TRUE(status.ok());
+    send_packet(stream.get(), group_id);
+    auto received = receive_packets(stream.get(), replicas.size());
+    ASSERT_EQ(replicas.as_set(), received);
+  }
+
+  {
+    auto status = delete_group(group);
+    EXPECT_TRUE(status.ok());
+    send_packet(stream.get(), group_id);
+    auto received = receive_packets(stream.get(), 1);
+    ASSERT_TRUE(received.empty());
+  }
+
+  stream->WritesDone();
+  stream->Finish();
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/testdata/multicast.json
+++ b/targets/simple_switch_grpc/tests/testdata/multicast.json
@@ -1,0 +1,317 @@
+{
+  "program" : "multicast.p4",
+  "__meta__" : {
+    "version" : [2, 7],
+    "compiler" : "https://github.com/p4lang/p4c"
+  },
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "Hdr",
+      "id" : 1,
+      "fields" : [
+        ["f1", 16, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 2,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 32, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["recirculate_flag", 32, false],
+        ["_padding", 5, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr",
+      "id" : 2,
+      "header_type" : "Hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "hdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "multicast.p4",
+        "line" : 48,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : ["hdr"]
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "act",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "mcast_grp"]
+            },
+            {
+              "type" : "field",
+              "value" : ["hdr", "f1"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "multicast.p4",
+            "line" : 41,
+            "column" : 12,
+            "source_fragment" : "sm.mcast_grp = h.hdr.f1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_0",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr", "f1"]
+            },
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_rid"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "multicast.p4",
+            "line" : 45,
+            "column" : 12,
+            "source_fragment" : "h.hdr.f1 = sm.egress_rid"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "multicast.p4",
+        "line" : 40,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_act",
+      "tables" : [
+        {
+          "name" : "tbl_act",
+          "id" : 0,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["act"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "act" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "multicast.p4",
+        "line" : 44,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : "tbl_act_0",
+      "tables" : [
+        {
+          "name" : "tbl_act_0",
+          "id" : 1,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["act_0"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "act_0" : null
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.recirculate_flag",
+      ["standard_metadata", "recirculate_flag"]
+    ]
+  ]
+}

--- a/targets/simple_switch_grpc/tests/testdata/multicast.p4
+++ b/targets/simple_switch_grpc/tests/testdata/multicast.p4
@@ -1,0 +1,52 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header Hdr {
+    bit<16> f1;
+}
+
+struct Headers {
+    Hdr hdr;
+}
+
+struct Meta { }
+
+parser p(packet_in b, out Headers h,
+         inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.hdr);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply { sm.mcast_grp = h.hdr.f1; }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply { h.hdr.f1 = sm.egress_rid; }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply { b.emit(h.hdr); }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;


### PR DESCRIPTION
This enables P4Runtime multicast support in simple_switch_grpc. We
include a GTest unit test which verifies dataplane behavior after
programming the bmv2 PRE through P4Runtime.