### PR TITLE
Do no log message about Thrift port unconditionally

### DIFF
--- a/src/bm_runtime/server.cpp
+++ b/src/bm_runtime/server.cpp
@@ -42,6 +42,7 @@ namespace thrift_provider = apache::thrift;
 #include <mutex>
 #include <thread>
 
+#include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/simple_pre.h>
 #include <bm/bm_sim/simple_pre_lag.h>
@@ -145,11 +146,12 @@ int serve(int port) {
 
 int start_server(bm::SwitchWContexts *sw, int port) {
   switch_ = sw;
+  bm::Logger::get()->info("Starting Thrift server on port {}", port);
   std::thread server_thread(serve, port);
-  printf("Thrift server was started\n");
   std::unique_lock<std::mutex> lock(m_ready);
   while(!ready) cv_ready.wait(lock);
   server_thread.detach();
+  bm::Logger::get()->info("Thrift server was started");
   return 0;
 }
 

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -382,9 +382,6 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
   if (vm.count("thrift-port")) {
     thrift_port = vm["thrift-port"].as<int>();
   } else {
-    outstream << "Thrift port was not specified, will use "
-              << default_thrift_port
-              << std::endl;
     thrift_port = default_thrift_port;
   }
 #endif

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -576,6 +576,13 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
   using ::sswitch_runtime::SimpleSwitchProcessor;
   bm_runtime::add_service<SimpleSwitchIf, SimpleSwitchProcessor>(
           "simple_switch", sswitch_runtime::get_handler(simple_switch.get()));
+#else
+  if (parser.option_was_provided("thrift-port")) {
+    bm::Logger::get()->warn(
+        "You used the '--thrift-port' command-line option, but this target was "
+        "compiled without Thrift support. You can enable Thrift support (not "
+        "recommended) by providing '--with-thrift' to configure.");
+  }
 #endif  // WITH_THRIFT
 
   simple_switch->start_and_return();


### PR DESCRIPTION
The message "Thrift port was not specified, will use 9090" was output
to stdout even when using simple_switch_grpc, which doesn't start a
Thrift server by default. We now only print a message (using the bmv2
logger) if the server is actually started by the target.

Fixes #678