### PR TITLE
Give access to "underlying" DevMgr in SimpleSwitchRunner

### DIFF
--- a/targets/simple_switch/bm/simple_switch/runner.h
+++ b/targets/simple_switch/bm/simple_switch/runner.h
@@ -21,6 +21,8 @@
 #ifndef SIMPLE_SWITCH_BM_SIMPLE_SWITCH_RUNNER_H_
 #define SIMPLE_SWITCH_BM_SIMPLE_SWITCH_RUNNER_H_
 
+#include <bm/bm_sim/dev_mgr.h>
+#include <bm/bm_sim/device_id.h>
 #include <bm/bm_sim/options_parse.h>
 
 #include <cstdint>
@@ -38,6 +40,10 @@ class SimpleSwitchRunner {
   ~SimpleSwitchRunner();
 
   int init_and_start(const bm::OptionsParser &parser);
+
+  device_id_t get_device_id() const;
+
+  DevMgr *get_dev_mgr();
 
  private:
   uint32_t cpu_port{0};

--- a/targets/simple_switch/runner.cpp
+++ b/targets/simple_switch/runner.cpp
@@ -74,6 +74,14 @@ int SimpleSwitchRunner::init_and_start(const bm::OptionsParser &parser) {
   return 0;
 }
 
+device_id_t SimpleSwitchRunner::get_device_id() const {
+  return simple_switch->get_device_id();
+}
+
+DevMgr *SimpleSwitchRunner::get_dev_mgr() {
+  return simple_switch.get();
+}
+
 }  // namespace sswitch
 
 }  // namespace bm


### PR DESCRIPTION
This is useful to "configure" ports and register for port status
updates.