### PR TITLE
Custom drop port for simple_switch and simple_switch_grpc

### DIFF
--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -52,16 +52,17 @@ Here are the fields:
   recirculated packets, the length of the packet in bytes.  For cloned
   or resubmitted packets, you may need to include this in a list of
   fields to preserve, otherwise its value will become 0.
-- `egress_spec` (sm14, v1m) - Can be assigned a value in ingress code
-  to control which output port a packet will go to.  The P4_14
-  primitive `drop`, and the v1model primitive action `mark_to_drop`,
-  have the side effect of assigning an implementation specific value
-  to this field (511 decimal for simple_switch), such that if
+- `egress_spec` (sm14, v1m) - Can be assigned a value in ingress code to
+  control which output port a packet will go to.  The P4_14 primitive
+  `drop`, and the v1model primitive action `mark_to_drop`, have the side
+  effect of assigning an implementation specific value to this field
+  (511 decimal for simple_switch by default, but can be changed through
+  the `--drop-port` target-specific command-line option), such that if
   `egress_spec` has that value at the end of ingress processing, the
   packet will be dropped and not stored in the packet buffer, nor sent
-  to egress processing.  See the "after-ingress pseudocode" for
-  relative priority of this vs. other possible packet operations at
-  end of ingress.
+  to egress processing.  See the "after-ingress pseudocode" for relative
+  priority of this vs. other possible packet operations at end of
+  ingress.
 - `egress_port` (sm14, v1m) - Only intended to be accessed during
   egress processing, read only.  The output port this packet is
   destined to.

