### PR TITLE
Added support for assert and assume primitives in bm_sim

### DIFF
--- a/include/bm/bm_sim/_assert.h
+++ b/include/bm/bm_sim/_assert.h
@@ -22,10 +22,13 @@
 #define BM_BM_SIM__ASSERT_H_
 
 // An assert that cannot be removed with NDEBUG
+#include <bm/bm_sim/source_info.h>
 
 namespace bm {
 
 [[ noreturn ]] void _assert(const char* expr, const char* file, int line);
+
+void error_message(const char* error_msg, const SourceInfo* srcInfo);
 
 }  // namespace bm
 

--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -535,6 +535,10 @@ class ActionPrimitive_ {
     this->p4objects = p4objects;
   }
 
+  void set_source_info(SourceInfo* source_info) {
+    srcInfo = source_info;
+  }
+
  protected:
   // This used to be regular members in ActionPrimitive, but there could be a
   // race condition. Making them thread_local solves the issue. I moved these
@@ -543,7 +547,7 @@ class ActionPrimitive_ {
   // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60056).
   static thread_local Packet *pkt;
   static thread_local PHV *phv;
-
+  SourceInfo* srcInfo = nullptr;
   P4Objects *get_p4objects() {
     return p4objects;
   }

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -255,6 +255,14 @@ class ParseState : public NamedP4Object {
   void add_verify(const BoolExpression &condition,
                   const ArithExpression &error_expr);
 
+  void add_assert(const BoolExpression& condition,
+                  const std::string& error_expr,
+                  std::unique_ptr<SourceInfo> src_info);
+
+  void add_assume(const BoolExpression& cond,
+                  const std::string& error_expr,
+                  std::unique_ptr<SourceInfo> src_info);
+
   void add_method_call(ActionFn *action_fn);
 
   void add_shift(size_t shift_bytes);

--- a/include/bm/bm_sim/parser_error.h
+++ b/include/bm/bm_sim/parser_error.h
@@ -78,7 +78,11 @@ class ErrorCodeMap {
     //! Extracting too many bits into a varbit field (unused for now)
     HeaderTooShort,
     //! Parser execution time limit exceeded (unused for now)
-    ParserTimeout
+    ParserTimeout,
+    //! Assert failure when boolean expression = false
+    AssertError,
+    //! Assume failure when boolean expression = true
+    AssumeError
   };
 
   bool add(const std::string &name, ErrorCode::type_t v);

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1168,6 +1168,24 @@ P4Objects::init_parsers(const Json::Value &cfg_root, InitState *init_state) {
           }
           error_expr.build();
           parse_state->add_verify(cond_expr, error_expr);
+        } else if (op_type == "assert") {
+          check_json_tuple_size(cfg_parser_op, "parameters", 1);
+          BoolExpression cond_expr;
+          build_expression(cfg_parameters[0], &cond_expr);
+          cond_expr.build();
+          auto error_code = error_codes.from_core(
+                            ErrorCodeMap::Core::AssertError);
+          parse_state->add_assert(cond_expr, error_codes.to_name(error_code),
+                                  object_source_info(cfg_parser_op));
+        } else if (op_type == "assume") {
+          check_json_tuple_size(cfg_parser_op, "parameters", 1);
+          BoolExpression cond_expr;
+          build_expression(cfg_parameters[0], &cond_expr);
+          cond_expr.build();
+          auto error_code = error_codes.from_core(
+                            ErrorCodeMap::Core::AssumeError);
+          parse_state->add_assume(cond_expr, error_codes.to_name(error_code),
+                                  object_source_info(cfg_parser_op));
         } else if (op_type == "primitive") {
           check_json_tuple_size(cfg_parser_op, "parameters", 1);
           const auto primitive_name = cfg_parameters[0]["op"].asString();

--- a/src/bm_sim/_assert.cpp
+++ b/src/bm_sim/_assert.cpp
@@ -31,4 +31,12 @@ void _assert(const char* expr, const char* file, int line) {
   std::abort();
 }
 
+void error_message(const char* error_msg, const SourceInfo* srcInfo) {
+    if (srcInfo != nullptr) {
+        std::cerr << error_msg << ": '" << srcInfo->get_source_fragment()
+        << "' failed, file '" << srcInfo->get_filename()
+        << "' line '" << srcInfo->get_line() << "'.\n";
+    }
+}
+
 }  // namespace bm

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -283,6 +283,9 @@ void
 ActionPrimitiveCall::execute(ActionEngineState *state,
                              const ActionParam *args) const {
   // TODO(unknown): log source info?
+  if (source_info != nullptr) {
+    primitive->set_source_info(source_info.get());
+  }
   primitive->execute(state, args);
 }
 

--- a/src/bm_sim/core/primitives.cpp
+++ b/src/bm_sim/core/primitives.cpp
@@ -19,6 +19,8 @@
  */
 
 #include <bm/bm_sim/core/primitives.h>
+#include <include/bm/bm_sim/parser_error.h>
+#include <include/bm/bm_sim/P4Objects.h>
 
 namespace bm {
 

--- a/src/bm_sim/parser_error.cpp
+++ b/src/bm_sim/parser_error.cpp
@@ -58,7 +58,8 @@ ErrorCodeMap::add_core() {
   // TODO(antonin): write an iterator for Core enum class instead
   for (const auto core : {Core::NoError, Core::PacketTooShort, Core::NoMatch,
                           Core::StackOutOfBounds, Core::HeaderTooShort,
-                          Core::ParserTimeout}) {
+                          Core::ParserTimeout, Core::AssertError,
+                          Core::AssumeError}) {
     auto name = core_to_name(core);
     if (!exists(name)) add(name, max_v++);
   }
@@ -102,6 +103,10 @@ ErrorCodeMap::core_to_name(const Core &core) {
       return "HeaderTooShort";
     case Core::ParserTimeout:
       return "ParserTimeout";
+    case Core::AssertError:
+      return "AssertError";
+    case Core::AssumeError:
+      return "AssumeError";
   }
   // unreachable but gcc complains without it
   assert(0);

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -26,6 +26,8 @@
 #include <bm/bm_sim/packet.h>
 #include <bm/bm_sim/phv.h>
 #include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/parser_error.h>
+#include <bm/bm_sim/P4Objects.h>
 
 #include <random>
 #include <thread>
@@ -41,6 +43,7 @@ using bm::CounterArray;
 using bm::RegisterArray;
 using bm::NamedCalculation;
 using bm::HeaderStack;
+using bm::ErrorCodeMap;
 
 class modify_field : public ActionPrimitive<Data &, const Data &> {
   void operator ()(Data &dst, const Data &src) {
@@ -141,6 +144,8 @@ class shift_right :
 REGISTER_PRIMITIVE(shift_right);
 
 class drop : public ActionPrimitive<> {
+  friend class assert_;
+  friend class assume_;
   void operator ()() {
     get_field("standard_metadata.egress_spec").set(511);
     if (get_phv().has_field("intrinsic_metadata.mcast_grp")) {
@@ -397,6 +402,36 @@ class truncate_ : public ActionPrimitive<const Data &> {
 };
 
 REGISTER_PRIMITIVE_W_NAME("truncate", truncate_);
+
+class assert_ : public ActionPrimitive<const Data &> {
+  void operator ()(const Data& src) {
+    if (src.test_eq(0)) {
+      auto error_code_map = get_p4objects()->get_error_codes();
+      auto error_code = error_code_map.from_core(
+                        ErrorCodeMap::Core::AssertError);
+      error_message(error_code_map.to_name(error_code).c_str(), srcInfo);
+      get_packet().mark_for_exit();
+      drop()();
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_W_NAME("assert", assert_);
+
+class assume_ : public ActionPrimitive<const Data &> {
+  void operator ()(const Data& src) {
+    if (src.test_eq(1)) {
+      auto error_code_map = get_p4objects()->get_error_codes();
+      auto error_code = error_code_map.from_core(
+                        ErrorCodeMap::Core::AssumeError);
+      error_message(error_code_map.to_name(error_code).c_str(), srcInfo);
+      get_packet().mark_for_exit();
+      drop()();
+    }
+  }
+};
+
+REGISTER_PRIMITIVE_W_NAME("assume", assume_);
 
 // dummy function, which ensures that this unit is not discarded by the linker
 // it is being called by the constructor of SimpleSwitch


### PR DESCRIPTION
* In simulation, if condition of assert evaluates to false,
assert error message will be printed and packet will be dropped

* If condition of assume evaluates to true, assume error message
will be printed and packet will be dropped

Signed-off-by: Enisa Hadzic <enisa.hadzic@rt-rk.com>