### PR TITLE
Fix bashisms in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,18 +226,18 @@ AS_IF([test "x$enable_modules" != "xno"], [
       modules_enabled=yes
     ], [
       AC_MSG_RESULT(no)
-      AS_IF([test "x$enable_modules" == "xyes"], [
+      AS_IF([test "x$enable_modules" = "xyes"], [
         AC_MSG_ERROR([Cannot enable modules without dlopen])
       ])
     ])
   ],[
     AC_MSG_RESULT(no)
-    AS_IF([test "x$enable_modules" == "xyes"], [
+    AS_IF([test "x$enable_modules" = "xyes"], [
       AC_MSG_ERROR([Cannot enable modules without dlfcn.h])
     ])
   ])
 ])
-AM_CONDITIONAL([ENABLE_MODULES], [test "x$modules_enabled" == "xyes"])
+AM_CONDITIONAL([ENABLE_MODULES], [test "x$modules_enabled" = "xyes"])
 
 # C++ libraries are harder (http://nerdland.net/2009/07/detecting-c-libraries-with-autotools/),
 # so use headers to check


### PR DESCRIPTION
POSIX does not mandate support for the `==` syntax for the equality check in `test`. Generating `configure` (which has a `#!/bin/sh` shebang) with lines like `test foo == bar` breaks in all environments where `test` does not support the `==` syntax (e.g. the version provided by dash).

This leads to `configure` output like this:

    ./configure: 18025: test: xyes: unexpected operator