### PR TITLE
Install simpleswitch_runner library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,8 +17,9 @@ if COND_PI
     MAYBE_PI = PI
 endif
 
+# simple_switch depends on libbmpi so PI needs to appear first
 SUBDIRS = $(MAYBE_THRIFT) third_party src include \
-$(MAYBE_TESTS) $(MAYBE_TARGETS) tools $(MAYBE_PDFIXED) $(MAYBE_PI)
+$(MAYBE_TESTS) $(MAYBE_PI) $(MAYBE_TARGETS) tools $(MAYBE_PDFIXED)
 
 # I am leaving all style-related files (cpplint) out of dist on purpose, maybe
 # will add them later if needed

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -2,13 +2,31 @@ if COND_NANOMSG
 MAYBE_TESTS = tests
 endif
 
+if COND_PI
+AM_CPPFLAGS += \
+-DWITH_PI \
+-I$(top_srcdir)/PI
+PI_LIB = $(top_builddir)/PI/libbmpi.la
+else
+PI_LIB =
+endif
+
 SUBDIRS = . $(MAYBE_TESTS)
 
 THRIFT_IDL = $(srcdir)/thrift/simple_switch.thrift
 
 noinst_LTLIBRARIES = libsimpleswitch.la
+lib_LTLIBRARIES = libsimpleswitch_runner.la
 
-libsimpleswitch_la_SOURCES = simple_switch.cpp simple_switch.h primitives.cpp
+libsimpleswitch_la_SOURCES = \
+simple_switch.cpp \
+simple_switch.h \
+primitives.cpp
+
+libsimpleswitch_runner_la_SOURCES = \
+runner.cpp
+
+nobase_include_HEADERS = bm/simple_switch/runner.h
 
 libsimpleswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \
@@ -16,6 +34,10 @@ $(top_builddir)/src/bf_lpm_trie/libbflpmtrie.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
 -lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+
+libsimpleswitch_runner_la_LIBADD = \
+$(PI_LIB) \
+libsimpleswitch.la
 
 if COND_THRIFT
 
@@ -80,7 +102,7 @@ if ENABLE_MODULES
 simple_switch_LDFLAGS += -rdynamic
 endif
 
-lib_LTLIBRARIES = libsimpleswitch_thrift.la
+lib_LTLIBRARIES += libsimpleswitch_thrift.la
 
 nodist_libsimpleswitch_thrift_la_SOURCES = \
 $(simple_switch_thrift_files)

--- a/targets/simple_switch/bm/simple_switch/runner.h
+++ b/targets/simple_switch/bm/simple_switch/runner.h
@@ -1,0 +1,51 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SIMPLE_SWITCH_BM_SIMPLE_SWITCH_RUNNER_H_
+#define SIMPLE_SWITCH_BM_SIMPLE_SWITCH_RUNNER_H_
+
+#include <bm/bm_sim/options_parse.h>
+
+#include <cstdint>
+#include <memory>
+
+class SimpleSwitch;
+
+namespace bm {
+
+namespace sswitch {
+
+class SimpleSwitchRunner {
+ public:
+  SimpleSwitchRunner();
+  ~SimpleSwitchRunner();
+
+  int init_and_start(const bm::OptionsParser &parser);
+
+ private:
+  uint32_t cpu_port{64};
+  std::unique_ptr<SimpleSwitch> simple_switch;
+};
+
+}  // namespace sswitch
+
+}  // namespace bm
+
+#endif  // SIMPLE_SWITCH_BM_SIMPLE_SWITCH_RUNNER_H_

--- a/targets/simple_switch/runner.cpp
+++ b/targets/simple_switch/runner.cpp
@@ -1,0 +1,76 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/logger.h>
+
+#ifdef WITH_PI
+#include <bm/PI/pi.h>
+#endif
+
+#include <bm/simple_switch/runner.h>
+
+#include <PI/pi.h>
+#include <PI/target/pi_imp.h>
+
+#include "simple_switch.h"
+
+namespace bm {
+
+namespace sswitch {
+
+SimpleSwitchRunner::SimpleSwitchRunner()
+    : simple_switch(
+          new SimpleSwitch(512 /* max_port */, true /* enable_swap */)) { }
+
+SimpleSwitchRunner::~SimpleSwitchRunner() = default;
+
+int SimpleSwitchRunner::init_and_start(const bm::OptionsParser &parser) {
+  int status = simple_switch->init_from_options_parser(
+      parser, nullptr, nullptr);
+  if (status != 0) return status;
+
+#ifdef WITH_PI
+  auto transmit_fn = [this](bm::DevMgrIface::port_t port_num,
+                            packet_id_t pkt_id, const char *buf, int len) {
+    (void)pkt_id;
+    if (cpu_port > 0 && port_num == cpu_port) {
+      BMLOG_DEBUG("Transmitting packet-in");
+      auto status = pi_packetin_receive(simple_switch->get_device_id(),
+                                        buf, static_cast<size_t>(len));
+      if (status != PI_STATUS_SUCCESS)
+        bm::Logger::get()->error("Error when transmitting packet-in");
+    } else {
+      simple_switch->transmit_fn(port_num, buf, len);
+    }
+  };
+  simple_switch->set_transmit_fn(transmit_fn);
+
+  bm::pi::register_switch(simple_switch.get(), cpu_port);
+#endif
+
+  simple_switch->start_and_return();
+
+  return 0;
+}
+
+}  // namespace sswitch
+
+}  // namespace bm


### PR DESCRIPTION
So that it can be used by third-party projects. It defines a
SimpleSwitchRunner class which can be used by a third-party executable
to run SimpleSwitch (without pulling in bmv2 build dependencies).