### PR TITLE
Stop using P4DeviceConfig in simple_switch_grpc tests

### DIFF
--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -21,7 +21,6 @@
 #include <grpc++/grpc++.h>
 
 #include <google/rpc/code.pb.h>
-#include <p4/tmp/p4config.grpc.pb.h>
 
 #include <fstream>
 #include <streambuf>
@@ -78,13 +77,11 @@ SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
       p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
   set_election_id(request.mutable_election_id());
   auto config = request.mutable_config();
-  p4::tmp::P4DeviceConfig device_config;
   std::ifstream istream(json_path);
   ASSERT_TRUE(istream.good());
-  device_config.mutable_device_data()->assign(
+  config->mutable_p4_device_config()->assign(
       (std::istreambuf_iterator<char>(istream)),
        std::istreambuf_iterator<char>());
-  device_config.SerializeToString(config->mutable_p4_device_config());
 
   p4v1::SetForwardingPipelineConfigResponse rep;
   ClientContext context;

--- a/targets/simple_switch_grpc/tests/example.cpp
+++ b/targets/simple_switch_grpc/tests/example.cpp
@@ -22,7 +22,6 @@
 
 #include <google/rpc/code.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>
-#include <p4/tmp/p4config.grpc.pb.h>
 
 #include <google/protobuf/util/message_differencer.h>
 
@@ -89,12 +88,10 @@ test() {
     set_election_id(request.mutable_election_id());
     auto config = request.mutable_config();
     config->set_allocated_p4info(&p4info);
-    p4::tmp::P4DeviceConfig device_config;
     std::ifstream istream(test_json);
-    device_config.mutable_device_data()->assign(
+    config->mutable_p4_device_config()->assign(
         (std::istreambuf_iterator<char>(istream)),
          std::istreambuf_iterator<char>());
-    device_config.SerializeToString(config->mutable_p4_device_config());
 
     p4v1::SetForwardingPipelineConfigResponse rep;
     ClientContext context;


### PR DESCRIPTION
Now that it has been deprecated and is no longer required to push a new
forwarding pipeline config to the P4Runtime server implementation.