### PR TITLE
Fix ingress thread deadlock for resubmit packets

### DIFF
--- a/include/bm/bm_sim/queueing.h
+++ b/include/bm/bm_sim/queueing.h
@@ -397,9 +397,9 @@ class QueueingLogicRL {
 //! high priority can starve lower-priority queues. For example, if the queue
 //! with priority `0` always contains at least one element, the other queues
 //! will never be served.
-//! As for QueueingLogicRL, the write behavior (push_front()) is blocking: once
-//! a logical queue is full, subsequent incoming elements will be dropped until
-//! the queue starts draining again.
+//! As for QueueingLogicRL, the write behavior (push_front()) is not blocking:
+//! once a logical queue is full, subsequent incoming elements will be dropped
+//! until the queue starts draining again.
 //! Look at the documentation for QueueingLogic for more information about the
 //! template parameters (they are the same).
 template <typename T, typename FMap>

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -126,6 +126,8 @@ class SimpleSwitch : public Switch {
 
   class MirroringSessions;
 
+  class InputBuffer;
+
   enum PktInstanceType {
     PKT_INSTANCE_TYPE_NORMAL,
     PKT_INSTANCE_TYPE_INGRESS_CLONE,
@@ -169,7 +171,9 @@ class SimpleSwitch : public Switch {
  private:
   port_t max_port;
   std::vector<std::thread> threads_;
-  Queue<std::unique_ptr<Packet> > input_buffer;
+  std::unique_ptr<InputBuffer> input_buffer;
+  // for these queues, the write operation is non-blocking and we drop the
+  // packet if the queue is full
 #ifdef SSWITCH_PRIORITY_QUEUEING_ON
   bm::QueueingLogicPriRL<std::unique_ptr<Packet>, EgressThreadMapper>
 #else


### PR DESCRIPTION
Resubmit packets were written to the input_buffer with a blocking call
by the ingress thread. Since the ingress thread is also in charge of
draining the input_buffer, this could have lead to a deadlock. Resubmit
packets can now be dropped if the buffer is full. To limit the number of
resubmit packets being lost, we place them is a higher priority queue
than "normal" packets.

Fixes #729