### PR TITLE
Fix linking for simple_switch_grpc

### DIFF
--- a/PI/Makefile.am
+++ b/PI/Makefile.am
@@ -21,9 +21,6 @@ src/action_helpers.cpp \
 src/direct_res_spec.h \
 src/direct_res_spec.cpp
 
-libbmpi_la_LIBADD = \
-$(top_builddir)/src/bm_sim/libbmsim.la
-
 lib_LTLIBRARIES = libbmpi.la
 
 nobase_include_HEADERS = bm/PI/pi.h

--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -41,9 +41,7 @@ endif
 libsimple_switch_grpc_la_LIBADD = \
 $(builddir)/../simple_switch/libsimpleswitch.la \
 $(builddir)/../../PI/libbmpi.la \
-libbm_grpc_dataplane.la \
--lpifeproto -lpigrpcserver -lpi \
-$(GRPC_LIBS) $(PROTOBUF_LIBS)
+libbm_grpc_dataplane.la
 
 if WITH_THRIFT
 libsimple_switch_grpc_la_LIBADD += \
@@ -51,6 +49,10 @@ $(builddir)/../../src/bm_runtime/libbmruntime.la \
 $(builddir)/../../thrift_src/libruntimestubs.la \
 $(builddir)/../simple_switch/libsimpleswitch_thrift.la
 endif
+
+libsimple_switch_grpc_la_LIBADD += \
+-lpifeproto -lpigrpcserver -lpi \
+$(GRPC_LIBS) $(PROTOBUF_LIBS)
 
 # dataplane_interface.proto
 


### PR DESCRIPTION
While investigating issue 630, I realized that the root cause was that
some bmv2 symbols were defined in different shared libraries that both
end up being linked against simple_switch_grpc. There is no linking
error, however it ends up causing some surprising behaviors at runtime
based on which symbol is preferred. In the case of issue 630, a
dynamic_cast "fails" because the vtable used is not the "right" one.

The problem comes from the libbmsim libtool convenience library which is
statically linked in both libbmpi and libsimpleswitch. Both of these
libraries are linked against simple_switch_grpc.

I "fixed" this by removing libbmsim from libbmpi's LIBADD
dependencies. LIBADD for non-convenience libraries is pretty much
useless on the Debian / Ubuntu version of libtool anyway
(https://stackoverflow.com/a/11932131/4538702).

Fixes #630