### PR TITLE
Add is_dp_service_active() API to SimpleSwitchGrpc to return the current status of dataplaneinterface gRPC service

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -97,6 +97,11 @@ class DataplaneInterfaceServiceImpl
     }
   }
 
+  bool get_packet_stream_status() {
+    Lock lock(mutex);
+    return active;
+  }
+
  private:
   using Lock = std::lock_guard<std::mutex>;
 
@@ -403,6 +408,14 @@ SimpleSwitchGrpcRunner::mirroring_mapping_add(int mirror_id,
 void
 SimpleSwitchGrpcRunner::block_until_all_packets_processed() {
   simple_switch->block_until_no_more_packets();
+}
+
+bool
+SimpleSwitchGrpcRunner::is_dp_service_active() {
+  if (dp_service != nullptr) {
+    return dp_service->get_packet_stream_status();
+  }
+  return false;
 }
 
 SimpleSwitchGrpcRunner::~SimpleSwitchGrpcRunner() {

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -71,6 +71,7 @@ class SimpleSwitchGrpcRunner {
   int mirroring_mapping_add(int mirror_id,
                             bm::DevMgrIface::port_t egress_port);
   void block_until_all_packets_processed();
+  bool is_dp_service_active();
 
  private:
   SimpleSwitchGrpcRunner(bm::DevMgrIface::port_t max_port = 512,


### PR DESCRIPTION
A possible race condition can occur when p4runtime service PacketOut reaches an inactive dataplane interface service. This API can be used to make sure dp service is active i.e. my_transmit_fn will transmit the packet, before sending p4runtime PacketOut.