--- a/targets/simple_switch/bm/simple_switch/runner.h
+++ b/targets/simple_switch/bm/simple_switch/runner.h
@@ -36,7 +36,10 @@ namespace sswitch {
 
 class SimpleSwitchRunner {
  public:
-  explicit SimpleSwitchRunner(uint32_t cpu_port = 0);
+  static constexpr uint32_t default_drop_port = 511;
+
+  explicit SimpleSwitchRunner(uint32_t cpu_port = 0,
+                              uint32_t drop_port = default_drop_port);
   ~SimpleSwitchRunner();
 
   int init_and_start(const bm::OptionsParser &parser);

--- a/targets/simple_switch/runner.cpp
+++ b/targets/simple_switch/runner.cpp
@@ -38,9 +38,12 @@ namespace bm {
 
 namespace sswitch {
 
-SimpleSwitchRunner::SimpleSwitchRunner(uint32_t cpu_port)
+/* static */
+constexpr uint32_t SimpleSwitchRunner::default_drop_port;
+
+SimpleSwitchRunner::SimpleSwitchRunner(uint32_t cpu_port, uint32_t drop_port)
     : cpu_port(cpu_port),
-      simple_switch(new SimpleSwitch(true /* enable_swap */)) { }
+      simple_switch(new SimpleSwitch(true /* enable_swap */, drop_port)) { }
 
 SimpleSwitchRunner::~SimpleSwitchRunner() = default;
 

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -78,12 +78,15 @@ class SimpleSwitch : public Switch {
     bool mgid_valid;
   };
 
+  static constexpr port_t default_drop_port = 511;
+
  private:
   using clock = std::chrono::high_resolution_clock;
 
  public:
   // by default, swapping is off
-  explicit SimpleSwitch(bool enable_swap = false);
+  explicit SimpleSwitch(bool enable_swap = false,
+                        port_t drop_port = default_drop_port);
 
   ~SimpleSwitch();
 
@@ -119,6 +122,15 @@ class SimpleSwitch : public Switch {
   }
 
   void set_transmit_fn(TransmitFn fn);
+
+  port_t get_drop_port() const {
+    return drop_port;
+  }
+
+  SimpleSwitch(const SimpleSwitch &) = delete;
+  SimpleSwitch &operator =(const SimpleSwitch &) = delete;
+  SimpleSwitch(SimpleSwitch &&) = delete;
+  SimpleSwitch &&operator =(SimpleSwitch &&) = delete;
 
  private:
   static constexpr size_t nb_egress_threads = 4u;
@@ -169,6 +181,7 @@ class SimpleSwitch : public Switch {
   void multicast(Packet *packet, unsigned int mgid);
 
  private:
+  port_t drop_port;
   std::vector<std::thread> threads_;
   std::unique_ptr<InputBuffer> input_buffer;
   // for these queues, the write operation is non-blocking and we drop the

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -36,8 +36,11 @@ main(int argc, char* argv[]) {
       "bind gRPC server to given address [default is 0.0.0.0:50051]");
   simple_switch_parser.add_uint_option(
       "cpu-port",
-      "set non-zero CPU port, will be used for packet-in / packet-out; "
+      "set CPU port, will be used for packet-in / packet-out; "
       "do not add an interface with this port number");
+  simple_switch_parser.add_uint_option(
+      "drop-port",
+      "choose drop port number (default is 511)");
   simple_switch_parser.add_string_option(
       "dp-grpc-server-addr",
       "use a gRPC channel to inject and receive dataplane packets; "
@@ -72,12 +75,21 @@ main(int argc, char* argv[]) {
       std::exit(1);
   }
 
-  uint32_t cpu_port = 0xFFFFFFFF;
+  uint32_t cpu_port = 0xffffffff;
   {
     auto rc = simple_switch_parser.get_uint_option("cpu-port", &cpu_port);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       cpu_port = 0;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port == 0)
+      std::exit(1);
+  }
+
+  uint32_t drop_port = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option("drop-port", &drop_port);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      drop_port = sswitch_grpc::SimpleSwitchGrpcRunner::default_drop_port;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
   }
 

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -474,11 +474,13 @@ class NotificationsCapture : public bm::TransportIface {
 };
 
 
-SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(bool enable_swap,
-                                               std::string grpc_server_addr,
-                                               bm::DevMgrIface::port_t cpu_port,
-                                               std::string dp_grpc_server_addr)
-    : simple_switch(new SimpleSwitch(enable_swap)),
+SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(
+    bool enable_swap,
+    std::string grpc_server_addr,
+    bm::DevMgrIface::port_t cpu_port,
+    std::string dp_grpc_server_addr,
+    bm::DevMgrIface::port_t drop_port)
+    : simple_switch(new SimpleSwitch(enable_swap, drop_port)),
       grpc_server_addr(grpc_server_addr), cpu_port(cpu_port),
       dp_grpc_server_addr(dp_grpc_server_addr),
       dp_service(nullptr),

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -48,15 +48,19 @@ class DataplaneInterfaceServiceImpl;
 
 class SimpleSwitchGrpcRunner {
  public:
+  static constexpr bm::DevMgrIface::port_t default_drop_port = 511;
+
   // there is no real need for a singleton here, except for the fact that we use
   // PIGrpcServerRunAddr, ... which uses static state
   static SimpleSwitchGrpcRunner &get_instance(
       bool enable_swap = false,
       std::string grpc_server_addr = "0.0.0.0:50051",
       bm::DevMgrIface::port_t cpu_port = 0,
-      std::string dp_grpc_server_addr = "") {
+      std::string dp_grpc_server_addr = "",
+      bm::DevMgrIface::port_t drop_port = default_drop_port) {
     static SimpleSwitchGrpcRunner instance(
-        enable_swap, grpc_server_addr, cpu_port, dp_grpc_server_addr);
+        enable_swap, grpc_server_addr, cpu_port, dp_grpc_server_addr,
+        drop_port);
     return instance;
   }
 
@@ -77,7 +81,8 @@ class SimpleSwitchGrpcRunner {
   SimpleSwitchGrpcRunner(bool enable_swap = false,
                          std::string grpc_server_addr = "0.0.0.0:50051",
                          bm::DevMgrIface::port_t cpu_port = 0,
-                         std::string dp_grpc_server_addr = "");
+                         std::string dp_grpc_server_addr = "",
+                         bm::DevMgrIface::port_t drop_port = default_drop_port);
   ~SimpleSwitchGrpcRunner();
 
   void port_status_cb(bm::DevMgrIface::port_t port,


### PR DESCRIPTION
Ability to provide custom drop port value (used for implementation of
drop and mark_to_drop primitives).