### PR TITLE
Add support for P4Runtime idle timeout to simple_switch_grpc

### DIFF
--- a/PI/bm/PI/pi.h
+++ b/PI/bm/PI/pi.h
@@ -21,6 +21,8 @@
 #ifndef BM_PI_PI_H_
 #define BM_PI_PI_H_
 
+#include <PI/pi.h>
+
 #include <cstdint>
 
 namespace bm {
@@ -30,6 +32,9 @@ class SwitchWContexts;  // forward declaration
 namespace pi {
 
 void register_switch(bm::SwitchWContexts *sw, uint32_t cpu_port = 0);
+
+pi_status_t table_idle_timeout_notify(pi_dev_id_t dev_id, pi_p4_id_t table_id,
+                                      pi_entry_handle_t entry_handle);
 
 }  // namespace pi
 

--- a/PI/src/common.cpp
+++ b/PI/src/common.cpp
@@ -24,28 +24,33 @@
 
 namespace pibmv2 {
 
-Buffer::Buffer() {
-  data.reserve(2048);
+Buffer::Buffer(size_t capacity) {
+  data_.reserve(capacity);
 }
 
 char *
 Buffer::extend(size_t s) {
   if (s == 0) return nullptr;
-  const auto size = data.size();
-  data.resize(size + s);
-  return &data[size];
+  const auto size = data_.size();
+  data_.resize(size + s);
+  return &data_[size];
 }
 
 char *
 Buffer::copy() const {
-  char *res = new char[data.size()];
-  std::copy(data.begin(), data.end(), res);
+  char *res = new char[data_.size()];
+  std::copy(data_.begin(), data_.end(), res);
   return res;
+}
+
+char *
+Buffer::data() {
+  return data_.data();
 }
 
 size_t
 Buffer::size() const {
-  return data.size();
+  return data_.size();
 }
 
 }  // namespace pibmv2

--- a/PI/src/common.h
+++ b/PI/src/common.h
@@ -71,16 +71,18 @@ struct IndirectHMgr {
 
 class Buffer {
  public:
-  Buffer();
+  explicit Buffer(size_t capacity = 2048);
 
   char *extend(size_t s);
 
   char *copy() const;
 
+  char *data();  // returns non-owning pointer
+
   size_t size() const;
 
  private:
-  std::vector<char> data{};
+  std::vector<char> data_{};
 };
 
 }  // namespace pibmv2

--- a/include/bm/bm_sim/ageing.h
+++ b/include/bm/bm_sim/ageing.h
@@ -22,8 +22,10 @@
 #define BM_BM_SIM_AGEING_H_
 
 #include <memory>
+#include <string>
 
 #include "device_id.h"
+#include "named_p4object.h"
 #include "transport.h"
 
 namespace bm {
@@ -48,7 +50,16 @@ class AgeingMonitorIface {
 
   virtual void set_sweep_interval(unsigned int ms) = 0;
 
+  virtual unsigned int get_sweep_interval() = 0;
+
   virtual void reset_state() = 0;
+
+  //! Returns an empty string if table doesn't support idle timeout; this is
+  //! useful to decode notifications.
+  //! Not thread-safe but can be called safely after the map has been populated
+  //! by P4Objects::init_objects, including as idle notifications are being
+  //! generated.
+  virtual std::string get_table_name_from_id(p4object_id_t id) const = 0;
 
   static std::unique_ptr<AgeingMonitorIface> make(
       device_id_t device_id, cxt_id_t cxt_id,

--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -56,6 +56,7 @@ class MatchTableAbstract : public NamedP4Object {
     std::vector<MatchKeyParam> match_key;
     uint32_t timeout_ms{0};
     uint32_t time_since_hit_ms{0};
+    int priority;
   };
 
   class handle_iterator
@@ -286,7 +287,6 @@ class MatchTable : public MatchTableAbstract {
   struct Entry : public EntryCommon {
     const ActionFn *action_fn;
     ActionData action_data;
-    int priority;
   };
 
  public:
@@ -381,7 +381,6 @@ class MatchTableIndirect : public MatchTableAbstract {
 
   struct Entry : public EntryCommon {
     mbr_hdl_t mbr;
-    int priority;
   };
 
  public:
@@ -476,7 +475,6 @@ class MatchTableIndirectWS : public MatchTableIndirect {
   struct Entry : public EntryCommon {
     mbr_hdl_t mbr;
     grp_hdl_t grp;
-    int priority;
   };
 
  public:

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -37,7 +37,8 @@ test_basic.cpp test_grpc_dp.cpp test_packet_io.cpp \
 test_counter.cpp test_meter.cpp \
 test_ternary.cpp \
 test_pre.cpp \
-test_digest.cpp
+test_digest.cpp \
+test_idle_timeout.cpp
 if WITH_SYSREPO
 test_gtest_SOURCES += test_gnmi.cpp
 endif

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -102,6 +102,47 @@ SimpleSwitchGrpcBaseTest::set_election_id(p4v1::Uint128 *election_id) const {
 }
 
 grpc::Status
+SimpleSwitchGrpcBaseTest::write(const p4v1::Entity &entity,
+                                p4v1::Update::Type type) const {
+  p4v1::WriteRequest request;
+  request.set_device_id(device_id);
+  auto update = request.add_updates();
+  update->set_type(type);
+  update->mutable_entity()->CopyFrom(entity);
+  ClientContext context;
+  p4v1::WriteResponse rep;
+  return Write(&context, request, &rep);
+}
+
+grpc::Status
+SimpleSwitchGrpcBaseTest::insert(const p4v1::Entity &entity) const {
+  return write(entity, p4v1::Update::INSERT);
+}
+
+grpc::Status
+SimpleSwitchGrpcBaseTest::modify(const p4v1::Entity &entity) const {
+  return write(entity, p4v1::Update::MODIFY);
+}
+
+grpc::Status
+SimpleSwitchGrpcBaseTest::remove(const p4v1::Entity &entity) const {
+  return write(entity, p4v1::Update::DELETE);
+}
+
+grpc::Status
+SimpleSwitchGrpcBaseTest::read(const p4v1::Entity &entity,
+                               p4v1::ReadResponse *rep) const {
+  p4v1::ReadRequest request;
+  request.set_device_id(device_id);
+  request.add_entities()->CopyFrom(entity);
+  ClientContext context;
+  std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
+      p4runtime_stub->Read(&context, request));
+  reader->Read(rep);
+  return reader->Finish();
+}
+
+grpc::Status
 SimpleSwitchGrpcBaseTest::Write(ClientContext *context,
                                 p4v1::WriteRequest &request,
                                 p4v1::WriteResponse *response) const {

--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -61,6 +61,15 @@ class SimpleSwitchGrpcBaseTest : public ::testing::Test {
 
   void set_election_id(p4::v1::Uint128 *election_id) const;
 
+  grpc::Status write(const p4::v1::Entity &entity,
+                     p4::v1::Update::Type type) const;
+  grpc::Status insert(const p4::v1::Entity &entity) const;
+  grpc::Status modify(const p4::v1::Entity &entity) const;
+  grpc::Status remove(const p4::v1::Entity &entity) const;
+
+  grpc::Status read(const p4::v1::Entity &entity,
+                    p4::v1::ReadResponse *rep) const;
+
   // calls p4runtime_stub->Write, with the appropriate election_id
   grpc::Status Write(ClientContext *context,
                      p4::v1::WriteRequest &request,

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -51,7 +51,7 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
     argv.push_back("45459");
 #endif  // WITH_THRIFT
     // you can uncomment this when debugging
-    // argv.push_back("--log-console");
+    argv.push_back("--log-console");
     argv.push_back(start_json);
     auto argc = static_cast<int>(argv.size());
     parser.parse(argc, const_cast<char **>(argv.data()), nullptr);

--- a/targets/simple_switch_grpc/tests/test_idle_timeout.cpp
+++ b/targets/simple_switch_grpc/tests/test_idle_timeout.cpp
@@ -1,0 +1,235 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <google/protobuf/util/message_differencer.h>
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "base_test.h"
+#include "utils.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+constexpr char digest_json[] = TESTDATADIR "/digest.json";
+constexpr char digest_proto[] = TESTDATADIR "/digest.proto.txt";
+
+class SimpleSwitchGrpcTest_IdleTimeout : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_IdleTimeout()
+      : SimpleSwitchGrpcBaseTest(digest_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(digest_json);
+    table_id = get_table_id(p4info, "ingress.smac");
+    stream_receiver.reset(
+        new StreamReceiver<ReaderWriter, p4v1::StreamMessageResponse>(
+            stream.get()));
+    {  // disable digest generation by setting the default action to NoAction
+      p4v1::WriteRequest req;
+      auto *update = req.add_updates();
+      update->set_type(p4v1::Update::MODIFY);
+      auto *entry = update->mutable_entity()->mutable_table_entry();
+      entry->set_table_id(table_id);
+      entry->set_is_default_action(true);
+      auto *action = entry->mutable_action()->mutable_action();
+      action->set_action_id(get_action_id(p4info, "NoAction"));
+      ClientContext context;
+      p4v1::WriteResponse rep;
+      EXPECT_TRUE(Write(&context, req, &rep).ok());
+    }
+  }
+
+  void TearDown() override {
+    stream->WritesDone();
+    auto status = stream->Finish();
+    EXPECT_TRUE(status.ok());
+  }
+
+  template<typename Rep, typename Period>
+  p4v1::Entity make_entry(
+      const std::string &smac,
+      const std::chrono::duration<Rep, Period> &idle_timeout = 0) const {
+    p4v1::Entity entity;
+    auto table_entry = entity.mutable_table_entry();
+    table_entry->set_table_id(table_id);
+    auto match = table_entry->add_match();
+    match->set_field_id(get_mf_id(p4info, "ingress.smac", "h.ethernet.smac"));
+    match->mutable_exact()->set_value(smac);
+    auto *action = table_entry->mutable_action()->mutable_action();
+    action->set_action_id(get_action_id(p4info, "NoAction"));
+    table_entry->set_idle_timeout_ns(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            idle_timeout).count());
+    return entity;
+  }
+
+  grpc::Status send_and_receive(
+      const std::string &smac,
+      const std::string &ethertype = "\xab\xab",
+      const std::string &dmac = std::string(6, '\x01'),
+      int ig_port = 1) {
+    static uint64_t id = 1;
+    std::string pkt = dmac + smac + ethertype;
+    p4::bm::PacketStreamRequest request;
+    request.set_id(id++);
+    request.set_device_id(device_id);
+    request.set_port(ig_port);
+    request.set_packet(pkt);
+    p4::bm::PacketStreamResponse response;
+    ClientContext context;
+    auto stream = dataplane_stub->PacketStream(&context);
+    stream->Write(request);
+    stream->Read(&response);
+    stream->WritesDone();
+    return stream->Finish();
+  }
+
+  template<typename Rep, typename Period>
+  std::unique_ptr<p4v1::IdleTimeoutNotification> receive_notification(
+      const std::chrono::duration<Rep, Period> &timeout) {
+    auto msg = stream_receiver->get(
+        [](const p4v1::StreamMessageResponse &response) {
+          return (response.update_case() ==
+                  p4v1::StreamMessageResponse::kIdleTimeoutNotification); },
+        timeout);
+    if (msg == nullptr) return nullptr;
+    return std::unique_ptr<p4v1::IdleTimeoutNotification>(
+        new p4v1::IdleTimeoutNotification(
+            std::move(msg->idle_timeout_notification())));
+  }
+
+  std::unique_ptr<p4v1::IdleTimeoutNotification> receive_notification() {
+    return receive_notification(defaultTimeout);
+  }
+
+  static constexpr std::chrono::milliseconds defaultTimeout{1000};
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+  int table_id;
+  std::unique_ptr<StreamReceiver<ReaderWriter, p4v1::StreamMessageResponse> >
+  stream_receiver{nullptr};
+};
+
+/* static */ constexpr std::chrono::milliseconds
+SimpleSwitchGrpcTest_IdleTimeout::defaultTimeout;
+
+TEST_F(SimpleSwitchGrpcTest_IdleTimeout, EntryExpire) {
+  const std::string smac("\x11\x22\x33\x44\x55\x66");
+  const std::chrono::milliseconds idle_timeout{2000};
+  auto entry = make_entry(smac, idle_timeout);
+  EXPECT_TRUE(insert(entry).ok());
+  // By default table sweeping happens every second, so we could wait for as
+  // long as 3 seconds for the notification, even though the TTL value is set to
+  // 2 seconds.
+  auto notification = receive_notification(
+      idle_timeout + std::chrono::milliseconds(1500));
+  ASSERT_TRUE(notification != nullptr);
+  ASSERT_EQ(notification->table_entry_size(), 1);
+  entry.mutable_table_entry()->clear_action();
+  using google::protobuf::util::MessageDifferencer;
+  EXPECT_TRUE(MessageDifferencer::Equals(
+      notification->table_entry(0), entry.table_entry()));
+}
+
+TEST_F(SimpleSwitchGrpcTest_IdleTimeout, NotifyAgain) {
+  const std::string smac("\x11\x22\x33\x44\x55\x66");
+  const std::chrono::milliseconds idle_timeout{2000};
+  auto entry = make_entry(smac, idle_timeout);
+  EXPECT_TRUE(insert(entry).ok());
+  {
+    auto notification = receive_notification(
+        idle_timeout + std::chrono::milliseconds(1500));
+    ASSERT_TRUE(notification != nullptr);
+  }
+  // TODO(antonin)
+  // The current bmv2 implementation uses a sweeper thread to generate idle
+  // timeout notifications. It never generates a notification for the same entry
+  // in 2 successive sweeps, but if the entry has not been hit by the 3rd sweep,
+  // a duplicate notification will be sent. This does not match the P4Runtime
+  // specification, which states that the target must generate a notification
+  // after one more TTL (and not a fixed sweep interval), so we will have to fix
+  // this in the future.
+  {
+    auto notification = receive_notification(
+        idle_timeout + std::chrono::milliseconds(1500));
+    ASSERT_TRUE(notification != nullptr);
+  }
+}
+
+TEST_F(SimpleSwitchGrpcTest_IdleTimeout, ReadEntry) {
+  const std::string smac("\x11\x22\x33\x44\x55\x66");
+  const std::chrono::milliseconds idle_timeout{2000};
+  auto entry = make_entry(smac, idle_timeout);
+  EXPECT_TRUE(insert(entry).ok());
+  const auto &written_table_entry = entry.table_entry();
+
+  {
+    p4v1::ReadResponse rep;
+    EXPECT_TRUE(read(entry, &rep).ok());
+    ASSERT_EQ(rep.entities_size(), 1);
+    ASSERT_TRUE(rep.entities(0).has_table_entry());
+    const auto &read_table_entry = rep.entities(0).table_entry();
+    using google::protobuf::util::MessageDifferencer;
+    EXPECT_TRUE(MessageDifferencer::Equals(
+        read_table_entry, written_table_entry));
+  }
+
+  std::this_thread::sleep_for(idle_timeout / 2);
+
+  {
+    p4v1::ReadResponse rep;
+    entry.mutable_table_entry()->mutable_time_since_last_hit();
+    EXPECT_TRUE(read(entry, &rep).ok());
+    ASSERT_EQ(rep.entities_size(), 1);
+    ASSERT_TRUE(rep.entities(0).has_table_entry());
+    const auto &read_table_entry = rep.entities(0).table_entry();
+    EXPECT_GT(read_table_entry.time_since_last_hit().elapsed_ns(), 0);
+    EXPECT_LT(read_table_entry.time_since_last_hit().elapsed_ns(),
+              std::chrono::duration_cast<std::chrono::nanoseconds>(
+                  idle_timeout).count());
+  }
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/test_ternary.cpp
+++ b/targets/simple_switch_grpc/tests/test_ternary.cpp
@@ -82,27 +82,12 @@ class SimpleSwitchGrpcTest_Ternary : public SimpleSwitchGrpcBaseTest {
   }
 
   grpc::Status add_entry(const p4v1::Entity &entry) const {
-    p4v1::WriteRequest request;
-    request.set_device_id(device_id);
-    auto update = request.add_updates();
-    update->set_type(p4v1::Update_Type_INSERT);
-    update->mutable_entity()->CopyFrom(entry);
-    ClientContext context;
-    p4v1::WriteResponse rep;
-    return Write(&context, request, &rep);
+    return insert(entry);
   }
 
   grpc::Status read_entry(const p4v1::Entity &entry,
                           p4v1::ReadResponse *rep) const {
-    p4v1::ReadRequest request;
-    request.set_device_id(device_id);
-    auto *entity = request.add_entities();
-    entity->CopyFrom(entry);
-    ClientContext context;
-    std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
-        p4runtime_stub->Read(&context, request));
-    reader->Read(rep);
-    return reader->Finish();
+    return read(entry, rep);
   }
 
   grpc::Status send_and_receive(const std::string &pkt, int ig_port,

--- a/targets/simple_switch_grpc/tests/testdata/digest.json
+++ b/targets/simple_switch_grpc/tests/testdata/digest.json
@@ -246,7 +246,7 @@
           ],
           "source_info" : {
             "filename" : "digest.p4",
-            "line" : 70,
+            "line" : 71,
             "column" : 26,
             "source_fragment" : "sm.egress_spec = sm.ingress_port"
           }
@@ -287,7 +287,7 @@
           "type" : "simple",
           "max_size" : 4096,
           "with_counters" : false,
-          "support_timeout" : false,
+          "support_timeout" : true,
           "direct_meters" : null,
           "action_ids" : [1, 0],
           "actions" : ["ingress.send_digest", "NoAction"],
@@ -394,7 +394,7 @@
       ["standard_metadata", "recirculate_flag"]
     ]
   ],
-  "program" : "./digest.p4i",
+  "program" : "/tmp//digest.p4i",
   "__meta__" : {
     "version" : [2, 18],
     "compiler" : "https://github.com/p4lang/p4c"

--- a/targets/simple_switch_grpc/tests/testdata/digest.p4
+++ b/targets/simple_switch_grpc/tests/testdata/digest.p4
@@ -66,6 +66,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         actions = { send_digest; NoAction; }
         default_action = send_digest();
         size = 4096;
+        support_timeout = true;
     }
     apply { smac.apply(); sm.egress_spec = sm.ingress_port; }
 }

--- a/targets/simple_switch_grpc/tests/testdata/digest.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/digest.proto.txt
@@ -1,3 +1,6 @@
+pkg_info {
+  arch: "v1model"
+}
 tables {
   preamble {
     id: 33610141
@@ -17,6 +20,7 @@ tables {
     id: 16800567
   }
   size: 4096
+  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/tests/test_ageing.cpp
+++ b/tests/test_ageing.cpp
@@ -196,3 +196,10 @@ TEST_F(AgeingTest, NoDuplicate) {
   elapsed = duration_cast<milliseconds>(tp4 - tp3).count();
   ASSERT_GT(elapsed, (unsigned int) (sweep_int * 1.5));
 }
+
+TEST_F(AgeingTest, GetTableNameFromId) {
+  unsigned int sweep_int = 200u;
+  init_monitor(sweep_int);
+  EXPECT_EQ(ageing_monitor->get_table_name_from_id(0), "test_table");
+  EXPECT_EQ(ageing_monitor->get_table_name_from_id(1), "");
+}


### PR DESCRIPTION
This enables idle timeout support by implementing the new PI target
functions and calling pi_table_idle_timeout_notify appropriately when a
match entry expires.

A few things to take into consideration:
 * _pi_table_idle_timeout_config_set is currently not doing anything. In
   bmv2 the sweep interval is global and not per table. We could set the
   sweep interval to the minimum of all the values provided by
   _pi_table_idle_timeout_config_set, but that would require storing
   some state in the PI implementation, and that did not seem worth the
   trouble at this stage.
 * bmv2 generates batched notifications for idle timeout (one per table
   per sweep interval). It seems a bit of a shame that we do not support
   batching in PI, therefore generating more function calls than we
   actually need.
 * the P4Runtime specification states that after generating a
   notification, the TTL should be reset to its initial value and a new
   notification should be generated if the match entry expires
   again. Currently, this is not exactly what bmv2 is doing. The bmv2
   "retimer" is based on the sweep interval and is not per entry. The
   sweeper thread will not generate notifications for the same entry in
   2 successive sweeps (by default the sweeper thread executes every
   1s), but if the entry has still not been hit or removed by the 3rd
   sweep, a new notification will be sent. We should be able to change
   this behavior easily in the future.