### PR TITLE
Add support for setting checksum error in Simple Switch

### DIFF
--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -242,6 +242,12 @@ class Packet final {
   //! be set to "NoError".
   ErrorCode get_error_code() const { return error_code; }
 
+  void set_checksum_error(const bool b) { checksum_error = b; }
+  //! Get the checksum error flag for this Packet, as set by the most
+  //! recent Parser object the packet went through. For most packets,
+  //! this error flag should be set to "false".
+  bool get_checksum_error() const { return checksum_error; }
+
   //! Mark the packet for exit by setting an exit flag. If this is called from
   //! an action, the current pipeline will be interrupted as soon as the current
   //! table is done processing the packet. This effectively skips the rest of
@@ -376,6 +382,8 @@ class Packet final {
   size_t entry_index{INVALID_ENTRY_INDEX};
 
   ErrorCode error_code{ErrorCode::make_invalid()};
+
+  bool checksum_error{false};
 
  private:
   static CopyIdGenerator *copy_id_gen;

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -337,7 +337,7 @@ class Parser : public NamedP4Object {
   Parser &operator=(Parser &&other) /*noexcept*/ = default;
 
  private:
-  void verify_checksums(const Packet &pkt) const;
+  void verify_checksums(Packet *pkt) const;
 
   const ParseState *init_state;
   const ErrorCodeMap *error_codes;

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -406,6 +406,11 @@ SimpleSwitch::ingress_thread() {
           packet->get_error_code().get());
     }
 
+    if (phv->has_field("standard_metadata.checksum_error")) {
+      phv->get_field("standard_metadata.checksum_error").set(
+           packet->get_checksum_error() ? 1 : 0);
+    }
+    
     ingress_mau->apply(packet.get());
 
     packet->reset_exit();

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -410,7 +410,7 @@ SimpleSwitch::ingress_thread() {
       phv->get_field("standard_metadata.checksum_error").set(
            packet->get_checksum_error() ? 1 : 0);
     }
-    
+
     ingress_mau->apply(packet.get());
 
     packet->reset_exit();


### PR DESCRIPTION
Main changes:
* Add boolean flag `checksum_error` to `Packet`, as well as `get_checksum_error` and `set_checksum_error` methods
* Modify `verify_checksums` to set Packet's `checksum_error` flag when checksum verification fails (and also change type of `Packet` parameter from a `const` reference to just a `pointer`)
* Modify Simple Switch to set `standard_metadata.checksum_error` using `checksum_error`

I've verified that this code works on an example. I'd be glad to add a test to the Bmv2 repository.