### PR TITLE
Support standard_metadata.parser_error field in SimpleSwitch

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -333,6 +333,11 @@ SimpleSwitch::ingress_thread() {
     const Packet::buffer_state_t packet_in_state = packet->save_buffer_state();
     parser->parse(packet.get());
 
+    if (phv->has_field("standard_metadata.parser_error")) {
+      phv->get_field("standard_metadata.parser_error").set(
+          packet->get_error_code().get());
+    }
+
     ingress_mau->apply(packet.get());
 
     packet->reset_exit();

--- a/targets/simple_switch/tests/Makefile.am
+++ b/targets/simple_switch/tests/Makefile.am
@@ -20,7 +20,8 @@ TESTS = test_packet_redirect \
 test_truncate \
 test_swap \
 test_queueing \
-test_recirc
+test_recirc \
+test_parser_error
 
 check_PROGRAMS = $(TESTS) test_all
 
@@ -30,13 +31,15 @@ test_truncate_SOURCES = $(common_source) test_truncate.cpp
 test_swap_SOURCES = $(common_source) test_swap.cpp
 test_queueing_SOURCES = $(common_source) test_queueing.cpp
 test_recirc_SOURCES = $(common_source) test_recirc.cpp
+test_parser_error_SOURCES = $(common_source) test_parser_error.cpp
 
 test_all_SOURCES = $(common_source) \
 test_packet_redirect.cpp \
 test_truncate.cpp \
 test_swap.cpp \
 test_queueing.cpp \
-test_recirc.cpp
+test_recirc.cpp \
+test_parser_error.cpp
 
 EXTRA_DIST = \
 testdata/packet_redirect.json \
@@ -44,4 +47,6 @@ testdata/truncate.json \
 testdata/swap_1.json \
 testdata/swap_2.json \
 testdata/queueing.json \
-testdata/recirc.json
+testdata/recirc.json \
+testdata/parser_error.p4 \
+testdata/parser_error.json

--- a/targets/simple_switch/tests/test_parser_error.cpp
+++ b/targets/simple_switch/tests/test_parser_error.cpp
@@ -1,0 +1,148 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_apps/packet_pipe.h>
+
+#include <boost/filesystem.hpp>
+
+#include <string>
+#include <memory>
+#include <vector>
+#include <algorithm>  // for std::fill_n
+#include <fstream>
+#include <streambuf>
+
+#include "simple_switch.h"
+
+#include "utils.h"
+
+namespace fs = boost::filesystem;
+
+using bm::MatchErrorCode;
+using bm::ActionData;
+using bm::MatchKeyParam;
+using bm::entry_handle_t;
+
+namespace {
+
+void
+packet_handler(int port_num, const char *buffer, int len, void *cookie) {
+  static_cast<SimpleSwitch *>(cookie)->receive(port_num, buffer, len);
+}
+
+}  // namespace
+
+class SimpleSwitch_ParserErrorP4 : public ::testing::Test {
+ protected:
+  static constexpr size_t kMaxBufSize = 512;
+
+  static constexpr bm::device_id_t device_id{0};
+
+  SimpleSwitch_ParserErrorP4()
+      : packet_inject(packet_in_addr) { }
+
+  // Per-test-case set-up.
+  // We make the switch a shared resource for all tests. This is mainly because
+  // the simple_switch target detaches threads
+  static void SetUpTestCase() {
+    // bm::Logger::set_logger_console();
+
+    test_switch = new SimpleSwitch(8);  // 8 ports
+
+    fs::path json_path = fs::path(testdata_dir) / fs::path(test_json);
+    test_switch->init_objects(json_path.string());
+
+    // packet in - packet out
+    test_switch->set_dev_mgr_packet_in(device_id, packet_in_addr, nullptr);
+    test_switch->Switch::start();  // there is a start member in SimpleSwitch
+    test_switch->set_packet_handler(packet_handler,
+                                    static_cast<void *>(test_switch));
+    test_switch->start_and_return();
+  }
+
+  // Per-test-case tear-down.
+  static void TearDownTestCase() {
+    delete test_switch;
+  }
+
+  virtual void SetUp() {
+    packet_inject.start();
+    auto cb = std::bind(&PacketInReceiver::receive, &receiver,
+                        std::placeholders::_1, std::placeholders::_2,
+                        std::placeholders::_3, std::placeholders::_4);
+    packet_inject.set_packet_receiver(cb, nullptr);
+  }
+
+  virtual void TearDown() {
+    // kind of experimental, so reserved for testing
+    test_switch->reset_state();
+  }
+
+ protected:
+  static const std::string packet_in_addr;
+  static SimpleSwitch *test_switch;
+  bm_apps::PacketInject packet_inject;
+  PacketInReceiver receiver{};
+
+ private:
+  static const std::string testdata_dir;
+  static const std::string test_json;
+};
+
+const std::string SimpleSwitch_ParserErrorP4::packet_in_addr =
+    "inproc://packets";
+
+SimpleSwitch *SimpleSwitch_ParserErrorP4::test_switch = nullptr;
+
+const std::string SimpleSwitch_ParserErrorP4::testdata_dir = TESTDATADIR;
+const std::string SimpleSwitch_ParserErrorP4::test_json = "parser_error.json";
+
+TEST_F(SimpleSwitch_ParserErrorP4, NoError) {
+  static constexpr int port = 1;
+  int recv_port;
+  char recv_buffer[kMaxBufSize];
+  const char pkt[] = {'\x00', '\x00', '\x00', '\x00'};
+  packet_inject.send(port, pkt, sizeof(pkt));
+  EXPECT_EQ(4u, receiver.read(recv_buffer, kMaxBufSize, &recv_port));
+  EXPECT_EQ(port, recv_port);
+  EXPECT_EQ(0, static_cast<int>(recv_buffer[3]));
+}
+
+TEST_F(SimpleSwitch_ParserErrorP4, PacketTooShort) {
+  static constexpr int port = 1;
+  int recv_port;
+  char recv_buffer[kMaxBufSize];
+  const char pkt[] = {'\x00', '\x00'};
+  packet_inject.send(port, pkt, sizeof(pkt));
+  // why 6? because the 2 bytes of pkt are never extracted because they are too
+  // short and are therefore considered payload bytes. In ingress, we make the
+  // header valid, therefore prepending 4 bytes to the packet.
+  EXPECT_EQ(6u, receiver.read(recv_buffer, kMaxBufSize, &recv_port));
+  EXPECT_EQ(port, recv_port);
+  EXPECT_EQ(1, static_cast<int>(recv_buffer[3]));
+}
+
+TEST_F(SimpleSwitch_ParserErrorP4, CustomError) {
+  static constexpr int port = 1;
+  int recv_port;
+  char recv_buffer[kMaxBufSize];
+  const char pkt[] = {'\x00', '\x00', '\x00', '\xab'};
+  packet_inject.send(port, pkt, sizeof(pkt));
+  EXPECT_EQ(4u, receiver.read(recv_buffer, kMaxBufSize, &recv_port));
+  EXPECT_EQ(port, recv_port);
+  EXPECT_EQ(2, static_cast<int>(recv_buffer[3]));
+}

--- a/targets/simple_switch/tests/testdata/parser_error.json
+++ b/targets/simple_switch/tests/testdata/parser_error.json
@@ -1,0 +1,615 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 1, false],
+        ["_padding_0", 7, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 32, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["recirculate_flag", 32, false],
+        ["parser_error", 32, false],
+        ["_padding", 5, false]
+      ]
+    },
+    {
+      "name" : "Hdr",
+      "id" : 2,
+      "fields" : [
+        ["f1", 32, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h",
+      "id" : 2,
+      "header_type" : "Hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6],
+    ["CustomError", 7]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "h"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "b2d",
+                      "left" : null,
+                      "right" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "<",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h", "f1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x0000000a"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "op" : "d2b",
+                    "left" : null,
+                    "right" : {
+                      "type" : "field",
+                      "value" : ["scalars", "tmp"]
+                    }
+                  }
+                },
+                {
+                  "type" : "hexstr",
+                  "value" : "7"
+                }
+              ],
+              "op" : "verify"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "parser_error.p4",
+        "line" : 52,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : ["h"]
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "act",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00000000"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 33,
+            "column" : 12,
+            "source_fragment" : "hdr.h.f1 = 0"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_0",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "h"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 35,
+            "column" : 12,
+            "source_fragment" : "hdr.h.setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00000001"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 36,
+            "column" : 12,
+            "source_fragment" : "hdr.h.f1 = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_1",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00000002"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 38,
+            "column" : 12,
+            "source_fragment" : "hdr.h.f1 = 2"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_2",
+      "id" : 3,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00000003"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 40,
+            "column" : 12,
+            "source_fragment" : "hdr.h.f1 = 3"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_3",
+      "id" : 4,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "ingress_port"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 42,
+            "column" : 8,
+            "source_fragment" : "standard_metadata.egress_spec = standard_metadata.ingress_port"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "parser_error.p4",
+        "line" : 28,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "node_2",
+      "tables" : [
+        {
+          "name" : "tbl_act",
+          "id" : 0,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["act"],
+          "base_default_next" : "tbl_act_3",
+          "next_tables" : {
+            "act" : "tbl_act_3"
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_0",
+          "id" : 1,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["act_0"],
+          "base_default_next" : "tbl_act_3",
+          "next_tables" : {
+            "act_0" : "tbl_act_3"
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_1",
+          "id" : 2,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["act_1"],
+          "base_default_next" : "tbl_act_3",
+          "next_tables" : {
+            "act_1" : "tbl_act_3"
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_2",
+          "id" : 3,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [3],
+          "actions" : ["act_2"],
+          "base_default_next" : "tbl_act_3",
+          "next_tables" : {
+            "act_2" : "tbl_act_3"
+          },
+          "default_entry" : {
+            "action_id" : 3,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_3",
+          "id" : 4,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [4],
+          "actions" : ["act_3"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "act_3" : null
+          },
+          "default_entry" : {
+            "action_id" : 4,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_2",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 32,
+            "column" : 12,
+            "source_fragment" : "standard_metadata.parser_error == error.NoError"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "1"
+              }
+            }
+          },
+          "true_next" : "tbl_act",
+          "false_next" : "node_4"
+        },
+        {
+          "name" : "node_4",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 34,
+            "column" : 19,
+            "source_fragment" : "standard_metadata.parser_error == error.PacketTooShort"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "2"
+              }
+            }
+          },
+          "true_next" : "tbl_act_0",
+          "false_next" : "node_6"
+        },
+        {
+          "name" : "node_6",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "parser_error.p4",
+            "line" : 37,
+            "column" : 19,
+            "source_fragment" : "standard_metadata.parser_error == error.CustomError"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "7"
+              }
+            }
+          },
+          "true_next" : "tbl_act_1",
+          "false_next" : "tbl_act_2"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "parser_error.p4",
+        "line" : 46,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.recirculate_flag",
+      ["standard_metadata", "recirculate_flag"]
+    ]
+  ],
+  "program" : "parser_error.p4",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/targets/simple_switch/tests/testdata/parser_error.p4
+++ b/targets/simple_switch/tests/testdata/parser_error.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header Hdr {
+    bit<32> f1;
+}
+
+struct parsed_packet_t {
+    Hdr h;
+};
+
+struct local_metadata_t {};
+
+error {
+    CustomError
+}
+
+parser parse(packet_in pk, out parsed_packet_t hdr,
+             inout local_metadata_t local_metadata,
+             inout standard_metadata_t standard_metadata) {
+    state start {
+        pk.extract(hdr.h);
+        verify(hdr.h.f1 < 10, error.CustomError);
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t hdr,
+                inout local_metadata_t local_metadata,
+	        inout standard_metadata_t standard_metadata) {
+    apply {
+        if (standard_metadata.parser_error == error.NoError) {
+            hdr.h.f1 = 0;
+        } else if (standard_metadata.parser_error == error.PacketTooShort) {
+            hdr.h.setValid();
+            hdr.h.f1 = 1;
+        } else if (standard_metadata.parser_error == error.CustomError) {
+            hdr.h.f1 = 2;
+        } else {
+            hdr.h.f1 = 3;
+        }
+        standard_metadata.egress_spec = standard_metadata.ingress_port;
+    }
+}
+
+control egress(inout parsed_packet_t hdr,
+               inout local_metadata_t local_metadata,
+	       inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control deparser(packet_out b, in parsed_packet_t hdr) {
+    apply {
+        b.emit(hdr);
+    }
+}
+
+control verify_checks(inout parsed_packet_t hdr,
+                      inout local_metadata_t local_metadata) {
+    apply { }
+}
+
+control compute_checksum(inout parsed_packet_t hdr,
+                         inout local_metadata_t local_metadata) {
+    apply { }
+}
+
+V1Switch(parse(), verify_checks(), ingress(), egress(),
+         compute_checksum(), deparser()) main;


### PR DESCRIPTION
v1model now includes a new standard metadata field that is used to
communicate the parser error code to the control blocks. This commit
makes sure that the code is written to the field after the parser
executes. The change itself is very small but we include a unit test for
SimpleSwitch (with P4 & JSON files).

Fixes #446