### PR TITLE
Packet & headers serialization functions

### DIFF
--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -265,6 +265,12 @@ class Packet final {
   //! called on the packet).
   bool is_marked_for_exit() const { return flags & (1 << FLAGS_EXIT); }
 
+  // Deparses the selected headers in front of the packet payload
+  char *deparsed_data(const std::vector<Header *> &hdrs, size_t *size);
+  // Reparses the data back into the headers
+  void reparse_headers(char *deparsed, const std::vector<Header *>&hdrs);
+
+
   //! Changes the context of the packet. You will only need to call this
   //! function if you target switch leverages the Context class and if your
   //! Packet instance changes contexts during its lifetime. This is needed

--- a/include/bm/bm_sim/phv.h
+++ b/include/bm/bm_sim/phv.h
@@ -288,6 +288,8 @@ class PHV {
   const std::string get_field_name(header_id_t header_index,
                                    int field_offset) const;
 
+  void get_valid_headers(std::vector<Header *> *hdrs);
+
  private:
   // To  be used only by PHVFactory
   // all headers need to be pushed back in order (according to header_index) !!!

--- a/src/bm_sim/phv.cpp
+++ b/src/bm_sim/phv.cpp
@@ -194,6 +194,18 @@ PHV::get_field_name(header_id_t header_index, int field_offset) const {
   return get_header(header_index).get_field_full_name(field_offset);
 }
 
+void
+PHV::get_valid_headers(std::vector<Header *> *hdrs) {
+  const std::string bad_prefix = "hdr_";
+  for (auto it = header_begin(); it != header_end(); it++) {
+    Header &hdr = *it;
+    if (hdr.is_valid() &&
+          !hdr.is_metadata() &&
+          hdr.get_name().compare(0, bad_prefix.size(), bad_prefix)) {
+      hdrs->push_back(&hdr);
+    }
+  }
+}
 
 void
 PHVFactory::push_back_header(const std::string &header_name,


### PR DESCRIPTION
This adds functionality to externs which require acting on the packet in a fully serialized form, including headers.

Three functions are added to the packet/phv interfaces:

```cpp
std::vector<Header *> headers;
phv->get_valid_headers(&headers);
```
Places in the `headers` vector all of the headers of the headers of the given packet which are valid, and will be deparsed at the end of the pipeline.
Note: Each header listed in the headers iterator in the phv appears to be listed twice -- one with the `hdr_` prefix, and one without. This ignores those headers prefixed with `hdr_` so as not to duplicate.

```cpp
size_t buff_size;
char *buff = packet.deparsed_data(hdrs, &buff_size);
// buff now contains the serialized packet prefixed by the headers in hdrs
// hdrs can be filled by get_valid_headers() or from headers manually
// passed to an extern
... // Use/modify serialized headers and packet
packet.reparse_headers(buff, hdrs);
```


