### PR TITLE
Add support for sending digests through P4Runtime

### DIFF
--- a/PI/src/pi_learn_imp.cpp
+++ b/PI/src/pi_learn_imp.cpp
@@ -19,25 +19,85 @@
  */
 
 #include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/learning.h>
+#include <bm/bm_sim/switch.h>
 
+#include <PI/p4info/digests.h>
 #include <PI/target/pi_learn_imp.h>
 
+#include "common.h"
+
+namespace {
+
+pi_status_t get_bm_list_id(const pi_p4info_t *p4info,
+                           bm::LearnEngineIface *learn_engine,
+                           pi_p4_id_t learn_id,
+                           bm::LearnEngineIface::list_id_t *list_id) {
+  const char *name = pi_p4info_digest_name_from_id(p4info, learn_id);
+  if (name == nullptr) return PI_STATUS_TARGET_ERROR;
+  auto rc = learn_engine->list_get_id_from_name(name, list_id);
+  if (rc != bm::LearnEngineIface::LearnErrorCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
+}
+
+}  // namespace
+
 extern "C" {
+
+pi_status_t _pi_learn_config_set(pi_session_handle_t session_handle,
+                                 pi_dev_id_t dev_id, pi_p4_id_t learn_id,
+                                 const pi_learn_config_t *config) {
+  _BM_UNUSED(session_handle);
+  const auto *p4info = pibmv2::get_device_info(dev_id);
+  assert(p4info != nullptr);
+  auto *learn_engine = pibmv2::switch_->get_learn_engine(0);
+  assert(learn_engine != nullptr);
+  bm::LearnEngineIface::list_id_t list_id;
+  auto status = get_bm_list_id(p4info, learn_engine, learn_id, &list_id);
+  if (status != PI_STATUS_SUCCESS) return status;
+  // TODO(antonin): here we do not anything when we should be disabling
+  // learning, we rely on the PI client to ignore notifications
+  if (config == nullptr) return PI_STATUS_SUCCESS;
+  auto max_samples = static_cast<size_t>(
+      (config->max_size == 0) ? 1024 : config->max_size);
+  auto timeout_ms = static_cast<unsigned int>(
+      config->max_timeout_ns / 1000000.);
+  {
+    auto rc = learn_engine->list_set_max_samples(list_id, max_samples);
+    if (rc != bm::LearnEngineIface::LearnErrorCode::SUCCESS)
+      return pibmv2::convert_error_code(rc);
+  }
+  {
+    auto rc = learn_engine->list_set_timeout(list_id, timeout_ms);
+    if (rc != bm::LearnEngineIface::LearnErrorCode::SUCCESS)
+      return pibmv2::convert_error_code(rc);
+  }
+  return PI_STATUS_SUCCESS;
+}
 
 pi_status_t _pi_learn_msg_ack(pi_session_handle_t session_handle,
                               pi_dev_id_t dev_id,
                               pi_p4_id_t learn_id,
                               pi_learn_msg_id_t msg_id) {
   _BM_UNUSED(session_handle);
-  _BM_UNUSED(dev_id);
-  _BM_UNUSED(learn_id);
-  _BM_UNUSED(msg_id);
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  const auto *p4info = pibmv2::get_device_info(dev_id);
+  assert(p4info != nullptr);
+  auto *learn_engine = pibmv2::switch_->get_learn_engine(0);
+  assert(learn_engine != nullptr);
+  bm::LearnEngineIface::list_id_t list_id;
+  auto status = get_bm_list_id(p4info, learn_engine, learn_id, &list_id);
+  if (status != PI_STATUS_SUCCESS) return status;
+  auto rc = learn_engine->ack_buffer(list_id, msg_id);
+  if (rc != bm::LearnEngineIface::LearnErrorCode::SUCCESS)
+    return pibmv2::convert_error_code(rc);
+  return PI_STATUS_SUCCESS;
 }
 
 pi_status_t _pi_learn_msg_done(pi_learn_msg_t *msg) {
-  _BM_UNUSED(msg);
-  return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  delete[] msg->entries;
+  delete msg;
+  return PI_STATUS_SUCCESS;
 }
 
 }

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -411,6 +411,13 @@ class Context final {
   Context &operator=(const Context &other) = delete;
 
  private:
+  enum SwapStatus {
+    NEW_CONFIG_LOADED = 0,
+    SWAP_REQUESTED = 1,
+    SWAP_COMPLETED = 2,
+    SWAP_CANCELLED = 3
+  };
+
   MatchErrorCode get_mt_indirect(const std::string &table_name,
                                  MatchTableIndirect **table) const;
   MatchErrorCode get_mt_indirect_ws(const std::string &table_name,
@@ -468,6 +475,8 @@ class Context final {
   //! Return a copy of the error codes map (a bi-directional map between an
   //! error code's integral value and its name / description).
   ErrorCodeMap get_error_codes() const;
+
+  void send_swap_status_notification(SwapStatus status);
 
  private:  // data members
   cxt_id_t cxt_id{};

--- a/include/bm/bm_sim/learning.h
+++ b/include/bm/bm_sim/learning.h
@@ -49,6 +49,7 @@ class LearnEngineIface {
   enum LearnErrorCode {
     SUCCESS = 0,
     INVALID_LIST_ID,
+    INVALID_LIST_NAME,
     ERROR
   };
 
@@ -67,7 +68,8 @@ class LearnEngineIface {
 
   virtual ~LearnEngineIface() { }
 
-  virtual void list_create(list_id_t list_id, size_t max_samples = 1,
+  virtual void list_create(list_id_t list_id, const std::string &list_name,
+                           size_t max_samples = 1,
                            unsigned int timeout_ms = 1000) = 0;
 
   virtual void list_set_learn_writer(
@@ -89,6 +91,12 @@ class LearnEngineIface {
 
   virtual LearnErrorCode list_set_max_samples(list_id_t list_id,
                                               size_t max_samples) = 0;
+
+  virtual LearnErrorCode list_get_name_from_id(
+      list_id_t list_id, std::string *list_name) const = 0;
+
+  virtual LearnErrorCode list_get_id_from_name(
+      const std::string &list_name, list_id_t *list_id) const = 0;
 
   //! Performs learning on the packet. Needs to be called by the target after a
   //! learning-enabled pipeline has been applied on the packet. See the simple

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -24,8 +24,9 @@
 #define BM_BM_SIM_OPTIONS_PARSE_H_
 
 #include <iosfwd>
-#include <string>
 #include <map>
+#include <string>
+#include <unordered_set>
 
 #include "device_id.h"
 #include "logger.h"
@@ -64,6 +65,8 @@ class OptionsParser {
 
   void parse(int argc, char *argv[], TargetParserIface *tp);
 
+  bool option_was_provided(const std::string &option) const;
+
   std::string config_file_path{};
   bool no_p4{false};
   InterfaceList ifaces{};
@@ -90,6 +93,7 @@ class OptionsParser {
   std::string debugger_addr{};
   std::string state_file_path{};
   size_t dump_packet_data{0};
+  std::unordered_set<std::string> options_provided{};
 };
 
 }  // namespace bm

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -2061,9 +2061,10 @@ P4Objects::init_learn_lists(const Json::Value &cfg_root) {
   for (const auto &cfg_learn_list : cfg_learn_lists) {
     LearnEngineIface::list_id_t list_id = cfg_learn_list["id"].asInt();
     dup_id_checker.add(list_id);
-    learn_engine->list_create(list_id, 16);  // 16 is max nb of samples
-    learn_engine->list_set_learn_writer(list_id, notifications_transport);
     auto list_name = cfg_learn_list["name"].asString();
+    // 16 is max nb of samples
+    learn_engine->list_create(list_id, list_name, 16);
+    learn_engine->list_set_learn_writer(list_id, notifications_transport);
     // does not compile with g++4.8
     // learn_lists.emplace(
     //     list_name, new P4Objects::LearnList(list_name, list_id));

--- a/src/bm_sim/learning.cpp
+++ b/src/bm_sim/learning.cpp
@@ -53,7 +53,8 @@ class LearnEngine final : public LearnEngineIface {
 
   explicit LearnEngine(device_id_t device_id = 0, cxt_id_t cxt_id = 0);
 
-  void list_create(list_id_t list_id, size_t max_samples = 1,
+  void list_create(list_id_t list_id, const std::string &list_name,
+                   size_t max_samples = 1,
                    unsigned int timeout_ms = 1000) override;
 
   void list_set_learn_writer(
@@ -73,6 +74,12 @@ class LearnEngine final : public LearnEngineIface {
 
   LearnErrorCode list_set_max_samples(list_id_t list_id,
                                       size_t max_samples) override;
+
+  LearnErrorCode list_get_name_from_id(
+      list_id_t list_id, std::string *list_name) const override;
+
+  LearnErrorCode list_get_id_from_name(
+      const std::string &list_name, list_id_t *list_id) const override;
 
   //! Performs learning on the packet. Needs to be called by the target after a
   //! learning-enabled pipeline has been applied on the packet. See the simple
@@ -141,7 +148,8 @@ class LearnEngine final : public LearnEngineIface {
     enum class LearnMode {NONE, WRITER, CB};
 
    public:
-    LearnList(list_id_t list_id, device_id_t device_id, cxt_id_t cxt_id,
+    LearnList(list_id_t list_id, const std::string &list_name,
+              device_id_t device_id, cxt_id_t cxt_id,
               size_t max_samples, unsigned int timeout);
 
     void init();
@@ -162,6 +170,8 @@ class LearnEngine final : public LearnEngineIface {
 
     void ack(buffer_id_t buffer_id, const std::vector<int> &sample_ids);
     void ack_buffer(buffer_id_t buffer_id);
+
+    std::string get_name() const;
 
     void reset_state();
 
@@ -184,6 +194,7 @@ class LearnEngine final : public LearnEngineIface {
     mutable MutexType mutex{};
 
     list_id_t list_id;
+    std::string list_name;
 
     device_id_t device_id;
     cxt_id_t cxt_id;
@@ -222,6 +233,7 @@ class LearnEngine final : public LearnEngineIface {
 
  private:
   LearnList *get_learn_list(list_id_t list_id);
+  const LearnList *get_learn_list(list_id_t list_id) const;
 
   device_id_t device_id{};
   cxt_id_t cxt_id{};
@@ -269,11 +281,15 @@ LearnEngine::LearnSampleBuilder::operator()(const PHV &phv,
   }
 }
 
-LearnEngine::LearnList::LearnList(list_id_t list_id, device_id_t device_id,
-                                  cxt_id_t cxt_id, size_t max_samples,
+LearnEngine::LearnList::LearnList(list_id_t list_id,
+                                  const std::string &list_name,
+                                  device_id_t device_id,
+                                  cxt_id_t cxt_id,
+                                  size_t max_samples,
                                   unsigned int timeout)
-    : list_id(list_id), device_id(device_id), cxt_id(cxt_id),
-      max_samples(max_samples), timeout(timeout), with_timeout(timeout > 0) { }
+    : list_id(list_id), list_name(list_name), device_id(device_id),
+      cxt_id(cxt_id), max_samples(max_samples), timeout(timeout),
+      with_timeout(timeout > 0) { }
 
 void
 LearnEngine::LearnList::init() {
@@ -510,6 +526,11 @@ LearnEngine::LearnList::ack_buffer(buffer_id_t buffer_id) {
   old_buffers.erase(it);
 }
 
+std::string
+LearnEngine::LearnList::get_name() const {
+  return list_name;
+}
+
 void
 LearnEngine::LearnList::reset_state() {
   LockType lock(mutex);
@@ -531,16 +552,24 @@ LearnEngine::get_learn_list(list_id_t list_id) {
   return it == learn_lists.end() ? nullptr : it->second.get();
 }
 
+const LearnEngine::LearnList *
+LearnEngine::get_learn_list(list_id_t list_id) const {
+  auto it = learn_lists.find(list_id);
+  return it == learn_lists.end() ? nullptr : it->second.get();
+}
+
 void
-LearnEngine::list_create(list_id_t list_id, size_t max_samples,
+LearnEngine::list_create(list_id_t list_id,
+                         const std::string &list_name,
+                         size_t max_samples,
                          unsigned int timeout_ms) {
   if (learn_lists.find(list_id) != learn_lists.end()) {
     BMLOG_ERROR("Trying to create learn list with id {} "
                 "but a list with the same id already exists", list_id);
         return;
   }
-  learn_lists[list_id] = std::unique_ptr<LearnList>(
-      new LearnList(list_id, device_id, cxt_id, max_samples, timeout_ms));
+  learn_lists[list_id] = std::unique_ptr<LearnList>(new LearnList(
+      list_id, list_name, device_id, cxt_id, max_samples, timeout_ms));
 }
 
 void
@@ -616,6 +645,26 @@ LearnEngine::list_set_max_samples(list_id_t list_id, size_t max_samples) {
   if (!list) return INVALID_LIST_ID;
   list->set_max_samples(max_samples);
   return SUCCESS;
+}
+
+LearnEngine::LearnErrorCode
+LearnEngine::list_get_name_from_id(
+    list_id_t list_id, std::string *list_name) const {
+  const LearnList *list = get_learn_list(list_id);
+  if (!list) return INVALID_LIST_ID;
+  *list_name = list->get_name();
+  return SUCCESS;
+}
+
+LearnEngine::LearnErrorCode
+LearnEngine::list_get_id_from_name(
+    const std::string &list_name, list_id_t *list_id) const {
+  for (const auto &p : learn_lists) {
+    if (p.second->get_name() != list_name) continue;
+    *list_id = p.first;
+    return SUCCESS;
+  }
+  return INVALID_LIST_NAME;
 }
 
 void

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -164,6 +164,8 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
   positional.add("input-config", 1);
   positional.add("to-pass-further", -1);
 
+  options_provided.clear();
+
   po::variables_map vm;
   auto parser = po::command_line_parser(argc, argv);
   parser.options(options).positional(positional);
@@ -187,6 +189,8 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
     }
     exit(1);
   }
+
+  for (const auto &p : vm) options_provided.insert(p.first);
 
   if (vm.count("help")) {
     outstream << "Usage: SWITCH_NAME [options] <path to JSON config file>\n";
@@ -400,6 +404,11 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
 void
 OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp) {
   parse(argc, argv, tp, std::cout);
+}
+
+bool
+OptionsParser::option_was_provided(const std::string &option) const {
+  return options_provided.find(option) != options_provided.end();
 }
 
 }  // namespace bm

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -36,7 +36,8 @@ $(common_source) main.cpp \
 test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp \
 test_counter.cpp test_meter.cpp \
 test_ternary.cpp \
-test_pre.cpp
+test_pre.cpp \
+test_digest.cpp
 if WITH_SYSREPO
 test_gtest_SOURCES += test_gnmi.cpp
 endif
@@ -57,4 +58,5 @@ counter.p4 counter.json counter.proto.txt \
 meter.p4 meter.json meter.proto.txt \
 ternary.p4 ternary.json ternary.proto.txt \
 multicast.p4 multicast.json multicast.proto.txt \
-clone.p4 clone.json clone.proto.txt
+clone.p4 clone.json clone.proto.txt \
+digest.p4 digest.json digest.proto.txt

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -105,6 +105,7 @@ grpc::Status
 SimpleSwitchGrpcBaseTest::Write(ClientContext *context,
                                 p4v1::WriteRequest &request,
                                 p4v1::WriteResponse *response) const {
+  request.set_device_id(device_id);
   set_election_id(request.mutable_election_id());
   return p4runtime_stub->Write(context, request, response);
 }

--- a/targets/simple_switch_grpc/tests/test_digest.cpp
+++ b/targets/simple_switch_grpc/tests/test_digest.cpp
@@ -1,0 +1,251 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <queue>
+#include <vector>
+
+#include "base_test.h"
+#include "utils.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+// TODO(antonin): use this class for PRE & gNMI tests rather than hack with
+// std::future.
+template <typename StreamType, typename MessageType>
+class StreamReceiver {
+ public:
+  using Clock = std::chrono::steady_clock;
+
+  explicit StreamReceiver(StreamType *stream)
+      : stream(stream) {
+    read_thread = std::thread(
+        &StreamReceiver<StreamType, MessageType>::receive, this);
+  }
+
+  ~StreamReceiver() {
+    read_thread.join();
+  }
+
+  void receive() {
+    MessageType msg;
+    while (stream->Read(&msg)) {
+      Lock lock(mutex);
+      messages.push(
+          std::unique_ptr<MessageType>(new MessageType(std::move(msg))));
+      cvar.notify_one();
+    }
+  }
+
+  template<typename Predicate, typename Rep, typename Period>
+  std::unique_ptr<MessageType> get(
+      Predicate predicate,
+      const std::chrono::duration<Rep, Period> &timeout) {
+    Lock lock(mutex);
+    if (cvar.wait_until(
+            lock, Clock::now() + timeout,
+            [this, predicate] {
+              return !messages.empty() && predicate(*messages.front()); })) {
+      auto msg = std::move(messages.front());
+      messages.pop();
+      return msg;
+    }
+    return nullptr;
+  }
+
+ private:
+  using Lock = std::unique_lock<std::mutex>;
+
+  StreamType *stream;
+  mutable std::mutex mutex{};
+  mutable std::condition_variable cvar{};
+  std::thread read_thread;
+  std::queue<std::unique_ptr<MessageType> > messages;
+};
+
+constexpr char digest_json[] = TESTDATADIR "/digest.json";
+constexpr char digest_proto[] = TESTDATADIR "/digest.proto.txt";
+
+class SimpleSwitchGrpcTest_Digest : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_Digest()
+      : SimpleSwitchGrpcBaseTest(digest_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(digest_json);
+    digest_id = get_digest_id(p4info, "L2_digest");
+    stream_receiver.reset(
+        new StreamReceiver<ReaderWriter, p4v1::StreamMessageResponse>(
+            stream.get()));
+  }
+
+  void TearDown() override {
+    stream->WritesDone();
+    auto status = stream->Finish();
+    EXPECT_TRUE(status.ok());
+  }
+
+  template<typename Rep1, typename Period1, typename Rep2, typename Period2>
+  grpc::Status config_digest(
+      int32_t max_list_size,
+      const std::chrono::duration<Rep1, Period1> &max_timeout,
+      const std::chrono::duration<Rep2, Period2> &ack_timeout,
+      p4v1::Update::Type type = p4v1::Update::INSERT) {
+    auto max_timeout_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        max_timeout).count();
+    auto ack_timeout_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        ack_timeout).count();
+    p4v1::WriteRequest request;
+    auto *update = request.add_updates();
+    update->set_type(type);
+    auto *digest_entry = update->mutable_entity()->mutable_digest_entry();
+    digest_entry->set_digest_id(digest_id);
+    auto *config = digest_entry->mutable_config();
+    config->set_max_list_size(max_list_size);
+    config->set_max_timeout_ns(max_timeout_ns);
+    config->set_ack_timeout_ns(ack_timeout_ns);
+    ClientContext context;
+    p4v1::WriteResponse rep;
+    return Write(&context, request, &rep);
+  }
+
+  bool ack_digest(const p4v1::DigestList &digest) {
+    p4v1::StreamMessageRequest request;
+    auto *ack = request.mutable_digest_ack();
+    ack->set_digest_id(digest.digest_id());
+    ack->set_list_id(digest.list_id());
+    return stream->Write(request);
+  }
+
+  grpc::Status send_and_receive(
+      const std::string &smac,
+      const std::string &ethertype = "\xab\xab",
+      const std::string &dmac = std::string(6, '\x01'),
+      int ig_port = 1) {
+    static uint64_t id = 1;
+    std::string pkt = dmac + smac + ethertype;
+    p4::bm::PacketStreamRequest request;
+    request.set_id(id++);
+    request.set_device_id(device_id);
+    request.set_port(ig_port);
+    request.set_packet(pkt);
+    p4::bm::PacketStreamResponse response;
+    ClientContext context;
+    auto stream = dataplane_stub->PacketStream(&context);
+    stream->Write(request);
+    stream->Read(&response);
+    stream->WritesDone();
+    return stream->Finish();
+  }
+
+  template<typename Rep, typename Period>
+  std::unique_ptr<p4v1::DigestList> receive_digest(
+      const std::chrono::duration<Rep, Period> &timeout) {
+    auto msg = stream_receiver->get(
+        [](const p4v1::StreamMessageResponse &response) {
+          return (response.update_case() ==
+                  p4v1::StreamMessageResponse::kDigest); },
+        timeout);
+    if (msg == nullptr) return nullptr;
+    return std::unique_ptr<p4v1::DigestList>(
+        new p4v1::DigestList(std::move(msg->digest())));
+  }
+
+  std::unique_ptr<p4v1::DigestList> receive_digest() {
+    return receive_digest(defaultTimeout);
+  }
+
+  static constexpr std::chrono::milliseconds timeout0ms{0};
+  static constexpr std::chrono::milliseconds timeout1000ms{1000};
+  static constexpr std::chrono::milliseconds defaultTimeout{1000};
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+  int digest_id;
+  std::unique_ptr<StreamReceiver<ReaderWriter, p4v1::StreamMessageResponse> >
+  stream_receiver{nullptr};
+};
+
+/* static */ constexpr std::chrono::milliseconds
+SimpleSwitchGrpcTest_Digest::timeout0ms;
+/* static */ constexpr std::chrono::milliseconds
+SimpleSwitchGrpcTest_Digest::timeout1000ms;
+/* static */ constexpr std::chrono::milliseconds
+SimpleSwitchGrpcTest_Digest::defaultTimeout;
+
+TEST_F(SimpleSwitchGrpcTest_Digest, OneSample) {
+  ASSERT_TRUE(config_digest(1, timeout0ms, timeout0ms).ok());
+  const std::string smac("\x11\x22\x33\x44\x55\x66");
+  EXPECT_TRUE(send_and_receive(smac).ok());
+  auto digest = receive_digest();
+  EXPECT_TRUE(digest != nullptr);
+}
+
+TEST_F(SimpleSwitchGrpcTest_Digest, Ack) {
+  ASSERT_TRUE(config_digest(1, timeout0ms, timeout1000ms).ok());
+  const std::string smac("\x11\x22\x33\x44\x55\x66");
+  ASSERT_TRUE(send_and_receive(smac).ok());
+  auto digest = receive_digest();
+  ASSERT_TRUE(digest != nullptr);
+  ASSERT_TRUE(send_and_receive(smac).ok());
+  EXPECT_TRUE(receive_digest(std::chrono::milliseconds(200)) == nullptr);
+  ASSERT_TRUE(ack_digest(*digest));
+  ASSERT_TRUE(send_and_receive(smac).ok());
+  EXPECT_TRUE(receive_digest() != nullptr);
+}
+
+TEST_F(SimpleSwitchGrpcTest_Digest, DeleteDigest) {
+  const std::string smac("\x11\x22\x33\x44\x55\x66");
+  ASSERT_TRUE(config_digest(1, timeout0ms, timeout0ms).ok());  // no caching
+  EXPECT_TRUE(send_and_receive(smac).ok());
+  EXPECT_TRUE(receive_digest() != nullptr);
+  ASSERT_TRUE(
+      config_digest(1, timeout0ms, timeout0ms, p4v1::Update::DELETE).ok());
+  EXPECT_TRUE(send_and_receive(smac).ok());
+  EXPECT_TRUE(receive_digest(std::chrono::milliseconds(200)) == nullptr);
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/testdata/digest.json
+++ b/targets/simple_switch_grpc/tests/testdata/digest.json
@@ -1,0 +1,402 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 48, false],
+        ["tmp_0", 9, false],
+        ["_padding_0", 7, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 32, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["recirculate_flag", 32, false],
+        ["parser_error", 32, false],
+        ["_padding", 5, false]
+      ]
+    },
+    {
+      "name" : "Ethernet_t",
+      "id" : 2,
+      "fields" : [
+        ["dmac", 48, false],
+        ["smac", 48, false],
+        ["ethertype", 16, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "ethernet",
+      "id" : 2,
+      "header_type" : "Ethernet_t",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "ethernet"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "digest.p4",
+        "line" : 49,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : ["ethernet"]
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [
+    {
+      "id" : 1,
+      "name" : "L2_digest",
+      "source_info" : {
+        "filename" : "digest.p4",
+        "line" : 62,
+        "column" : 29,
+        "source_fragment" : "{h.ethernet.smac, sm.ingress_port}"
+      },
+      "elements" : [
+        {
+          "type" : "field",
+          "value" : ["scalars", "tmp"]
+        },
+        {
+          "type" : "field",
+          "value" : ["scalars", "tmp_0"]
+        }
+      ]
+    }
+  ],
+  "actions" : [
+    {
+      "name" : "NoAction",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "ingress.send_digest",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["scalars", "tmp"]
+            },
+            {
+              "type" : "field",
+              "value" : ["ethernet", "smac"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "digest.p4",
+            "line" : 62,
+            "column" : 30,
+            "source_fragment" : "h.ethernet.smac"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["scalars", "tmp_0"]
+            },
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "ingress_port"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "digest.p4",
+            "line" : 62,
+            "column" : 47,
+            "source_fragment" : "sm.ingress_port"
+          }
+        },
+        {
+          "op" : "generate_digest",
+          "parameters" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x00000001"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "digest.p4",
+            "line" : 62,
+            "column" : 8,
+            "source_fragment" : "digest<L2_digest>(1, {h.ethernet.smac, sm.ingress_port})"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "ingress_port"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "digest.p4",
+            "line" : 70,
+            "column" : 26,
+            "source_fragment" : "sm.egress_spec = sm.ingress_port"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "digest.p4",
+        "line" : 60,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "ingress.smac",
+      "tables" : [
+        {
+          "name" : "ingress.smac",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "digest.p4",
+            "line" : 64,
+            "column" : 10,
+            "source_fragment" : "smac"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "name" : "h.ethernet.smac",
+              "target" : ["ethernet", "smac"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 4096,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1, 0],
+          "actions" : ["ingress.send_digest", "NoAction"],
+          "base_default_next" : "tbl_act",
+          "next_tables" : {
+            "ingress.send_digest" : "tbl_act",
+            "NoAction" : "tbl_act"
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : false,
+            "action_data" : [],
+            "action_entry_const" : false
+          }
+        },
+        {
+          "name" : "tbl_act",
+          "id" : 1,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["act"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "act" : null
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "digest.p4",
+        "line" : 45,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.recirculate_flag",
+      ["standard_metadata", "recirculate_flag"]
+    ]
+  ],
+  "program" : "./digest.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/targets/simple_switch_grpc/tests/testdata/digest.p4
+++ b/targets/simple_switch_grpc/tests/testdata/digest.p4
@@ -1,0 +1,73 @@
+/* Copyright 2018-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> MacAddr_t;
+typedef bit<9> PortId_t;
+
+header Ethernet_t {
+    MacAddr_t dmac;
+    MacAddr_t smac;
+    bit<16> ethertype;
+}
+
+struct Headers {
+    Ethernet_t ethernet;
+}
+
+struct Meta { }
+
+parser p(packet_in b, out Headers h,
+         inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.ethernet);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {}
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h.ethernet);
+    }
+}
+
+struct L2_digest {
+    MacAddr_t smac;
+    PortId_t ig_port;
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action send_digest() {
+        digest<L2_digest>(1, {h.ethernet.smac, sm.ingress_port});
+    }
+    table smac {
+        key = { h.ethernet.smac : exact; }
+        actions = { send_digest; NoAction; }
+        default_action = send_digest();
+        size = 4096;
+    }
+    apply { smac.apply(); sm.egress_spec = sm.ingress_port; }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/targets/simple_switch_grpc/tests/testdata/digest.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/digest.proto.txt
@@ -1,0 +1,73 @@
+tables {
+  preamble {
+    id: 33610141
+    name: "ingress.smac"
+    alias: "smac"
+  }
+  match_fields {
+    id: 1
+    name: "h.ethernet.smac"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16783753
+  }
+  action_refs {
+    id: 16800567
+  }
+  size: 4096
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16783753
+    name: "ingress.send_digest"
+    alias: "send_digest"
+  }
+}
+digests {
+  preamble {
+    id: 385912120
+    name: "L2_digest"
+    alias: "L2_digest"
+  }
+  type_spec {
+    struct {
+      name: "L2_digest"
+    }
+  }
+}
+type_info {
+  structs {
+    key: "L2_digest"
+    value {
+      members {
+        name: "smac"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 48
+            }
+          }
+        }
+      }
+      members {
+        name: "ig_port"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 9
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/targets/simple_switch_grpc/tests/utils.cpp
+++ b/targets/simple_switch_grpc/tests/utils.cpp
@@ -74,6 +74,15 @@ int get_param_id(const p4configv1::P4Info &p4info,
   return -1;
 }
 
+int get_digest_id(const p4::config::v1::P4Info &p4info,
+                  const std::string &digest_name) {
+  for (const auto &digest : p4info.digests()) {
+    const auto &pre = digest.preamble();
+    if (pre.name() == digest_name) return pre.id();
+  }
+  return 0;
+}
+
 p4configv1::P4Info parse_p4info(const char *path) {
   p4configv1::P4Info p4info;
   std::ifstream istream(path);

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -41,6 +41,9 @@ int get_mf_id(const p4::config::v1::P4Info &p4info,
 int get_param_id(const p4::config::v1::P4Info &p4info,
                  const std::string &a_name, const std::string &param_name);
 
+int get_digest_id(const p4::config::v1::P4Info &p4info,
+                  const std::string &digest_name);
+
 p4::config::v1::P4Info parse_p4info(const char *path);
 
 }  // namespace testing

--- a/tests/test_learning.cpp
+++ b/tests/test_learning.cpp
@@ -94,7 +94,7 @@ class LearningTest : public ::testing::Test {
 
   void learn_on_test1_f16(LearnEngineIface::list_id_t list_id,
                           size_t max_samples, unsigned timeout_ms) {
-    learn_engine->list_create(list_id, max_samples, timeout_ms);
+    learn_engine->list_create(list_id, "test_digest", max_samples, timeout_ms);
     learn_engine->list_set_learn_writer(list_id, learn_writer);
     learn_engine->list_push_back_field(list_id, testHeader1, 0);  // test1.f16
     learn_engine->list_init(list_id);
@@ -209,7 +209,7 @@ TEST_F(LearningTest, OneSampleConstData) {
   char buffer[sizeof(LearnEngineIface::msg_hdr_t) + 2];
   std::shared_ptr<MemoryAccessor> learn_writer(new
   MemoryAccessor(sizeof(buffer)));
-  learn_engine->list_create(list_id, max_samples, timeout_ms);
+  learn_engine->list_create(list_id, "test_digest", max_samples, timeout_ms);
   learn_engine->list_set_learn_writer(list_id, learn_writer);
   learn_engine->list_push_back_constant(list_id, "0xaba");  // 2 bytes
   learn_engine->list_init(list_id);
@@ -526,7 +526,7 @@ TEST_F(LearningTest, MaxSamplesChangeBadList) {
 TEST_F(LearningTest, OneSampleCbMode) {
   LearnEngineIface::list_id_t list_id = 1;
   size_t max_samples = 1; unsigned timeout_ms = 100;
-  learn_engine->list_create(list_id, max_samples, timeout_ms);
+  learn_engine->list_create(list_id, "test_digest", max_samples, timeout_ms);
   learn_engine->list_set_learn_cb(list_id, LearningTest::learn_cb, this);
   learn_engine->list_push_back_field(list_id, testHeader1, 0);  // test1.f16
   learn_engine->list_init(list_id);

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -181,7 +181,8 @@ exception InvalidParseVSetOperation {
 
 enum LearnOperationErrorCode {
   INVALID_LIST_ID = 1,
-  ERROR = 2
+  INVALID_LIST_NAME = 2,
+  ERROR = 3
 }
 
 exception InvalidLearnOperation {


### PR DESCRIPTION
For the simple_switch_grpc target. This is done by registering a custom
TransportIface implementation with the Switch base class, to capture all
the notifications which are usually broadcast on a Nanomsg PUBSUB
socket.

The P4Runtime implementation in p4lang/PI requires that no digest
notification be sent while a forwarding pipeline config swap is
ongoing. To ensure that we respect this assumption, we now generate a
new kind of notifications for "swap" events. These notifications are
captured by our custom TransportIface implementation for
simple_switch_grpc, to ensure that all digest notifications are ignored
during the swap.