### PR TITLE
Support cloning to a multicast group in simple_switch

### DIFF
--- a/PI/Makefile.am
+++ b/PI/Makefile.am
@@ -1,5 +1,9 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
+if COND_TARGETS
+AM_CPPFLAGS += -I$(top_srcdir)/targets/simple_switch -DWITH_SIMPLE_SWITCH
+endif
+
 libbmpi_la_SOURCES = \
 src/pi.cpp \
 src/pi_imp.cpp \
@@ -9,6 +13,7 @@ src/pi_counter_imp.cpp \
 src/pi_meter_imp.cpp \
 src/pi_learn_imp.cpp \
 src/pi_mc_imp.cpp \
+src/pi_clone_imp.cpp \
 src/common.h \
 src/common.cpp \
 src/action_helpers.h \

--- a/PI/src/pi_clone_imp.cpp
+++ b/PI/src/pi_clone_imp.cpp
@@ -1,0 +1,102 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <bm/bm_sim/_assert.h>
+
+#include <PI/pi_clone.h>
+#include <PI/pi_mc.h>
+#include <PI/target/pi_clone_imp.h>
+
+// TODO(antonin): it would probably make more sense to move this code to
+// targets/simple_switch, but for now it will have to do.
+#if WITH_SIMPLE_SWITCH
+#include "simple_switch.h"
+
+#include "common.h"
+
+extern "C" {
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t session_handle,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_tgt);
+  auto *sswitch = dynamic_cast<SimpleSwitch *>(pibmv2::switch_);
+  if (sswitch == nullptr) return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  SimpleSwitch::MirroringSessionConfig config = {};
+  if (clone_session_config->direction != PI_CLONE_DIRECTION_BOTH)
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  config.egress_port = clone_session_config->eg_port;
+  config.egress_port_valid = clone_session_config->eg_port_valid;
+  config.mgid = clone_session_config->mc_grp_id;
+  config.mgid_valid = clone_session_config->mc_grp_id_valid;
+  // TODO(antonin): add support for truncation in bmv2
+  if (clone_session_config->max_packet_length != 0)
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  auto success = sswitch->mirroring_add_session(
+      clone_session_id, config);
+  return success ? PI_STATUS_SUCCESS : PI_STATUS_TARGET_ERROR;
+}
+
+pi_status_t _pi_clone_session_reset(
+    pi_session_handle_t session_handle,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_tgt);
+  auto *sswitch = dynamic_cast<SimpleSwitch *>(pibmv2::switch_);
+  if (sswitch == nullptr) return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  auto success = sswitch->mirroring_delete_session(clone_session_id);
+  return success ? PI_STATUS_SUCCESS : PI_STATUS_TARGET_ERROR;
+}
+
+}
+
+#else  // WITH_SIMPLE_SWITCH
+
+extern "C" {
+
+pi_status_t _pi_clone_session_set(
+    pi_session_handle_t session_handle,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id,
+    const pi_clone_session_config_t *clone_session_config) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_tgt);
+  _BM_UNUSED(clone_session_id);
+  _BM_UNUSED(clone_session_config);
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
+pi_status_t _pi_clone_session_reset(
+    pi_session_handle_t session_handle,
+    pi_dev_tgt_t dev_tgt,
+    pi_clone_session_id_t clone_session_id) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_tgt);
+  _BM_UNUSED(clone_session_id);
+  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
+}
+
+#endif  // WITH_SIMPLE_SWITCH

--- a/targets/simple_switch/thrift/simple_switch.thrift
+++ b/targets/simple_switch/thrift/simple_switch.thrift
@@ -21,11 +21,32 @@
 namespace cpp sswitch_runtime
 namespace py sswitch_runtime
 
+struct MirroringSessionConfig {
+  1:optional i32 port;
+  2:optional i32 mgid;
+}
+
+enum MirroringOperationErrorCode {
+  SESSION_NOT_FOUND = 1,
+}
+
+exception InvalidMirroringOperation {
+  1:MirroringOperationErrorCode code;
+}
+
 service SimpleSwitch {
 
+  // deprecated, use the mirroring_session_* RPCs instead
   i32 mirroring_mapping_add(1:i32 mirror_id, 2:i32 egress_port);
   i32 mirroring_mapping_delete(1:i32 mirror_id);
   i32 mirroring_mapping_get_egress_port(1:i32 mirror_id);
+
+  void mirroring_session_add(1:i32 mirror_id, 2:MirroringSessionConfig config)
+  throws (1:InvalidMirroringOperation ouch);
+  void mirroring_session_delete(1:i32 mirror_id)
+  throws (1:InvalidMirroringOperation ouch);
+  MirroringSessionConfig mirroring_session_get(1:i32 mirror_id)
+  throws (1:InvalidMirroringOperation ouch);
 
   i32 set_egress_queue_depth(1:i32 port_num, 2:i32 depth_pkts);
   i32 set_all_egress_queue_depths(1:i32 depth_pkts);

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -402,7 +402,10 @@ SimpleSwitchGrpcRunner::shutdown() {
 int
 SimpleSwitchGrpcRunner::mirroring_mapping_add(int mirror_id,
   bm::DevMgrIface::port_t egress_port) {
-  return simple_switch->mirroring_mapping_add(mirror_id, egress_port);
+  SimpleSwitch::MirroringSessionConfig config = {};
+  config.egress_port = egress_port;
+  config.egress_port_valid = true;
+  return simple_switch->mirroring_add_session(mirror_id, config);
 }
 
 void


### PR DESCRIPTION
The PSA architecture has recently introduced the ability to clone a
packet (I2E & E2E) to a set of egress ports. P4Runtime also supports
this by offering a runtime API to map a clone session id to a list of
(port, rid) tuples.

While neither PSA nor P4Runtime require this functionality to be
implemented using multicast (by associating a clone session id to a
multicast group), it seems that a lot of HW targets would probably
choose this approach. As a result, this is also the approach we take for
simple_switch. Note that simple_switch now supports cloning to both a
unicast port & a multicast group simultaneously, which may not be the
case for a lot of targets.

The Thrift service for simple_switch has been updated to include new
RPCs for cloning / mirroring. With these new RPCs, it is possible to map
a session id to a unicast port, a multicast group or both. The old RPCs
have been preserved for backward-compatibility but they should be
considered deprecated. The simple_switch_CLI has also been updated; it
uses separate commands to configure a session with unicast and with
multicast (there is currently no way to configure a session for both
using the CLI, but this may be added in the future if needed).