### PR TITLE
p4dbg.py: don't use thrift if socket and json are specified

### DIFF
--- a/tools/p4dbg.py
+++ b/tools/p4dbg.py
@@ -674,12 +674,16 @@ class DebuggerAPI(cmd.Cmd):
         self.reset()
         print "We have been notified that the JSON config has changed on the",
         print "switch. The debugger state has therefore been reset."
+
+        if not self.standard_client:
+            print "Unable to request new config from switch because Thrift is unavailable"
+            sys.exit(0)
+
         print "You can request the new config and keep debugging,",
         print "or we will exit."
+
         v = prompt_yes_no("Do you want to request the new config?", True)
         if v:
-            if not self.standard_client:
-                raise UIn_Error("Unable to request new config from switch because Thrift is unavailable")
            self.json_dependent_init()
         else:
             sys.exit(0)


### PR DESCRIPTION
This lets you use `p4dbg.py` with `simple_switch_grpc` without thrift. You must specify both the `--json` and `--socket` path. 