### PR TITLE
Store copy of user callback in PortMonitor

### DIFF
--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -106,8 +106,7 @@ class DevMgrIface : public PacketDispatcherIface {
 
   bool port_is_up(port_t port_num) const;
 
-  ReturnCode register_status_cb(const PortStatus &type,
-                                const PortStatusCb &port_cb);
+  ReturnCode register_status_cb(const PortStatus &type, PortStatusCb port_cb);
 
   std::map<port_t, PortInfo> get_port_info() const;
 
@@ -199,8 +198,7 @@ class DevMgr : public PacketDispatcherIface {
 
   //! Register a callback function to be called every time the status of a port
   //! changes.
-  ReturnCode register_status_cb(const PortStatus &type,
-                                const PortStatusCb &port_cb);
+  ReturnCode register_status_cb(const PortStatus &type, PortStatusCb port_cb);
 
   // start the thread that performs packet processing
   void start();

--- a/include/bm/bm_sim/port_monitor.h
+++ b/include/bm/bm_sim/port_monitor.h
@@ -65,8 +65,8 @@ class PortMonitorIface {
     notify_(port_num, evt);
   }
 
-  void register_cb(const PortStatus evt, const PortStatusCb &cb) {
-    register_cb_(evt, cb);
+  void register_cb(const PortStatus evt, PortStatusCb cb) {
+    register_cb_(evt, std::move(cb));
   }
 
   void start(const PortStatusFn &fn) {
@@ -94,7 +94,7 @@ class PortMonitorIface {
  private:
   virtual void notify_(port_t port_num, const PortStatus evt) = 0;
 
-  virtual void register_cb_(const PortStatus evt, const PortStatusCb &cb) = 0;
+  virtual void register_cb_(const PortStatus evt, PortStatusCb cb) = 0;
 
   virtual void start_(const PortStatusFn &fn) = 0;
 

--- a/src/bm_sim/dev_mgr.cpp
+++ b/src/bm_sim/dev_mgr.cpp
@@ -179,10 +179,9 @@ DevMgrIface::clear_port_stats_(port_t port) {  // default implementation
 }
 
 PacketDispatcherIface::ReturnCode
-DevMgrIface::register_status_cb(const PortStatus &type,
-                                const PortStatusCb &port_cb) {
+DevMgrIface::register_status_cb(const PortStatus &type, PortStatusCb port_cb) {
   assert(p_monitor);
-  p_monitor->register_cb(type, port_cb);
+  p_monitor->register_cb(type, std::move(port_cb));
   return ReturnCode::SUCCESS;
 }
 
@@ -249,10 +248,9 @@ DevMgr::set_packet_handler(const PacketHandler &handler, void *cookie) {
 }
 
 PacketDispatcherIface::ReturnCode
-DevMgr::register_status_cb(const PortStatus &type,
-                           const PortStatusCb &port_cb) {
+DevMgr::register_status_cb(const PortStatus &type, PortStatusCb port_cb) {
   assert(pimp);
-  return pimp->register_status_cb(type, port_cb);
+  return pimp->register_status_cb(type, std::move(port_cb));
 }
 
 bool

--- a/tests/test_devmgr.cpp
+++ b/tests/test_devmgr.cpp
@@ -137,8 +137,8 @@ class DevMgrTest : public ::testing::Test {
   }
 
   void register_callback() {
-    port_cb = std::bind(&DevMgrTest::port_status, this, std::placeholders::_1,
-                        std::placeholders::_2);
+    auto port_cb = std::bind(&DevMgrTest::port_status, this,
+                             std::placeholders::_1, std::placeholders::_2);
     g_mgr->register_status_cb(DevMgrIface::PortStatus::PORT_ADDED, port_cb);
     g_mgr->register_status_cb(DevMgrIface::PortStatus::PORT_REMOVED, port_cb);
     g_mgr->register_status_cb(DevMgrIface::PortStatus::PORT_UP, port_cb);
@@ -157,7 +157,6 @@ class DevMgrTest : public ::testing::Test {
     return cb_counts.at(status);
   }
 
-  DevMgrIface::PortStatusCb port_cb{};
   std::map<DevMgrIface::PortStatus, uint32_t> cb_counts{};
   mutable std::mutex cnt_mutex{};
   std::unique_ptr<TestDevMgrImp> g_mgr{nullptr};
@@ -359,8 +358,8 @@ class PacketInDevMgrPortStatusTest : public PacketInDevMgrTest {
   }
 
   void register_callback() {
-    port_cb = std::bind(&PacketInDevMgrPortStatusTest::port_status, this,
-                        std::placeholders::_1, std::placeholders::_2);
+    auto port_cb = std::bind(&PacketInDevMgrPortStatusTest::port_status, this,
+                             std::placeholders::_1, std::placeholders::_2);
     sw.register_status_cb(DevMgrIface::PortStatus::PORT_ADDED, port_cb);
     sw.register_status_cb(DevMgrIface::PortStatus::PORT_REMOVED, port_cb);
     sw.register_status_cb(DevMgrIface::PortStatus::PORT_UP, port_cb);
@@ -388,7 +387,6 @@ class PacketInDevMgrPortStatusTest : public PacketInDevMgrTest {
     reset_counts();
   }
 
-  DevMgrIface::PortStatusCb port_cb{};
   std::map<DevMgrIface::PortStatus, uint32_t> cb_counts{};
   mutable std::mutex cnt_mutex{};
 };


### PR DESCRIPTION
Instead of storing a reference. This is much more convenient IMO because
of the lack of cookie in the CB registration, which makes it more likely
that the user will use something "more" than just a plain function
pointer. When using std::bind for example, it is convenient to let the
PortMonitor store the bind result. There is no drawback AFAIK. I also
modified the signature of the CB registration functions all the way to
DevMgr to take a value instead of a const reference (to make it more
obvious that we make a copy and that the function object must be
copyable).