### PR TITLE
Fix ternary match for largest priority value

### DIFF
--- a/src/bm_sim/lookup_structures.cpp
+++ b/src/bm_sim/lookup_structures.cpp
@@ -269,7 +269,10 @@ class EntryList {
     internal_handle_t min_handle = 0;
 
     for (const Entry *entry = head; entry; entry = entry->next) {
-      if (entry->priority >= min_priority) continue;
+      // not sufficient if the first entry in the table has priority
+      // "min_priority" (= max integer value).
+      // if (entry->priority >= min_priority) continue;
+      if (entry->priority >= min_priority && min_entry != nullptr) continue;
 
       if (cmp(key_data, *entry->key)) {
         min_priority = entry->priority;

--- a/targets/simple_switch_grpc/tests/test_ternary.cpp
+++ b/targets/simple_switch_grpc/tests/test_ternary.cpp
@@ -173,6 +173,26 @@ TEST_F(SimpleSwitchGrpcTest_Ternary, PriorityOrder) {
   }
 }
 
+// zero is the lowest priority in P4Runtime (which corresponds to a high
+// priority value in bmv2); this test was added for the following issue:
+// https://github.com/p4lang/behavioral-model/issues/618
+TEST_F(SimpleSwitchGrpcTest_Ternary, PriorityZero) {
+  int priority = 0;
+  int ig_port = 3;
+  std::string pkt("\xaa\xbb");
+  p4::bm::PacketStreamResponse rcv_pkt;
+  auto entity = make_entry("\xaa\xbb", "\xff\xff", priority, a_s1_id);
+  {
+    auto status = add_entry(entity);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    auto status = send_and_receive(pkt, ig_port, &rcv_pkt);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(1, rcv_pkt.port());
+  }
+}
+
 }  // namespace
 
 }  // namespace testing


### PR DESCRIPTION
There was an issue for the edge case where the first entry in the
ternary table has the largest priority value possible (which for bmv2
means this is the entry with the lowest logical priority). This edge
case was triggered when using priority value 0 with P4Runtime (at the
moment we are still discussing whether it is legal to use a priority of
0 for ternary matches in P4Runtime).

Fixes #618