### PR TITLE
Remove --with-p4thrift configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,28 +134,13 @@ AC_LANG_PUSH(C)
 AC_LANG_PUSH(C++)
 
 # Thrift
-want_p4thrift=no
-AC_ARG_WITH([p4thrift],
-    AS_HELP_STRING([--with-p4thrift], [Use p4lang version of Thrift]),
-    [want_p4thrift=yes], [])
-
-AS_IF([test "$want_thrift" = no && test "$want_p4thrift" = yes],
-    [AC_MSG_ERROR(cannot use --with-p4thrift if Thrift is disabled)])
-
 AS_IF([test "$want_thrift" = no && test "$want_pdfixed" = yes],
     [AC_MSG_ERROR(cannot use --with-pdfixed if Thrift is disabled)])
 
 AS_IF([test "$want_thrift" = yes], [
-    AS_IF([test "$want_p4thrift" = yes], [
-        AC_PATH_PROG([THRIFT], [p4thrift], [])
-        AC_SUBST([THRIFT_LIB], ["-lp4thrift"])
-        AC_DEFINE([P4THRIFT], [], [Use P4.org Thrift fork])
-        AC_CHECK_HEADER([p4thrift/P4Thrift.h], [], [AC_MSG_ERROR([P4Thrift headers not found. Install P4Thrift from http://github.com/p4lang/thrift/])])
-    ], [
-        AC_PATH_PROG([THRIFT], [thrift], [])
-        AC_SUBST([THRIFT_LIB], ["-lthrift"])
-        AC_CHECK_HEADER([thrift/Thrift.h], [], [AC_MSG_ERROR([Thrift headers not found. Install Thrift from http://thrift.apache.org/docs/install/])])
-    ])
+    AC_PATH_PROG([THRIFT], [thrift], [])
+    AC_SUBST([THRIFT_LIB], ["-lthrift"])
+    AC_CHECK_HEADER([thrift/Thrift.h], [], [AC_MSG_ERROR([Thrift headers not found. Install Thrift from http://thrift.apache.org/docs/install/])])
     AS_IF([test x"$THRIFT" = x], [AC_MSG_ERROR([cannot find thrift])])
     AC_DEFINE([THRIFT_ON], [], [Enable Thrift support])
     AC_CHECK_HEADER([thrift/stdcxx.h], [
@@ -168,8 +153,6 @@ AS_IF([test "$want_pi" = yes], [
     AC_CHECK_HEADERS([PI/pi.h PI/target/pi_imp.h PI/p4info.h], [],
                      [AC_MSG_ERROR([Cannot find PI headers, did you install $PI_url])])
 ])
-
-AM_CONDITIONAL([P4THRIFT], [test "$want_p4thrift" = yes])
 
 AC_CHECK_HEADERS([algorithm array cassert cmath queue \
 cstdio string sys/stat.h sys/types.h ctime tuple unistd.h unordered_map \
@@ -320,8 +303,5 @@ AS_ECHO("With Nanomsg .................. : $want_nanomsg")
 AS_ECHO("Event logger enabled .......... : $elogger_enabled")
 AS_ECHO("Debugger enabled .............. : $debugger_enabled")
 AS_ECHO("With Thrift ................... : $want_thrift")
-AS_IF([test "$want_thrift" = yes], [
-AS_ECHO("  With p4Thrift ............... : $want_p4thrift")
-])
 AS_ECHO("With pdfixed .................. : $want_pdfixed")
 AS_ECHO("With PI ....................... : $want_pi")

--- a/include/bm/bm_runtime/bm_runtime.h
+++ b/include/bm/bm_runtime/bm_runtime.h
@@ -1,18 +1,9 @@
 #ifndef _BM_RUNTIME_BM_RUNTIME_H_
 #define _BM_RUNTIME_BM_RUNTIME_H_
 
-#include <bm/config.h>
-
-#ifdef BM_P4THRIFT
-#include <p4thrift/processor/TMultiplexedProcessor.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/processor/TMultiplexedProcessor.h>
 
-namespace thrift_provider = apache::thrift;
-#endif
-
+#include <bm/config.h>
 #include <bm/bm_sim/switch.h>
 #include <bm/thrift/stdcxx.h>
 

--- a/include/bm/thrift/stdcxx.h
+++ b/include/bm/thrift/stdcxx.h
@@ -3,11 +3,7 @@
 
 #include <bm/config.h>
 
-#ifdef BM_P4THRIFT
-namespace thrift_provider = p4::thrift;
-#else
 namespace thrift_provider = apache::thrift;
-#endif
 
 #ifdef BM_HAVE_THRIFT_STDCXX_H
 #include <thrift/stdcxx.h>

--- a/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
+++ b/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
@@ -23,21 +23,12 @@
 
 #include <bm/config.h>
 
-#ifdef BM_P4THRIFT
-#include <p4thrift/protocol/TBinaryProtocol.h>
-#include <p4thrift/transport/TSocket.h>
-#include <p4thrift/transport/TTransportUtils.h>
-#include <p4thrift/protocol/TMultiplexedProtocol.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportUtils.h>
 #include <thrift/protocol/TMultiplexedProtocol.h>
 
 namespace thrift_provider = apache::thrift;
-#endif
 
 #ifdef BM_HAVE_THRIFT_STDCXX_H
 #include <thrift/stdcxx.h>

--- a/pdfixed/thrift-src/pdfixed_rpc_server.cpp
+++ b/pdfixed/thrift-src/pdfixed_rpc_server.cpp
@@ -1,15 +1,5 @@
 #include <bm/config.h>
 
-#ifdef BM_P4THRIFT
-#include <p4thrift/protocol/TBinaryProtocol.h>
-#include <p4thrift/server/TSimpleServer.h>
-#include <p4thrift/server/TThreadedServer.h>
-#include <p4thrift/transport/TServerSocket.h>
-#include <p4thrift/transport/TBufferTransports.h>
-#include <p4thrift/processor/TMultiplexedProcessor.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/server/TThreadedServer.h>
@@ -18,7 +8,6 @@ namespace thrift_provider = p4::thrift;
 #include <thrift/processor/TMultiplexedProcessor.h>
 
 namespace thrift_provider = apache::thrift;
-#endif
 
 #ifdef BM_HAVE_THRIFT_STDCXX_H
 #include <thrift/stdcxx.h>

--- a/src/bm_apps/learn.cpp
+++ b/src/bm_apps/learn.cpp
@@ -20,21 +20,12 @@
 
 #include <bm/config.h>
 
-#ifdef BM_P4THRIFT
-#include <p4thrift/protocol/TBinaryProtocol.h>
-#include <p4thrift/transport/TSocket.h>
-#include <p4thrift/transport/TTransportUtils.h>
-#include <p4thrift/protocol/TMultiplexedProtocol.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportUtils.h>
 #include <thrift/protocol/TMultiplexedProtocol.h>
 
 namespace thrift_provider = apache::thrift;
-#endif
 
 #include <bm/bm_apps/learn.h>
 #include <bm/thrift/stdcxx.h>

--- a/src/bm_runtime/server.cpp
+++ b/src/bm_runtime/server.cpp
@@ -20,16 +20,6 @@
 
 #include <bm/config.h>
 
-#ifdef BM_P4THRIFT
-#include <p4thrift/protocol/TBinaryProtocol.h>
-#include <p4thrift/server/TSimpleServer.h>
-#include <p4thrift/server/TThreadedServer.h>
-#include <p4thrift/transport/TServerSocket.h>
-#include <p4thrift/transport/TBufferTransports.h>
-#include <p4thrift/processor/TMultiplexedProcessor.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/server/TThreadedServer.h>
@@ -38,7 +28,6 @@ namespace thrift_provider = p4::thrift;
 #include <thrift/processor/TMultiplexedProcessor.h>
 
 namespace thrift_provider = apache::thrift;
-#endif
 
 #include <iostream>
 #include <mutex>

--- a/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
+++ b/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
@@ -21,21 +21,12 @@
 #include <bm/config.h>
 #include <bm/PsaSwitch.h>
 
-#ifdef BM_P4THRIFT
-#include <p4thrift/protocol/TBinaryProtocol.h>
-#include <p4thrift/server/TThreadedServer.h>
-#include <p4thrift/transport/TServerSocket.h>
-#include <p4thrift/transport/TBufferTransports.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TBufferTransports.h>
 
 namespace thrift_provider = apache::thrift;
-#endif
 
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/logger.h>

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -21,21 +21,12 @@
 #include <bm/config.h>
 #include <bm/SimpleSwitch.h>
 
-#ifdef BM_P4THRIFT
-#include <p4thrift/protocol/TBinaryProtocol.h>
-#include <p4thrift/server/TThreadedServer.h>
-#include <p4thrift/transport/TServerSocket.h>
-#include <p4thrift/transport/TBufferTransports.h>
-
-namespace thrift_provider = p4::thrift;
-#else
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TBufferTransports.h>
 
 namespace thrift_provider = apache::thrift;
-#endif
 
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/logger.h>


### PR DESCRIPTION
Dates back to when we were using a custom p4lang Thrift version. AFAIK,
this option is no longer required.

Fixes #735