### PR TITLE
Use config.h file to fix use of #ifdef in headers

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1935,7 +1935,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = BMELOG_ON BMLOG_DEBUG_ON BMLOG_TRACE_ON
+PREDEFINED             = BM_ELOG_ON BM_LOG_DEBUG_ON BM_LOG_TRACE_ON
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-exec autoreconf -fi
+# generates config.h.in
+autoheader
+
+autoreconf -fi

--- a/configure.ac
+++ b/configure.ac
@@ -45,8 +45,6 @@ AC_ARG_WITH([pdfixed],
 
 AM_CONDITIONAL([COND_PDFIXED], [test "$want_pdfixed" = yes])
 
-MY_CPPFLAGS=""
-
 AC_ARG_WITH([nanomsg],
     AS_HELP_STRING([--with-nanomsg], [Build Nanomsg RPC service, if disabled then you must have some other way of controlling the switch]),
     [want_nanomsg="$withval"], [want_nanomsg=yes])
@@ -59,7 +57,7 @@ AC_ARG_ENABLE([debugger],
 AS_IF([test "x$enable_debugger" = "xyes"], [
     AS_IF([test "$want_nanomsg" = "yes"], [
         debugger_enabled=yes
-        MY_CPPFLAGS="$MY_CPPFLAGS -DBMDEBUG_ON"
+        AC_DEFINE([DEBUG_ON], [], [Enable debugger])
     ], [
         AC_MSG_ERROR([Cannot use debugger without nanomsg])
     ])
@@ -71,10 +69,11 @@ AC_ARG_ENABLE([logging_macros],
                    [Disable compile time debug and trace logging macros]))
 AS_IF([test "x$enable_logging_macros" != "xno"], [
     logging_macros_enabled=yes
-    MY_CPPFLAGS="$MY_CPPFLAGS -DBMLOG_DEBUG_ON -DBMLOG_TRACE_ON"
+    AC_DEFINE([LOG_DEBUG_ON], [], [Enable compile-time macro for debug logging])
+    AC_DEFINE([LOG_TRACE_ON], [], [Enable compile-time macro for trace logging])
 ])
 
-# BMELOG_ON is defined by default, since it is required for some tests
+# BM_ELOG_ON is defined by default, since it is required for some tests
 elogger_enabled=no
 AC_ARG_ENABLE([elogger],
     AS_HELP_STRING([--disable-elogger],
@@ -83,7 +82,7 @@ AC_ARG_ENABLE([elogger],
 AS_IF([test "x$enable_elogger" != "xno"], [
     AS_IF([test "$want_nanomsg" = "yes"], [
         elogger_enabled=yes
-        MY_CPPFLAGS="$MY_CPPFLAGS -DBMELOG_ON"
+        AC_DEFINE([ELOG_ON], [], [Enable nanomsg event logger])
     ], [
         AC_MSG_WARN([Cannot use elogger without nanomsg])
     ])
@@ -118,7 +117,7 @@ AC_ARG_ENABLE([WP4-16-stacks],
     [enable_WP4_16_stacks="$enableval"], [enable_WP4_16_stacks=yes])
 
 AS_IF([test "$enable_WP4_16_stacks" = "yes"],
-      [MY_CPPFLAGS="$MY_CPPFLAGS -DBM_WP4_16_STACKS"])
+      [AC_DEFINE([WP4_16_STACKS], [], [Implement stacks as per P4_16 spec])])
 
 # Checks for programs.
 AC_PROG_CXX
@@ -150,7 +149,7 @@ AS_IF([test "$want_thrift" = yes], [
     AS_IF([test "$want_p4thrift" = yes], [
         AC_PATH_PROG([THRIFT], [p4thrift], [])
         AC_SUBST([THRIFT_LIB], ["-lp4thrift"])
-        MY_CPPFLAGS="$MY_CPPFLAGS -DP4THRIFT"
+        AC_DEFINE([P4THRIFT], [], [Use P4.org Thrift fork])
         AC_CHECK_HEADER([p4thrift/P4Thrift.h], [], [AC_MSG_ERROR([P4Thrift headers not found. Install P4Thrift from http://github.com/p4lang/thrift/])])
     ], [
         AC_PATH_PROG([THRIFT], [thrift], [])
@@ -158,9 +157,9 @@ AS_IF([test "$want_thrift" = yes], [
         AC_CHECK_HEADER([thrift/Thrift.h], [], [AC_MSG_ERROR([Thrift headers not found. Install Thrift from http://thrift.apache.org/docs/install/])])
     ])
     AS_IF([test x"$THRIFT" = x], [AC_MSG_ERROR([cannot find thrift])])
-    MY_CPPFLAGS="$MY_CPPFLAGS -DBMTHRIFT_ON"
+    AC_DEFINE([THRIFT_ON], [], [Enable Thrift support])
     AC_CHECK_HEADER([thrift/stdcxx.h], [
-        MY_CPPFLAGS="$MY_CPPFLAGS -DHAVE_THRIFT_STDCXX_H"
+        AC_DEFINE([HAVE_THRIFT_STDCXX_H], [], [Found Thrift stdcxx wrapper])
     ], [])
 ])
 
@@ -178,7 +177,7 @@ utility vector], [], [AC_MSG_ERROR([Missing header file])])
 
 AS_IF([test "$want_nanomsg" = yes], [
     AC_CHECK_LIB([nanomsg], [nn_errno], [], [AC_MSG_ERROR([Missing libnanomsg])])
-    MY_CPPFLAGS="$MY_CPPFLAGS -DBMNANOMSG_ON"
+    AC_DEFINE([NANOMSG_ON], [], [Enable Nanomsg support])
 ])
 
 # Check for pthread, libjudy, libgmp, libpcap
@@ -222,7 +221,8 @@ AS_IF([test "x$enable_modules" != "xno"], [
   AC_MSG_CHECKING(for dlopen())
   AC_CHECK_HEADERS(dlfcn.h, [
     AC_SEARCH_LIBS([dlopen], [dl], [
-      MY_CPPFLAGS="$MY_CPPFLAGS -DBM_HAVE_DLOPEN -DBM_ENABLE_MODULES"
+      AC_DEFINE([HAVE_DLOPEN], [], [Found dlopen])
+      AC_DEFINE([ENABLE_MODULES], [], [Enable dynamic loading of modules])
       modules_enabled=yes
     ], [
       AC_MSG_RESULT(no)
@@ -252,8 +252,8 @@ AC_CHECK_HEADER([boost/program_options.hpp], [], [AC_MSG_ERROR([Missing boost pr
 AC_CHECK_HEADER([boost/functional/hash.hpp], [], [AC_MSG_ERROR([Missing boost functional hash header])])
 AC_CHECK_HEADER([boost/filesystem.hpp], [], [AC_MSG_ERROR([Missing boost filesystem header])])
 
-AC_SUBST([AM_CPPFLAGS], ["$MY_CPPFLAGS \
-                          -I\$(top_srcdir)/include \
+AC_SUBST([AM_CPPFLAGS], ["-I\$(top_srcdir)/include \
+                          -I\$(top_builddir)/include \
                           -isystem\$(top_srcdir)/third_party/jsoncpp/include \
                           -isystem\$(top_srcdir)/third_party/spdlog"])
 AC_SUBST([AM_CFLAGS], ["$PTHREAD_CFLAGS"])
@@ -307,6 +307,8 @@ AC_CONFIG_FILES([tests/utils.cpp
                  mininet/stress_test_ipv4.py])
 AC_CONFIG_FILES([targets/simple_switch/tests/CLI_tests/run_one_test.py],
                 [chmod +x targets/simple_switch/tests/CLI_tests/run_one_test.py])
+
+AX_PREFIX_CONFIG_H([include/bm/config.h], [BM])
 
 AC_OUTPUT
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,6 +1,11 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
-nobase_include_HEADERS =
+nobase_include_HEADERS = \
+bm/config.h
+
+distclean-local: distclean-ax-prefix-config-h
+distclean-ax-prefix-config-h:
+	rm -f bm/config.h
 
 if COND_NANOMSG
 nobase_include_HEADERS += \

--- a/include/bm/bm_runtime/bm_runtime.h
+++ b/include/bm/bm_runtime/bm_runtime.h
@@ -1,7 +1,9 @@
 #ifndef _BM_RUNTIME_BM_RUNTIME_H_
 #define _BM_RUNTIME_BM_RUNTIME_H_
 
-#ifdef P4THRIFT
+#include <bm/config.h>
+
+#ifdef BM_P4THRIFT
 #include <p4thrift/processor/TMultiplexedProcessor.h>
 
 namespace thrift_provider = p4::thrift;
@@ -36,4 +38,4 @@ int start_server(bm::SwitchWContexts *sw, int port);
 
 }
 
-#endif
+#endif  // _BM_RUNTIME_BM_RUNTIME_H_

--- a/include/bm/bm_sim/debugger.h
+++ b/include/bm/bm_sim/debugger.h
@@ -21,10 +21,10 @@
 #ifndef BM_BM_SIM_DEBUGGER_H_
 #define BM_BM_SIM_DEBUGGER_H_
 
+#include <bm/config.h>
+
 #include <limits>
 #include <string>
-
-// #define BMDEBUG_ON
 
 namespace bm {
 
@@ -145,7 +145,7 @@ class DebuggerIface {
   virtual std::string get_addr_() const = 0;
 };
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
 #define DEBUGGER_NOTIFY_UPDATE(packet_id, id, bytes, nbits) \
   Debugger::get()->notify_update(packet_id, id, bytes, nbits);
 #define DEBUGGER_NOTIFY_UPDATE_V(packet_id, id, v) \

--- a/include/bm/bm_sim/dev_mgr.h
+++ b/include/bm/bm_sim/dev_mgr.h
@@ -35,6 +35,8 @@
 #ifndef BM_BM_SIM_DEV_MGR_H_
 #define BM_BM_SIM_DEV_MGR_H_
 
+#include <bm/config.h>
+
 #include <functional>
 #include <string>
 #include <map>
@@ -170,7 +172,7 @@ class DevMgr : public PacketDispatcherIface {
   // wait before starting to process packets.
   void set_dev_mgr_files(unsigned wait_time_in_seconds);
 
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
   // if enforce ports is set to true, packets coming in on un-registered ports
   // are dropped
   void set_dev_mgr_packet_in(

--- a/include/bm/bm_sim/event_logger.h
+++ b/include/bm/bm_sim/event_logger.h
@@ -23,6 +23,8 @@
 #ifndef BM_BM_SIM_EVENT_LOGGER_H_
 #define BM_BM_SIM_EVENT_LOGGER_H_
 
+#include <bm/config.h>
+
 #include <string>
 #include <memory>
 
@@ -124,7 +126,7 @@ class EventLogger {
 //! // packet processing
 //! BMELOG(packet_out, packet);
 //! @endcode
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
 #define BMELOG(fn, ...) bm::EventLogger::get()->fn(__VA_ARGS__)
 #else
 #define BMELOG(fn, ...)

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -23,6 +23,8 @@
 #ifndef BM_BM_SIM_FIELDS_H_
 #define BM_BM_SIM_FIELDS_H_
 
+#include <bm/config.h>
+
 #include <algorithm>  // for std::copy
 
 #include <cassert>
@@ -143,7 +145,7 @@ class Field : public Data {
 
   void reset_VL();
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   void set_id(uint64_t id) { my_id = id; }
   void set_packet_id(const Debugger::PacketId *id) { packet_id = id; }
 #else
@@ -189,7 +191,7 @@ class Field : public Data {
   Bignum mask{1};
   Bignum max{1};
   Bignum min{1};
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   uint64_t my_id{};
   const Debugger::PacketId *packet_id{&Debugger::dummy_PacketId};
 #endif

--- a/include/bm/bm_sim/headers.h
+++ b/include/bm/bm_sim/headers.h
@@ -23,6 +23,8 @@
 #ifndef BM_BM_SIM_HEADERS_H_
 #define BM_BM_SIM_HEADERS_H_
 
+#include <bm/config.h>
+
 #include <vector>
 #include <string>
 #include <set>
@@ -265,7 +267,7 @@ class Header : public NamedP4Object {
   // same value.
   bool cmp(const Header &other) const;
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   void set_packet_id(const Debugger::PacketId *id);
 #else
   void set_packet_id(const Debugger::PacketId *) { }
@@ -313,7 +315,7 @@ class Header : public NamedP4Object {
   int nbytes_packet{0};
   std::unique_ptr<ArithExpression> VL_expr;
   std::unique_ptr<UnionMembership> union_membership{nullptr};
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   const Debugger::PacketId *packet_id{&Debugger::dummy_PacketId};
 #endif
 };

--- a/include/bm/bm_sim/logger.h
+++ b/include/bm/bm_sim/logger.h
@@ -33,6 +33,7 @@
 #ifndef BM_BM_SIM_LOGGER_H_
 #define BM_BM_SIM_LOGGER_H_
 
+#include <bm/config.h>
 #include <bm/spdlog/spdlog.h>
 
 #include <string>
@@ -106,17 +107,17 @@ class Logger {
 
 }  // namespace bm
 
-#ifdef BMLOG_DEBUG_ON
+#ifdef BM_LOG_DEBUG_ON
 //! Preferred way (because can be disabled at compile time) to log a debug
-//! message. Is enabled by preprocessor BMLOG_DEBUG_ON.
+//! message. Is enabled by preprocessor BM_LOG_DEBUG_ON.
 #define BMLOG_DEBUG(...) bm::Logger::get()->debug(__VA_ARGS__);
 #else
 #define BMLOG_DEBUG(...)
 #endif
 
-#ifdef BMLOG_TRACE_ON
+#ifdef BM_LOG_TRACE_ON
 //! Preferred way (because can be disabled at compile time) to log a trace
-//! message. Is enabled by preprocessor BMLOG_TRACE_ON.
+//! message. Is enabled by preprocessor BM_LOG_TRACE_ON.
 #define BMLOG_TRACE(...) bm::Logger::get()->trace(__VA_ARGS__);
 #else
 #define BMLOG_TRACE(...)

--- a/include/bm/bm_sim/transport.h
+++ b/include/bm/bm_sim/transport.h
@@ -21,6 +21,8 @@
 #ifndef BM_BM_SIM_TRANSPORT_H_
 #define BM_BM_SIM_TRANSPORT_H_
 
+#include <bm/config.h>
+
 #include <string>
 #include <initializer_list>
 #include <memory>
@@ -59,7 +61,7 @@ class TransportIface {
     return send_msgs_(msgs);
   }
 
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
   static std::unique_ptr<TransportIface> make_nanomsg(const std::string &addr);
 #endif
   static std::unique_ptr<TransportIface> make_dummy();

--- a/include/bm/thrift/stdcxx.h
+++ b/include/bm/thrift/stdcxx.h
@@ -1,7 +1,9 @@
 #ifndef _BM_STDCXX_H_
 #define _BM_STDCXX_H_
 
-#ifdef HAVE_THRIFT_STDCXX_H
+#include <bm/config.h>
+
+#ifdef BM_HAVE_THRIFT_STDCXX_H
 #include <thrift/stdcxx.h>
 namespace stdcxx = thrift_provider::stdcxx;
 #else

--- a/m4/ax_prefix_config_h.m4
+++ b/m4/ax_prefix_config_h.m4
@@ -1,0 +1,203 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_prefix_config_h.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PREFIX_CONFIG_H [(OUTPUT-HEADER [,PREFIX [,ORIG-HEADER]])]
+#
+# DESCRIPTION
+#
+#   Generate an installable config.h.
+#
+#   A package should not normally install its config.h as a system header,
+#   but if it must, this macro can be used to avoid namespace pollution by
+#   making a copy of config.h with a prefix added to all the macro names.
+#
+#   Each "#define SOMEDEF" line of the configuration header has the given
+#   prefix added, in the same case as the first character of the macro name.
+#
+#   Defaults:
+#
+#     OUTPUT-HEADER = $PACKAGE-config.h
+#     PREFIX = $PACKAGE
+#     ORIG-HEADER, from AM_CONFIG_HEADER(config.h)
+#
+#   Your configure.ac script should contain both macros in this order.
+#
+#   Example:
+#
+#     AC_INIT(config.h.in)        # config.h.in as created by "autoheader"
+#     AM_INIT_AUTOMAKE(testpkg, 0.1.1)    # makes #undef VERSION and PACKAGE
+#     AM_CONFIG_HEADER(config.h)          # prep config.h from config.h.in
+#     AX_PREFIX_CONFIG_H(mylib/_config.h) # prep mylib/_config.h from it..
+#     AC_MEMORY_H                         # makes "#undef NEED_MEMORY_H"
+#     AC_C_CONST_H                        # makes "#undef const"
+#     AC_OUTPUT(Makefile)                 # creates the "config.h" now
+#                                         # and also mylib/_config.h
+#
+#   If the argument to AX_PREFIX_CONFIG_H would have been omitted then the
+#   default output file would have been called simply "testpkg-config.h",
+#   but even under the name "mylib/_config.h" it contains prefix-defines
+#   like
+#
+#     #ifndef TESTPKG_VERSION
+#     #define TESTPKG_VERSION "0.1.1"
+#     #endif
+#     #ifndef TESTPKG_NEED_MEMORY_H
+#     #define TESTPKG_NEED_MEMORY_H 1
+#     #endif
+#     #ifndef _testpkg_const
+#     #define _testpkg_const _const
+#     #endif
+#
+#   and this "mylib/_config.h" can be installed along with other header
+#   files, which is most convenient when creating a shared library (that has
+#   some headers) whose functionality depends on features detected at
+#   compile-time. No need to invent some "mylib-confdefs.h.in" manually.
+#
+#   Note that some AC_DEFINEs that end up in the config.h file are actually
+#   self-referential - e.g. AC_C_INLINE, AC_C_CONST, and the AC_TYPE_OFF_T
+#   say that they "will define inline|const|off_t if the system does not do
+#   it by itself". You might want to clean up about these - consider an
+#   extra mylib/conf.h that reads something like:
+#
+#     #include <mylib/_config.h>
+#     #ifndef _testpkg_const
+#     #define _testpkg_const const
+#     #endif
+#
+#   and then start using _testpkg_const in the header files. That is also a
+#   good thing to differentiate whether some library-user has starting to
+#   take up with a different compiler, so perhaps it could read something
+#   like this:
+#
+#     #ifdef _MSC_VER
+#     #include <mylib/_msvc.h>
+#     #else
+#     #include <mylib/_config.h>
+#     #endif
+#     #ifndef _testpkg_const
+#     #define _testpkg_const const
+#     #endif
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Reuben Thomas <rrt@sc3d.org>
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2008 Marten Svantesson
+#   Copyright (c) 2008 Gerald Point <Gerald.Point@labri.fr>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 16
+
+AC_DEFUN([AX_PREFIX_CONFIG_H],[dnl
+AC_PREREQ([2.62])
+AC_BEFORE([AC_CONFIG_HEADERS],[$0])dnl
+AC_CONFIG_COMMANDS(m4_default([$1], [$PACKAGE-config.h]),[dnl
+AS_VAR_PUSHDEF([_OUT],[ac_prefix_conf_OUT])dnl
+AS_VAR_PUSHDEF([_DEF],[ac_prefix_conf_DEF])dnl
+AS_VAR_PUSHDEF([_PKG],[ac_prefix_conf_PKG])dnl
+AS_VAR_PUSHDEF([_LOW],[ac_prefix_conf_LOW])dnl
+AS_VAR_PUSHDEF([_UPP],[ac_prefix_conf_UPP])dnl
+AS_VAR_PUSHDEF([_INP],[ac_prefix_conf_INP])dnl
+m4_pushdef([_script],[conftest.prefix])dnl
+m4_pushdef([_symbol],[m4_cr_Letters[]m4_cr_digits[]_])dnl
+_OUT=`echo m4_default([$1], [$PACKAGE-config.h])`
+_DEF=`echo _$_OUT | sed -e "y:m4_cr_letters:m4_cr_LETTERS[]:" -e "s/@<:@^m4_cr_Letters@:>@/_/g"`
+_PKG=`echo m4_default([$2], [$PACKAGE])`
+_LOW=`echo _$_PKG | sed -e "y:m4_cr_LETTERS-:m4_cr_letters[]_:"`
+_UPP=`echo $_PKG | sed -e "y:m4_cr_letters-:m4_cr_LETTERS[]_:"  -e "/^@<:@m4_cr_digits@:>@/s/^/_/"`
+_INP=`echo "$3" | sed -e 's/ *//'`
+if test ".$_INP" = "."; then
+   for ac_file in : $CONFIG_HEADERS; do test "_$ac_file" = _: && continue
+     case "$ac_file" in
+        *.h) _INP=$ac_file ;;
+        *)
+     esac
+     test ".$_INP" != "." && break
+   done
+fi
+if test ".$_INP" = "."; then
+   case "$_OUT" in
+      */*) _INP=`basename "$_OUT"`
+      ;;
+      *-*) _INP=`echo "$_OUT" | sed -e "s/@<:@_symbol@:>@*-//"`
+      ;;
+      *) _INP=config.h
+      ;;
+   esac
+fi
+if test -z "$_PKG" ; then
+   AC_MSG_ERROR([no prefix for _PREFIX_PKG_CONFIG_H])
+else
+  if test ! -f "$_INP" ; then if test -f "$srcdir/$_INP" ; then
+     _INP="$srcdir/$_INP"
+  fi fi
+  AC_MSG_NOTICE(creating $_OUT - prefix $_UPP for $_INP defines)
+  if test -f $_INP ; then
+    AS_ECHO(["s/^@%:@undef  *\\(@<:@m4_cr_LETTERS[]_@:>@\\)/@%:@undef $_UPP""_\\1/"]) > _script
+    AS_ECHO(["s/^@%:@undef  *\\(@<:@m4_cr_letters@:>@\\)/@%:@undef $_LOW""_\\1/"]) >> _script
+    AS_ECHO(["s/^@%:@def[]ine  *\\(@<:@m4_cr_LETTERS[]_@:>@@<:@_symbol@:>@*\\)\\(.*\\)/@%:@ifndef $_UPP""_\\1\\"]) >> _script
+    AS_ECHO(["@%:@def[]ine $_UPP""_\\1\\2\\"]) >> _script
+    AS_ECHO(["@%:@endif/"]) >> _script
+    AS_ECHO(["s/^@%:@def[]ine  *\\(@<:@m4_cr_letters@:>@@<:@_symbol@:>@*\\)\\(.*\\)/@%:@ifndef $_LOW""_\\1\\"]) >> _script
+    AS_ECHO(["@%:@define $_LOW""_\\1\\2\\"]) >> _script
+    AS_ECHO(["@%:@endif/"]) >> _script
+    # now executing _script on _DEF input to create _OUT output file
+    echo "@%:@ifndef $_DEF"      >$tmp/pconfig.h
+    echo "@%:@def[]ine $_DEF 1" >>$tmp/pconfig.h
+    echo ' ' >>$tmp/pconfig.h
+    echo /'*' $_OUT. Generated automatically at end of configure. '*'/ >>$tmp/pconfig.h
+
+    sed -f _script $_INP >>$tmp/pconfig.h
+    echo ' ' >>$tmp/pconfig.h
+    echo '/* once:' $_DEF '*/' >>$tmp/pconfig.h
+    echo "@%:@endif" >>$tmp/pconfig.h
+    if cmp -s $_OUT $tmp/pconfig.h 2>/dev/null; then
+      AC_MSG_NOTICE([$_OUT is unchanged])
+    else
+      ac_dir=`AS_DIRNAME(["$_OUT"])`
+      AS_MKDIR_P(["$ac_dir"])
+      rm -f "$_OUT"
+      mv $tmp/pconfig.h "$_OUT"
+    fi
+  else
+    AC_MSG_ERROR([input file $_INP does not exist - skip generating $_OUT])
+  fi
+  rm -f conftest.*
+fi
+m4_popdef([_symbol])dnl
+m4_popdef([_script])dnl
+AS_VAR_POPDEF([_INP])dnl
+AS_VAR_POPDEF([_UPP])dnl
+AS_VAR_POPDEF([_LOW])dnl
+AS_VAR_POPDEF([_PKG])dnl
+AS_VAR_POPDEF([_DEF])dnl
+AS_VAR_POPDEF([_OUT])dnl
+],[PACKAGE="$PACKAGE"])])

--- a/src/bm_apps/learn.cpp
+++ b/src/bm_apps/learn.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#ifdef P4THRIFT
+#include <bm/config.h>
+
+#ifdef BM_P4THRIFT
 #include <p4thrift/protocol/TBinaryProtocol.h>
 #include <p4thrift/transport/TSocket.h>
 #include <p4thrift/transport/TTransportUtils.h>

--- a/src/bm_runtime/server.cpp
+++ b/src/bm_runtime/server.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#ifdef P4THRIFT
+#include <bm/config.h>
+
+#ifdef BM_P4THRIFT
 #include <p4thrift/protocol/TBinaryProtocol.h>
 #include <p4thrift/server/TSimpleServer.h>
 #include <p4thrift/server/TThreadedServer.h>

--- a/src/bm_sim/debugger.cpp
+++ b/src/bm_sim/debugger.cpp
@@ -18,9 +18,10 @@
  *
  */
 
+#include <bm/config.h>
 #include <bm/bm_sim/debugger.h>
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
 #include <bm/bm_sim/nn.h>
 
 // temporary deps?
@@ -40,7 +41,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <vector>
-#endif  // BMDEBUG_ON
+#endif  // BM_DEBUG_ON
 
 namespace bm {
 
@@ -90,7 +91,7 @@ class DebuggerDummy final : public DebuggerIface {
   }
 };
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
 
 class DebuggerNN final : public DebuggerIface {
  public:
@@ -910,7 +911,7 @@ DebuggerNN::request_in() {
   }
 }
 
-#endif  // BMDEBUG_ON
+#endif  // BM_DEBUG_ON
 
 DebuggerIface *Debugger::debugger = new DebuggerDummy();
 
@@ -920,7 +921,7 @@ void
 Debugger::init_debugger(const std::string &addr, device_id_t device_id) {
   if (is_init) return;
   is_init = true;
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   DebuggerDummy *dummy = dynamic_cast<DebuggerDummy *>(debugger);
   assert(dummy);
   delete dummy;

--- a/src/bm_sim/dev_mgr_packet_in.cpp
+++ b/src/bm_sim/dev_mgr_packet_in.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#ifdef BMNANOMSG_ON
+#include <bm/config.h>
+
+#ifdef BM_NANOMSG_ON
 
 #include <bm/bm_sim/dev_mgr.h>
 #include <bm/bm_sim/logger.h>
@@ -325,4 +327,4 @@ DevMgr::set_dev_mgr_packet_in(
 
 }  // namespace bm
 
-#endif  // BMNANOMSG_ON
+#endif  // BM_NANOMSG_ON

--- a/src/bm_sim/headers.cpp
+++ b/src/bm_sim/headers.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <bm/config.h>
+
 #include <bm/bm_sim/headers.h>
 #include <bm/bm_sim/header_unions.h>
 #include <bm/bm_sim/phv.h>
@@ -279,7 +281,7 @@ Header::deparse(char *data) const {
   }
 }
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
 void
 Header::set_packet_id(const Debugger::PacketId *id) {
   for (Field &f : fields) f.set_packet_id(id);

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <bm/config.h>
 #include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/event_logger.h>
 #include <bm/bm_sim/logger.h>
@@ -102,12 +103,12 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
        "(interface X corresponds to two files X_in.pcap and X_out.pcap). "
        "Argument is the time to wait (in seconds) before starting to process "
        "the packet files.")
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
       ("packet-in", po::value<std::string>(),
        "Enable receiving packet on this (nanomsg) socket. "
        "The --interface options will be ignored.")
 #endif
-#ifdef BMTHRIFT_ON
+#ifdef BM_THRIFT_ON
       ("thrift-port", po::value<int>(),
        "TCP port on which to run the Thrift runtime server")
 #endif
@@ -125,13 +126,13 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
        "'trace', 'debug', 'info', 'warn', 'error', off'; default is 'trace'")
       ("log-flush", "If used with '--log-file', the logger will flush to disk "
        "after every log message")
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
       ("notifications-addr", po::value<std::string>(),
        "Specify the nanomsg address to use for notifications "
        "(e.g. learning, ageing, ...); "
        "default is ipc:///tmp/bmv2-<device-id>-notifications.ipc")
 #endif
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
       ("debugger", "Activate debugger")
       ("debugger-addr", po::value<std::string>(),
        "Specify the nanomsg address to use for debugger communication; "
@@ -245,7 +246,7 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
     device_id = vm["device-id"].as<device_id_t>();
   }
 
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
   if (vm.count("notifications-addr")) {
     notifications_addr = vm["notifications-addr"].as<std::string>();
   } else {
@@ -255,7 +256,7 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
 #endif
 
   if (vm.count("nanolog")) {
-#ifndef BMELOG_ON
+#ifndef BM_ELOG_ON
     outstream << "Warning: you requested the nanomsg event logger, but bmv2 "
               << "was compiled without -DBMELOG, and the event logger cannot "
               << "be activated\n";
@@ -299,10 +300,10 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
 
   auto log_requested = console_logging || !file_logger.empty();
   auto missing_macros = false;
-#ifndef BMLOG_TRACE_ON
+#ifndef BM_LOG_TRACE_ON
   missing_macros |= log_level <= Logger::LogLevel::TRACE;
 #endif
-#ifndef BMLOG_DEBUG_ON
+#ifndef BM_LOG_DEBUG_ON
   missing_macros |= log_level <= Logger::LogLevel::DEBUG;
 #endif
   if (log_requested && missing_macros) {
@@ -354,7 +355,7 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
       wait_time = 0;
   }
 
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
   if (vm.count("packet-in")) {
     packet_in = true;
     packet_in_addr = vm["packet-in"].as<std::string>();
@@ -377,7 +378,7 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
         + std::to_string(device_id) + std::string("-debug.ipc");
   }
 
-#ifdef BMTHRIFT_ON
+#ifdef BM_THRIFT_ON
   int default_thrift_port = 9090;
   if (vm.count("thrift-port")) {
     thrift_port = vm["thrift-port"].as<int>();

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <bm/config.h>
 #include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/P4Objects.h>
@@ -94,7 +95,7 @@ SwitchWContexts::reset_target_state() {
 
 std::string
 SwitchWContexts::get_debugger_addr() const {
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   return Debugger::get_addr();
 #else
   return "";
@@ -211,7 +212,7 @@ SwitchWContexts::init_from_options_parser(
 
   auto transport = my_transport;
   if (transport == nullptr) {
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
     notifications_addr = parser.notifications_addr;
     transport = std::shared_ptr<TransportIface>(
         TransportIface::make_nanomsg(notifications_addr));
@@ -223,7 +224,7 @@ SwitchWContexts::init_from_options_parser(
   // won't hurt if transport has already been opened
   transport->open();
 
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   // has to be before init_objects because forces arith
   if (parser.debugger) {
     for (Context &c : contexts)
@@ -252,7 +253,7 @@ SwitchWContexts::init_from_options_parser(
     set_dev_mgr(std::move(my_dev_mgr));
   else if (parser.use_files)
     set_dev_mgr_files(parser.wait_time);
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
   else if (parser.packet_in)
     set_dev_mgr_packet_in(device_id, parser.packet_in_addr, transport);
 #endif
@@ -456,7 +457,7 @@ SwitchWContexts::do_swap() {
       phv_source->set_phv_factory(cxt_id, &cxt.get_phv_factory());
     rc &= swap_done;
   }
-#ifdef BMDEBUG_ON
+#ifdef BM_DEBUG_ON
   Debugger::get()->config_change();
 #endif
   BMELOG(config_change);

--- a/src/bm_sim/transport_nn.cpp
+++ b/src/bm_sim/transport_nn.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#ifdef BMNANOMSG_ON
+#include <bm/config.h>
+
+#ifdef BM_NANOMSG_ON
 
 #include <bm/bm_sim/transport.h>
 #include <bm/bm_sim/nn.h>
@@ -122,4 +124,4 @@ TransportIface::make_nanomsg(const std::string &addr) {
 
 }  // namespace bm
 
-#endif  // BMNANOMSG_ON
+#endif  // BM_NANOMSG_ON

--- a/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
+++ b/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
@@ -18,9 +18,10 @@
  *
  */
 
+#include <bm/config.h>
 #include <bm/PsaSwitch.h>
 
-#ifdef P4THRIFT
+#ifdef BM_P4THRIFT
 #include <p4thrift/protocol/TBinaryProtocol.h>
 #include <p4thrift/server/TThreadedServer.h>
 #include <p4thrift/transport/TServerSocket.h>

--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -20,6 +20,8 @@
 
 /* Switch instance */
 
+#include <bm/config.h>
+
 #ifdef BM_HAVE_DLOPEN
 #  include <dlfcn.h>
 #endif  // BM_HAVE_DLOPEN

--- a/targets/simple_switch/tests/test_packet_redirect.cpp
+++ b/targets/simple_switch/tests/test_packet_redirect.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <bm/config.h>
 #include <bm/bm_apps/packet_pipe.h>
 #include <bm/bm_sim/logger.h>
 
@@ -66,7 +67,7 @@ class SimpleSwitch_PacketRedirectP4 : public ::testing::Test {
   // the simple_switch target detaches threads
   static void SetUpTestCase() {
     // bm::Logger::set_logger_console();
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
     auto event_transport = bm::TransportIface::make_nanomsg(event_logger_addr);
     event_transport->open();
     bm::EventLogger::init(std::move(event_transport));
@@ -191,7 +192,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4, Baseline) {
   ASSERT_EQ(2, static_cast<int>(recv_buffer[1]));
   ASSERT_EQ(port_out, recv_port);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
   events.get_and_remove_events(pid(0), &pevents, 8u);
@@ -273,7 +274,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4, Multicast) {
   ASSERT_TRUE((recv_port_1 == 1 && recv_port_2 == 2) ||
               (recv_port_1 == 2 && recv_port_2 == 1));
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -356,7 +357,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4_CloneI2E, CloneI2E) {
 
   test_switch->mirroring_delete_session(mirror_id);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -417,7 +418,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4_CloneI2E, CloneI2E_Multicast) {
   test_switch->mirroring_delete_session(mirror_id);
   return;
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -508,7 +509,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4_CloneE2E, CloneE2E) {
 
   test_switch->mirroring_delete_session(mirror_id);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -567,7 +568,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4_CloneE2E, CloneE2E_Multicast) {
 
   test_switch->mirroring_delete_session(mirror_id);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -645,7 +646,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4, Resubmit) {
   receiver.read(recv_buffer, sizeof(pkt), &recv_port);
   ASSERT_EQ(port_out_2, recv_port);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -722,7 +723,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4, Recirculate) {
   receiver.read(recv_buffer, sizeof(pkt), &recv_port);
   ASSERT_EQ(port_out_2, recv_port);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 
@@ -775,7 +776,7 @@ TEST_F(SimpleSwitch_PacketRedirectP4, ExitIngress) {
   receiver.read(recv_buffer, sizeof(pkt), &recv_port);
   ASSERT_EQ(port_out, recv_port);
 
-#ifdef BMELOG_ON
+#ifdef BM_ELOG_ON
   // event check
   std::vector<NNEventListener::NNEvent> pevents;
 

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -18,9 +18,10 @@
  *
  */
 
+#include <bm/config.h>
 #include <bm/SimpleSwitch.h>
 
-#ifdef P4THRIFT
+#ifdef BM_P4THRIFT
 #include <p4thrift/protocol/TBinaryProtocol.h>
 #include <p4thrift/server/TThreadedServer.h>
 #include <p4thrift/transport/TServerSocket.h>

--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -13,7 +13,8 @@ AM_CPPFLAGS += -DWITH_SYSREPO
 endif
 
 if WITH_THRIFT
-AM_CPPFLAGS += -DWITH_THRIFT
+AM_CPPFLAGS += -DWITH_THRIFT \
+-I$(builddir)/../simple_switch/gen-cpp
 endif
 
 bin_PROGRAMS = simple_switch_grpc

--- a/targets/simple_switch_grpc/configure.ac
+++ b/targets/simple_switch_grpc/configure.ac
@@ -6,8 +6,6 @@ AC_INIT([simple-switch-grpc], [0.1], [antonin@barefootnetworks.com])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 
-MY_CPPFLAGS=""
-
 AC_PROG_CC
 AC_PROG_CXX
 
@@ -34,7 +32,7 @@ AC_ARG_ENABLE([Werror],
     AS_HELP_STRING([--enable-Werror], [Make all compiler warnings fatal]),
     [enable_Werror="$enableval"], [enable_Werror=no])
 
-AC_SUBST([AM_CPPFLAGS], ["$MY_CPPFLAGS"])
+AC_SUBST([AM_CPPFLAGS], [])
 AC_SUBST([AM_CFLAGS], ["$PTHREAD_CFLAGS"])
 # Using ax_append_compile_flags requires copying 4 macro definitions from the
 # autoconf archive to m4/

--- a/tests/test_bm_apps.cpp
+++ b/tests/test_bm_apps.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#ifdef BMNANOMSG_ON
+#include <bm/config.h>
+
+#ifdef BM_NANOMSG_ON
 
 #include <gtest/gtest.h>
 
@@ -206,4 +208,4 @@ TEST_F(NotificationsTest, PortEvent) {
   test(1, PortStatus::PORT_UP, true, PortEvent::PORT_UP);
 }
 
-#endif  // BMNANOMSG_ON
+#endif  // BM_NANOMSG_ON

--- a/tests/test_devmgr.cpp
+++ b/tests/test_devmgr.cpp
@@ -15,6 +15,7 @@
 
 #include <gtest/gtest.h>
 
+#include <bm/config.h>
 #include <bm/bm_sim/dev_mgr.h>
 #include <bm/bm_sim/port_monitor.h>
 #include <bm/bm_apps/packet_pipe.h>
@@ -255,7 +256,7 @@ class PacketInReceiver {
   mutable std::condition_variable can_read{};
 };
 
-#ifdef BMNANOMSG_ON
+#ifdef BM_NANOMSG_ON
 
 // is here because DevMgr has a protected destructor
 class PacketInSwitch : public DevMgr { };
@@ -445,7 +446,7 @@ TEST_F(PacketInDevMgrPortStatusTest, Status) {
   check_and_reset_counts(0u, 1u, 0u, 0u);
 }
 
-#endif  // BMNANOMSG_ON
+#endif  // BM_NANOMSG_ON
 
 struct PMActive { };
 struct PMPassive { };

--- a/tests/test_tables.cpp
+++ b/tests/test_tables.cpp
@@ -2946,7 +2946,7 @@ extern bool WITH_VALGRIND;  // defined in main.cpp
 
 // used to fail because of deadlock in dump_entry_string (when called from
 // apply_action); could only be observed when bmv2 was compiled with
-// -DBMLOG_DEBUG_ON
+// BM_LOG_DEBUG_ON defined
 TEST_F(TableDeadlock, DumpEntryString) {
   auto modify_loop = [this](size_t iters, entry_handle_t handle) {
     for (size_t i = 0; i < iters; i++) {


### PR DESCRIPTION
Ideally we would not use custom #ifdef in headers at all but this is a
bigger project for the future...

the bmv2 library with BMDEBUG_ON defined but within a separate project
(simple_switch_grpc) without BMDEBUG_ON defined, which was causing the
bm::Field class to have a different layout in the library and in the
application. This was causing different segfaults based on the other
preprocessor flags and compiler flags used and was difficult to diagnose
(wasn't caught by Valgrind).

To avoid this issue, we now rely on the config.h file generated from
configure.ac. This file needs to be installed because it is required by
installed bmv2 headers. To avoid interfering with other libraries, we
use AX_PREFIX_CONFIG_H to install config.h under @includedir@/bm and to
prefix all defined macros with BM_.

Fixes #715