### PR TITLE
Fix shared pointer conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You also need to install the following from source. Feel free to use the
 install scripts under travis/.
 
 - [thrift 0.9.2](https://github.com/apache/thrift/releases/tag/0.9.2) or later
+  (up to 0.12.1)
 - [nanomsg 1.0.0](https://github.com/nanomsg/nanomsg/releases/tag/1.0.0) or
   later
 

--- a/include/bm/bm_apps/learn.h
+++ b/include/bm/bm_apps/learn.h
@@ -21,8 +21,6 @@
 #ifndef BM_BM_APPS_LEARN_H_
 #define BM_BM_APPS_LEARN_H_
 
-#include <boost/shared_ptr.hpp>
-
 #include <string>
 #include <functional>
 #include <memory>
@@ -71,7 +69,7 @@ class LearnListener {
 
   void ack_buffer(cxt_id_t cxt_id, list_id_t list_id, buffer_id_t buffer_id);
 
-  boost::shared_ptr<bm_runtime::standard::StandardClient> get_client() {
+  std::shared_ptr<bm_runtime::standard::StandardClient> get_client() {
     return bm_client;
   }
 
@@ -87,7 +85,7 @@ class LearnListener {
   std::thread listen_thread{};
   bool stop_listen_thread{false};
   mutable std::mutex mutex{};
-  boost::shared_ptr<bm_runtime::standard::StandardClient> bm_client{nullptr};
+  std::shared_ptr<bm_runtime::standard::StandardClient> bm_client{nullptr};
 };
 
 }  // namespace bm_apps

--- a/include/bm/thrift/stdcxx.h
+++ b/include/bm/thrift/stdcxx.h
@@ -3,6 +3,12 @@
 
 #include <bm/config.h>
 
+#ifdef BM_P4THRIFT
+namespace thrift_provider = p4::thrift;
+#else
+namespace thrift_provider = apache::thrift;
+#endif
+
 #ifdef BM_HAVE_THRIFT_STDCXX_H
 #include <thrift/stdcxx.h>
 namespace stdcxx = thrift_provider::stdcxx;

--- a/pdfixed/Makefile.am
+++ b/pdfixed/Makefile.am
@@ -154,10 +154,6 @@ AM_CPPFLAGS += -I$(srcdir)/include
 AM_CPPFLAGS += -I$(top_srcdir)/include
 AM_CPPFLAGS += -I$(builddir)/pd_thrift_gen/gen-cpp/
 
-if P4THRIFT
-    AM_CPPFLAGS += -DP4THRIFT
-endif
-
 CLEANFILES = $(BUILT_SOURCES) \
 pdfixed_thrift_files.ts \
 pd_thrift_gen/gen-cpp/mc_server.skeleton.cpp \

--- a/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
+++ b/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
@@ -21,7 +21,9 @@
 #ifndef BM_PDFIXED_INT_PD_CONN_MGR_H_
 #define BM_PDFIXED_INT_PD_CONN_MGR_H_
 
-#ifdef P4THRIFT
+#include <bm/config.h>
+
+#ifdef BM_P4THRIFT
 #include <p4thrift/protocol/TBinaryProtocol.h>
 #include <p4thrift/transport/TSocket.h>
 #include <p4thrift/transport/TTransportUtils.h>
@@ -35,6 +37,13 @@ namespace thrift_provider = p4::thrift;
 #include <thrift/protocol/TMultiplexedProtocol.h>
 
 namespace thrift_provider = apache::thrift;
+#endif
+
+#ifdef BM_HAVE_THRIFT_STDCXX_H
+#include <thrift/stdcxx.h>
+namespace stdcxx = thrift_provider::stdcxx;
+#else
+namespace stdcxx = boost;
 #endif
 
 #include <mutex>
@@ -74,7 +83,8 @@ struct ClientState {
   std::mutex mutex{};
   std::vector<void *> ptrs{};
   int dev_id{};
-  boost::shared_ptr<::thrift_provider::protocol::TTransport> transport{nullptr};
+  ::stdcxx::shared_ptr<::thrift_provider::protocol::TTransport>
+  transport{nullptr};
 };
 
 }  // namespace detail
@@ -119,12 +129,12 @@ struct Connector<A, Args...> {
     using namespace ::thrift_provider::protocol;  // NOLINT(build/namespaces)
     using namespace ::thrift_provider::transport;  // NOLINT(build/namespaces)
 
-    boost::shared_ptr<TTransport> socket(
+    ::stdcxx::shared_ptr<TTransport> socket(
         new TSocket("localhost", thrift_port_num));
-    boost::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
-    boost::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
+    ::stdcxx::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
+    ::stdcxx::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
 
-    boost::shared_ptr<TMultiplexedProtocol> sub_protocol(
+    ::stdcxx::shared_ptr<TMultiplexedProtocol> sub_protocol(
         new TMultiplexedProtocol(protocol, *it));
 
     cstate->transport = transport;

--- a/pdfixed/thrift-src/pdfixed_rpc_server.cpp
+++ b/pdfixed/thrift-src/pdfixed_rpc_server.cpp
@@ -1,4 +1,6 @@
-#ifdef P4THRIFT
+#include <bm/config.h>
+
+#ifdef BM_P4THRIFT
 #include <p4thrift/protocol/TBinaryProtocol.h>
 #include <p4thrift/server/TSimpleServer.h>
 #include <p4thrift/server/TThreadedServer.h>
@@ -18,12 +20,19 @@ namespace thrift_provider = p4::thrift;
 namespace thrift_provider = apache::thrift;
 #endif
 
+#ifdef BM_HAVE_THRIFT_STDCXX_H
+#include <thrift/stdcxx.h>
+namespace stdcxx = thrift_provider::stdcxx;
+#else
+namespace stdcxx = boost;
+#endif
+
 using namespace ::thrift_provider;
 using namespace ::thrift_provider::protocol;
 using namespace ::thrift_provider::transport;
 using namespace ::thrift_provider::server;
 
-using boost::shared_ptr;
+using ::stdcxx::shared_ptr;
 
 #include <pthread.h>
 

--- a/src/bm_apps/learn.cpp
+++ b/src/bm_apps/learn.cpp
@@ -44,6 +44,7 @@ namespace thrift_provider = apache::thrift;
 #include <nanomsg/pubsub.h>
 
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include <cassert>
@@ -115,7 +116,7 @@ LearnListener::start() {
   shared_ptr<TMultiplexedProtocol> standard_protocol(
       new TMultiplexedProtocol(protocol, "standard"));
 
-  bm_client = boost::shared_ptr<runtime::StandardClient>(
+  bm_client = std::shared_ptr<runtime::StandardClient>(
       new runtime::StandardClient(standard_protocol));
 
   transport->open();

--- a/src/bm_runtime/SimplePreLAG_server.cpp
+++ b/src/bm_runtime/SimplePreLAG_server.cpp
@@ -23,6 +23,7 @@
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/simple_pre_lag.h>
 #include <bm/bm_sim/logger.h>
+#include <bm/thrift/stdcxx.h>
 
 namespace bm_runtime { namespace simple_pre_lag {
 
@@ -142,8 +143,9 @@ private:
   std::vector<std::shared_ptr<McSimplePreLAG> > pres{};
 };
 
-boost::shared_ptr<SimplePreLAGIf> get_handler(SwitchWContexts *switch_) {
-  return boost::shared_ptr<SimplePreLAGHandler>(new SimplePreLAGHandler(switch_));
+::stdcxx::shared_ptr<SimplePreLAGIf> get_handler(SwitchWContexts *switch_) {
+  return ::stdcxx::shared_ptr<SimplePreLAGHandler>(
+      new SimplePreLAGHandler(switch_));
 }
 
 }  // namespace simple_pre_lag

--- a/src/bm_runtime/SimplePre_server.cpp
+++ b/src/bm_runtime/SimplePre_server.cpp
@@ -23,6 +23,7 @@
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/simple_pre.h>
 #include <bm/bm_sim/logger.h>
+#include <bm/thrift/stdcxx.h>
 
 namespace bm_runtime { namespace simple_pre {
 
@@ -128,8 +129,8 @@ private:
   std::vector<std::shared_ptr<McSimplePre> > pres{};
 };
 
-boost::shared_ptr<SimplePreIf> get_handler(SwitchWContexts *switch_) {
-  return boost::shared_ptr<SimplePreHandler>(new SimplePreHandler(switch_));
+::stdcxx::shared_ptr<SimplePreIf> get_handler(SwitchWContexts *switch_) {
+  return ::stdcxx::shared_ptr<SimplePreHandler>(new SimplePreHandler(switch_));
 }
 
 }  // namespace simple_pre

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -23,6 +23,7 @@
 #include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/switch.h>
+#include <bm/thrift/stdcxx.h>
 
 #include <functional>
 
@@ -1269,8 +1270,8 @@ void StandardHandler::copy_one_group(
   for (const auto h : from.mbr_handles) g->mbr_handles.push_back(h);
 }
 
-boost::shared_ptr<StandardIf> get_handler(SwitchWContexts *switch_) {
-  return boost::shared_ptr<StandardHandler>(new StandardHandler(switch_));
+::stdcxx::shared_ptr<StandardIf> get_handler(SwitchWContexts *switch_) {
+  return ::stdcxx::shared_ptr<StandardHandler>(new StandardHandler(switch_));
 }
 
 }  // namespace standard

--- a/targets/l2_switch/learn_client/learn_client.cpp
+++ b/targets/l2_switch/learn_client/learn_client.cpp
@@ -48,7 +48,7 @@ void learn_cb(const bm_apps::LearnListener::MsgInfo &msg_info,
   (void) cookie;
   std::cout << "CB with " << msg_info.num_samples << " samples\n";
 
-  boost::shared_ptr<runtime::StandardClient> client = listener->get_client();
+  auto client = listener->get_client();
   assert(client);
 
   for (unsigned int i = 0; i < msg_info.num_samples; i++) {

--- a/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
+++ b/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
@@ -39,6 +39,7 @@ namespace thrift_provider = apache::thrift;
 
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/logger.h>
+#include <bm/thrift/stdcxx.h>
 
 #include "psa_switch.h"
 
@@ -110,8 +111,8 @@ class PsaSwitchHandler : virtual public PsaSwitchIf {
   PsaSwitch *switch_;
 };
 
-boost::shared_ptr<PsaSwitchIf> get_handler(PsaSwitch *sw) {
-  return boost::shared_ptr<PsaSwitchHandler>(new PsaSwitchHandler(sw));
+stdcxx::shared_ptr<PsaSwitchIf> get_handler(PsaSwitch *sw) {
+  return stdcxx::shared_ptr<PsaSwitchHandler>(new PsaSwitchHandler(sw));
 }
 
 }  // namespace pswitch_runtime

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -39,6 +39,7 @@ namespace thrift_provider = apache::thrift;
 
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/logger.h>
+#include <bm/thrift/stdcxx.h>
 
 #include "simple_switch.h"
 
@@ -153,8 +154,8 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
   SimpleSwitch *switch_;
 };
 
-boost::shared_ptr<SimpleSwitchIf> get_handler(SimpleSwitch *sw) {
-  return boost::shared_ptr<SimpleSwitchHandler>(new SimpleSwitchHandler(sw));
+stdcxx::shared_ptr<SimpleSwitchIf> get_handler(SimpleSwitch *sw) {
+  return stdcxx::shared_ptr<SimpleSwitchHandler>(new SimpleSwitchHandler(sw));
 }
 
 }  // namespace sswitch_runtime


### PR DESCRIPTION
And more generally, remove all references to boost::shared_ptr for
objects returned by the Thrift library. Instead use stdcxx::shared_ptr,
where stdcxx depends on the Thrift version (boost or std).

Fixes #732