### PR TITLE
add psa metadata requirements for psa_switch startup

### DIFF
--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -90,16 +90,37 @@ PsaSwitch::PsaSwitch(port_t max_port, bool enable_swap)
     start(clock::now()) {
   add_component<McSimplePreLAG>(pre);
 
-  add_required_field("standard_metadata", "ingress_port");
-  add_required_field("standard_metadata", "packet_length");
-  add_required_field("standard_metadata", "instance_type");
-  add_required_field("standard_metadata", "egress_spec");
-  add_required_field("standard_metadata", "clone_spec");
-  add_required_field("standard_metadata", "egress_port");
+  add_required_field("psa_ingress_parser_input_metadata", "ingress_port");
+  add_required_field("psa_ingress_parser_input_metadata", "packet_path");
 
-  force_arith_header("standard_metadata");
-  force_arith_header("queueing_metadata");
-  force_arith_header("intrinsic_metadata");
+  add_required_field("psa_ingress_input_metadata", "ingress_port");
+  add_required_field("psa_ingress_input_metadata", "packet_path");
+  add_required_field("psa_ingress_input_metadata", "ingress_timestamp");
+  add_required_field("psa_ingress_input_metadata", "parser_error");
+
+  add_required_field("psa_ingress_output_metadata", "class_of_service");
+  add_required_field("psa_ingress_output_metadata", "clone");
+  add_required_field("psa_ingress_output_metadata", "clone_session_id");
+  add_required_field("psa_ingress_output_metadata", "drop");
+  add_required_field("psa_ingress_output_metadata", "resubmit");
+  add_required_field("psa_ingress_output_metadata", "multicast_group");
+  add_required_field("psa_ingress_output_metadata", "egress_port");
+
+  add_required_field("psa_egress_parser_input_metadata", "egress_port");
+  add_required_field("psa_egress_parser_input_metadata", "packet_path");
+
+  add_required_field("psa_egress_input_metadata", "class_of_service");
+  add_required_field("psa_egress_input_metadata", "egress_port");
+  add_required_field("psa_egress_input_metadata", "packet_path");
+  add_required_field("psa_egress_input_metadata", "instance");
+  add_required_field("psa_egress_input_metadata", "egress_timestamp");
+  add_required_field("psa_egress_input_metadata", "parser_error");
+
+  add_required_field("psa_egress_output_metadata", "clone");
+  add_required_field("psa_egress_output_metadata", "clone_session_id");
+  add_required_field("psa_egress_output_metadata", "drop");
+
+  add_required_field("psa_egress_deparser_input_metadata", "egress_port");
 
   import_primitives();
 }


### PR DESCRIPTION
changelog:
- remove v1model metadata header requirements from `psa_switch.cpp`
- add psa metadata header requirements to `psa_switch.cpp`