### PR TITLE
Change "private" v1model standard_metadata fields to BMv2 packet regi…

### DIFF
--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -105,7 +105,7 @@ class Packet final {
   using buffer_state_t = PacketBuffer::state_t;
 
   //! Number of general purpose registers per packet
-  static constexpr size_t nb_registers = 2u;
+  static constexpr size_t nb_registers = 3u;
 
   static constexpr size_t INVALID_ENTRY_INDEX =
       std::numeric_limits<size_t>::max();

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -105,7 +105,7 @@ class Packet final {
   using buffer_state_t = PacketBuffer::state_t;
 
   //! Number of general purpose registers per packet
-  static constexpr size_t nb_registers = 3u;
+  static constexpr size_t nb_registers = 4u;
 
   static constexpr size_t INVALID_ENTRY_INDEX =
       std::numeric_limits<size_t>::max();

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -226,7 +226,7 @@ class generate_digest : public ActionPrimitive<const Data &, const Data &> {
     // discared receiver for now
     (void) receiver;
     auto &packet = get_packet();
-    RegisterAccess::set_lf_field_list(packet, learn_id.get<uint16_t>());
+    RegisterAccess::set_lf_field_list(&packet, learn_id.get<uint16_t>());
   }
 };
 
@@ -288,9 +288,9 @@ class clone_ingress_pkt_to_egress
     // significant bit to always make the value non-0.  This enables
     // cleanly supporting mirror_session_id == 0, in case that is ever
     // helpful.
-    RegisterAccess::set_clone_mirror_session_id(packet,
+    RegisterAccess::set_clone_mirror_session_id(&packet,
         mirror_session_id.get<uint16_t>() | (1u << 15));
-    RegisterAccess::set_clone_field_list(packet,
+    RegisterAccess::set_clone_field_list(&packet,
         field_list_id.get<uint16_t>());
   }
 };
@@ -302,9 +302,9 @@ class clone_egress_pkt_to_egress
   void operator ()(const Data &mirror_session_id, const Data &field_list_id) {
     auto &packet = get_packet();
     // See clone_ingress_pkt_to_egress for why the arithmetic.
-    RegisterAccess::set_clone_mirror_session_id(packet,
+    RegisterAccess::set_clone_mirror_session_id(&packet,
         mirror_session_id.get<uint16_t>() | (1u << 15));
-    RegisterAccess::set_clone_field_list(packet,
+    RegisterAccess::set_clone_field_list(&packet,
         field_list_id.get<uint16_t>());
   }
 };
@@ -314,7 +314,7 @@ REGISTER_PRIMITIVE(clone_egress_pkt_to_egress);
 class resubmit : public ActionPrimitive<const Data &> {
   void operator ()(const Data &field_list_id) {
     auto &packet = get_packet();
-    RegisterAccess::set_resubmit_flag(packet, field_list_id.get<uint16_t>());
+    RegisterAccess::set_resubmit_flag(&packet, field_list_id.get<uint16_t>());
   }
 };
 
@@ -323,7 +323,8 @@ REGISTER_PRIMITIVE(resubmit);
 class recirculate : public ActionPrimitive<const Data &> {
   void operator ()(const Data &field_list_id) {
     auto &packet = get_packet();
-    RegisterAccess::set_recirculate_flag(packet, field_list_id.get<uint16_t>());
+    RegisterAccess::set_recirculate_flag(&packet,
+                                         field_list_id.get<uint16_t>());
   }
 };
 

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -284,12 +284,14 @@ class clone_ingress_pkt_to_egress
   : public ActionPrimitive<const Data &, const Data &> {
   void operator ()(const Data &mirror_session_id, const Data &field_list_id) {
     auto &packet = get_packet();
-    // Assume mirror_session_id < (1u << 15) so that we can use most
-    // significant bit to always make the value non-0.  This enables
-    // cleanly supporting mirror_session_id == 0, in case that is ever
-    // helpful.
+    // We limit mirror_session_id values to small enough values that
+    // we can use one of the bit positions as a "clone was performed"
+    // indicator, making mirror_seesion_id stored here always non-0 if
+    // a clone was done.  This enables cleanly supporting
+    // mirror_session_id == 0, in case that is ever helpful.
     RegisterAccess::set_clone_mirror_session_id(&packet,
-        mirror_session_id.get<uint16_t>() | (1u << 15));
+        mirror_session_id.get<uint16_t>() |
+        RegisterAccess::MIRROR_SESSION_ID_VALID_MASK);
     RegisterAccess::set_clone_field_list(&packet,
         field_list_id.get<uint16_t>());
   }
@@ -303,7 +305,8 @@ class clone_egress_pkt_to_egress
     auto &packet = get_packet();
     // See clone_ingress_pkt_to_egress for why the arithmetic.
     RegisterAccess::set_clone_mirror_session_id(&packet,
-        mirror_session_id.get<uint16_t>() | (1u << 15));
+        mirror_session_id.get<uint16_t>() |
+        RegisterAccess::MIRROR_SESSION_ID_VALID_MASK);
     RegisterAccess::set_clone_field_list(&packet,
         field_list_id.get<uint16_t>());
   }

--- a/targets/simple_switch/primitives.cpp
+++ b/targets/simple_switch/primitives.cpp
@@ -241,8 +241,8 @@ class add_header : public ActionPrimitive<Header &> {
       // updated the length packet register (register 0)
       auto &packet = get_packet();
       packet.set_register(RegisterAccess::PACKET_LENGTH_REG_IDX,
-                          packet.get_register(RegisterAccess::PACKET_LENGTH_REG_IDX) +
-                          hdr.get_nbytes_packet());
+          packet.get_register(RegisterAccess::PACKET_LENGTH_REG_IDX) +
+          hdr.get_nbytes_packet());
     }
   }
 };
@@ -263,8 +263,8 @@ class remove_header : public ActionPrimitive<Header &> {
       // updated the length packet register (register 0)
       auto &packet = get_packet();
       packet.set_register(RegisterAccess::PACKET_LENGTH_REG_IDX,
-                          packet.get_register(RegisterAccess::PACKET_LENGTH_REG_IDX) -
-                          hdr.get_nbytes_packet());
+          packet.get_register(RegisterAccess::PACKET_LENGTH_REG_IDX) -
+          hdr.get_nbytes_packet());
       hdr.mark_invalid();
     }
   }

--- a/targets/simple_switch/register_access.h
+++ b/targets/simple_switch/register_access.h
@@ -21,28 +21,28 @@
 #ifndef SIMPLE_SWITCH_REGISTER_ACCESS_H_
 #define SIMPLE_SWITCH_REGISTER_ACCESS_H_
 
-#define PACKET_LENGTH_REG_IDX             0
-
-#define CLONE_MIRROR_SESSION_ID_REG_IDX   1
-#define CLONE_MIRROR_SESSION_ID_MASK      0x000000000000ffff
-#define CLONE_MIRROR_SESSION_ID_SHIFT     0
-#define CLONE_FIELD_LIST_REG_IDX          1
-#define CLONE_FIELD_LIST_MASK             0x00000000ffff0000
-#define CLONE_FIELD_LIST_SHIFT            16
-#define LF_FIELD_LIST_REG_IDX             1
-#define LF_FIELD_LIST_MASK                0x0000ffff00000000
-#define LF_FIELD_LIST_SHIFT               32
-#define RESUBMIT_FLAG_REG_IDX             1
-#define RESUBMIT_FLAG_MASK                0xffff000000000000
-#define RESUBMIT_FLAG_SHIFT               48
-
-#define RECIRCULATE_FLAG_REG_IDX          2
-#define RECIRCULATE_FLAG_MASK             0x000000000000ffff
-#define RECIRCULATE_FLAG_SHIFT            0
-
 
 class RegisterAccess {
  public:
+    static constexpr int PACKET_LENGTH_REG_IDX = 0;
+
+    static constexpr int CLONE_MIRROR_SESSION_ID_REG_IDX = 1;
+    static constexpr uint64_t CLONE_MIRROR_SESSION_ID_MASK = 0x000000000000ffff;
+    static constexpr uint64_t CLONE_MIRROR_SESSION_ID_SHIFT = 0;
+    static constexpr int CLONE_FIELD_LIST_REG_IDX = 1;
+    static constexpr uint64_t CLONE_FIELD_LIST_MASK = 0x00000000ffff0000;
+    static constexpr uint64_t CLONE_FIELD_LIST_SHIFT = 16;
+    static constexpr int LF_FIELD_LIST_REG_IDX = 1;
+    static constexpr uint64_t LF_FIELD_LIST_MASK = 0x0000ffff00000000;
+    static constexpr uint64_t LF_FIELD_LIST_SHIFT = 32;
+    static constexpr int RESUBMIT_FLAG_REG_IDX = 1;
+    static constexpr uint64_t RESUBMIT_FLAG_MASK = 0xffff000000000000;
+    static constexpr uint64_t RESUBMIT_FLAG_SHIFT = 48;
+
+    static constexpr int RECIRCULATE_FLAG_REG_IDX = 2;
+    static constexpr uint64_t RECIRCULATE_FLAG_MASK = 0x000000000000ffff;
+    static constexpr uint64_t RECIRCULATE_FLAG_SHIFT = 0;
+
     static void clear_all(Packet &pkt) {
         // except do not clear packet length
         pkt.set_register(1, 0);
@@ -50,8 +50,8 @@ class RegisterAccess {
     }
     static uint16_t get_clone_mirror_session_id(Packet &pkt) {
         uint64_t rv = pkt.get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
-        return (uint16_t) ((rv & CLONE_MIRROR_SESSION_ID_MASK) >>
-                           CLONE_MIRROR_SESSION_ID_SHIFT);
+        return static_cast<uint16_t>((rv & CLONE_MIRROR_SESSION_ID_MASK) >>
+                                     CLONE_MIRROR_SESSION_ID_SHIFT);
     }
     static void set_clone_mirror_session_id(Packet &pkt,
                                             uint16_t mirror_session_id) {
@@ -63,8 +63,8 @@ class RegisterAccess {
     }
     static uint16_t get_clone_field_list(Packet &pkt) {
         uint64_t rv = pkt.get_register(CLONE_FIELD_LIST_REG_IDX);
-        return (uint16_t) ((rv & CLONE_FIELD_LIST_MASK) >>
-                           CLONE_FIELD_LIST_SHIFT);
+        return static_cast<uint16_t>((rv & CLONE_FIELD_LIST_MASK) >>
+                                     CLONE_FIELD_LIST_SHIFT);
     }
     static void set_clone_field_list(Packet &pkt, uint16_t field_list_id) {
         uint64_t rv = pkt.get_register(CLONE_FIELD_LIST_REG_IDX);
@@ -74,7 +74,8 @@ class RegisterAccess {
     }
     static uint16_t get_lf_field_list(Packet &pkt) {
         uint64_t rv = pkt.get_register(LF_FIELD_LIST_REG_IDX);
-        return (uint16_t) ((rv & LF_FIELD_LIST_MASK) >> LF_FIELD_LIST_SHIFT);
+        return static_cast<uint16_t>((rv & LF_FIELD_LIST_MASK) >>
+                                     LF_FIELD_LIST_SHIFT);
     }
     static void set_lf_field_list(Packet &pkt, uint16_t field_list_id) {
         uint64_t rv = pkt.get_register(LF_FIELD_LIST_REG_IDX);
@@ -84,7 +85,8 @@ class RegisterAccess {
     }
     static uint16_t get_resubmit_flag(Packet &pkt) {
         uint64_t rv = pkt.get_register(RESUBMIT_FLAG_REG_IDX);
-        return (uint16_t) ((rv & RESUBMIT_FLAG_MASK) >> RESUBMIT_FLAG_SHIFT);
+        return static_cast<uint16_t>((rv & RESUBMIT_FLAG_MASK) >>
+                                     RESUBMIT_FLAG_SHIFT);
     }
     static void set_resubmit_flag(Packet &pkt, uint16_t field_list_id) {
         uint64_t rv = pkt.get_register(RESUBMIT_FLAG_REG_IDX);
@@ -94,8 +96,8 @@ class RegisterAccess {
     }
     static uint16_t get_recirculate_flag(Packet &pkt) {
         uint64_t rv = pkt.get_register(RECIRCULATE_FLAG_REG_IDX);
-        return (uint16_t) ((rv & RECIRCULATE_FLAG_MASK) >>
-                           RECIRCULATE_FLAG_SHIFT);
+        return static_cast<uint16_t>((rv & RECIRCULATE_FLAG_MASK) >>
+                                     RECIRCULATE_FLAG_SHIFT);
     }
     static void set_recirculate_flag(Packet &pkt, uint16_t field_list_id) {
         uint64_t rv = pkt.get_register(RECIRCULATE_FLAG_REG_IDX);

--- a/targets/simple_switch/register_access.h
+++ b/targets/simple_switch/register_access.h
@@ -43,67 +43,67 @@ class RegisterAccess {
     static constexpr uint64_t RECIRCULATE_FLAG_MASK = 0x000000000000ffff;
     static constexpr uint64_t RECIRCULATE_FLAG_SHIFT = 0;
 
-    static void clear_all(Packet &pkt) {
+    static void clear_all(Packet *pkt) {
         // except do not clear packet length
-        pkt.set_register(1, 0);
-        pkt.set_register(2, 0);
+        pkt->set_register(1, 0);
+        pkt->set_register(2, 0);
     }
-    static uint16_t get_clone_mirror_session_id(Packet &pkt) {
-        uint64_t rv = pkt.get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
+    static uint16_t get_clone_mirror_session_id(Packet *pkt) {
+        uint64_t rv = pkt->get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
         return static_cast<uint16_t>((rv & CLONE_MIRROR_SESSION_ID_MASK) >>
                                      CLONE_MIRROR_SESSION_ID_SHIFT);
     }
-    static void set_clone_mirror_session_id(Packet &pkt,
+    static void set_clone_mirror_session_id(Packet *pkt,
                                             uint16_t mirror_session_id) {
-        uint64_t rv = pkt.get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
+        uint64_t rv = pkt->get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
         rv = ((rv & ~CLONE_MIRROR_SESSION_ID_MASK) |
               (((uint64_t) mirror_session_id) <<
                CLONE_MIRROR_SESSION_ID_SHIFT));
-        pkt.set_register(CLONE_MIRROR_SESSION_ID_REG_IDX, rv);
+        pkt->set_register(CLONE_MIRROR_SESSION_ID_REG_IDX, rv);
     }
-    static uint16_t get_clone_field_list(Packet &pkt) {
-        uint64_t rv = pkt.get_register(CLONE_FIELD_LIST_REG_IDX);
+    static uint16_t get_clone_field_list(Packet *pkt) {
+        uint64_t rv = pkt->get_register(CLONE_FIELD_LIST_REG_IDX);
         return static_cast<uint16_t>((rv & CLONE_FIELD_LIST_MASK) >>
                                      CLONE_FIELD_LIST_SHIFT);
     }
-    static void set_clone_field_list(Packet &pkt, uint16_t field_list_id) {
-        uint64_t rv = pkt.get_register(CLONE_FIELD_LIST_REG_IDX);
+    static void set_clone_field_list(Packet *pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt->get_register(CLONE_FIELD_LIST_REG_IDX);
         rv = ((rv & ~CLONE_FIELD_LIST_MASK) |
               (((uint64_t) field_list_id) << CLONE_FIELD_LIST_SHIFT));
-        pkt.set_register(CLONE_FIELD_LIST_REG_IDX, rv);
+        pkt->set_register(CLONE_FIELD_LIST_REG_IDX, rv);
     }
-    static uint16_t get_lf_field_list(Packet &pkt) {
-        uint64_t rv = pkt.get_register(LF_FIELD_LIST_REG_IDX);
+    static uint16_t get_lf_field_list(Packet *pkt) {
+        uint64_t rv = pkt->get_register(LF_FIELD_LIST_REG_IDX);
         return static_cast<uint16_t>((rv & LF_FIELD_LIST_MASK) >>
                                      LF_FIELD_LIST_SHIFT);
     }
-    static void set_lf_field_list(Packet &pkt, uint16_t field_list_id) {
-        uint64_t rv = pkt.get_register(LF_FIELD_LIST_REG_IDX);
+    static void set_lf_field_list(Packet *pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt->get_register(LF_FIELD_LIST_REG_IDX);
         rv = ((rv & ~LF_FIELD_LIST_MASK) |
               (((uint64_t) field_list_id) << LF_FIELD_LIST_SHIFT));
-        pkt.set_register(LF_FIELD_LIST_REG_IDX, rv);
+        pkt->set_register(LF_FIELD_LIST_REG_IDX, rv);
     }
-    static uint16_t get_resubmit_flag(Packet &pkt) {
-        uint64_t rv = pkt.get_register(RESUBMIT_FLAG_REG_IDX);
+    static uint16_t get_resubmit_flag(Packet *pkt) {
+        uint64_t rv = pkt->get_register(RESUBMIT_FLAG_REG_IDX);
         return static_cast<uint16_t>((rv & RESUBMIT_FLAG_MASK) >>
                                      RESUBMIT_FLAG_SHIFT);
     }
-    static void set_resubmit_flag(Packet &pkt, uint16_t field_list_id) {
-        uint64_t rv = pkt.get_register(RESUBMIT_FLAG_REG_IDX);
+    static void set_resubmit_flag(Packet *pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt->get_register(RESUBMIT_FLAG_REG_IDX);
         rv = ((rv & ~RESUBMIT_FLAG_MASK) |
               (((uint64_t) field_list_id) << RESUBMIT_FLAG_SHIFT));
-        pkt.set_register(RESUBMIT_FLAG_REG_IDX, rv);
+        pkt->set_register(RESUBMIT_FLAG_REG_IDX, rv);
     }
-    static uint16_t get_recirculate_flag(Packet &pkt) {
-        uint64_t rv = pkt.get_register(RECIRCULATE_FLAG_REG_IDX);
+    static uint16_t get_recirculate_flag(Packet *pkt) {
+        uint64_t rv = pkt->get_register(RECIRCULATE_FLAG_REG_IDX);
         return static_cast<uint16_t>((rv & RECIRCULATE_FLAG_MASK) >>
                                      RECIRCULATE_FLAG_SHIFT);
     }
-    static void set_recirculate_flag(Packet &pkt, uint16_t field_list_id) {
-        uint64_t rv = pkt.get_register(RECIRCULATE_FLAG_REG_IDX);
+    static void set_recirculate_flag(Packet *pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt->get_register(RECIRCULATE_FLAG_REG_IDX);
         rv = ((rv & ~RECIRCULATE_FLAG_MASK) |
               (((uint64_t) field_list_id) << RECIRCULATE_FLAG_SHIFT));
-        pkt.set_register(RECIRCULATE_FLAG_REG_IDX, rv);
+        pkt->set_register(RECIRCULATE_FLAG_REG_IDX, rv);
     }
 };
 

--- a/targets/simple_switch/register_access.h
+++ b/targets/simple_switch/register_access.h
@@ -43,6 +43,10 @@ class RegisterAccess {
     static constexpr uint64_t RECIRCULATE_FLAG_MASK = 0x000000000000ffff;
     static constexpr uint64_t RECIRCULATE_FLAG_SHIFT = 0;
 
+    static constexpr uint16_t MAX_MIRROR_SESSION_ID = (1u << 15) - 1;
+    static constexpr uint16_t MIRROR_SESSION_ID_VALID_MASK = (1u << 15);
+    static constexpr uint16_t MIRROR_SESSION_ID_MASK = 0x7FFFu;
+
     static void clear_all(Packet *pkt) {
         // except do not clear packet length
         pkt->set_register(1, 0);
@@ -57,7 +61,7 @@ class RegisterAccess {
                                             uint16_t mirror_session_id) {
         uint64_t rv = pkt->get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
         rv = ((rv & ~CLONE_MIRROR_SESSION_ID_MASK) |
-              (((uint64_t) mirror_session_id) <<
+              ((static_cast<uint64_t>(mirror_session_id)) <<
                CLONE_MIRROR_SESSION_ID_SHIFT));
         pkt->set_register(CLONE_MIRROR_SESSION_ID_REG_IDX, rv);
     }
@@ -69,7 +73,8 @@ class RegisterAccess {
     static void set_clone_field_list(Packet *pkt, uint16_t field_list_id) {
         uint64_t rv = pkt->get_register(CLONE_FIELD_LIST_REG_IDX);
         rv = ((rv & ~CLONE_FIELD_LIST_MASK) |
-              (((uint64_t) field_list_id) << CLONE_FIELD_LIST_SHIFT));
+              ((static_cast<uint64_t>(field_list_id)) <<
+               CLONE_FIELD_LIST_SHIFT));
         pkt->set_register(CLONE_FIELD_LIST_REG_IDX, rv);
     }
     static uint16_t get_lf_field_list(Packet *pkt) {
@@ -80,7 +85,7 @@ class RegisterAccess {
     static void set_lf_field_list(Packet *pkt, uint16_t field_list_id) {
         uint64_t rv = pkt->get_register(LF_FIELD_LIST_REG_IDX);
         rv = ((rv & ~LF_FIELD_LIST_MASK) |
-              (((uint64_t) field_list_id) << LF_FIELD_LIST_SHIFT));
+              ((static_cast<uint64_t>(field_list_id)) << LF_FIELD_LIST_SHIFT));
         pkt->set_register(LF_FIELD_LIST_REG_IDX, rv);
     }
     static uint16_t get_resubmit_flag(Packet *pkt) {
@@ -91,7 +96,7 @@ class RegisterAccess {
     static void set_resubmit_flag(Packet *pkt, uint16_t field_list_id) {
         uint64_t rv = pkt->get_register(RESUBMIT_FLAG_REG_IDX);
         rv = ((rv & ~RESUBMIT_FLAG_MASK) |
-              (((uint64_t) field_list_id) << RESUBMIT_FLAG_SHIFT));
+              ((static_cast<uint64_t>(field_list_id)) << RESUBMIT_FLAG_SHIFT));
         pkt->set_register(RESUBMIT_FLAG_REG_IDX, rv);
     }
     static uint16_t get_recirculate_flag(Packet *pkt) {
@@ -102,7 +107,8 @@ class RegisterAccess {
     static void set_recirculate_flag(Packet *pkt, uint16_t field_list_id) {
         uint64_t rv = pkt->get_register(RECIRCULATE_FLAG_REG_IDX);
         rv = ((rv & ~RECIRCULATE_FLAG_MASK) |
-              (((uint64_t) field_list_id) << RECIRCULATE_FLAG_SHIFT));
+              ((static_cast<uint64_t>(field_list_id)) <<
+               RECIRCULATE_FLAG_SHIFT));
         pkt->set_register(RECIRCULATE_FLAG_REG_IDX, rv);
     }
 };

--- a/targets/simple_switch/register_access.h
+++ b/targets/simple_switch/register_access.h
@@ -1,0 +1,105 @@
+/* Copyright 2019-present Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Andy Fingerhut (jafinger@cisco.com)
+ *
+ */
+
+#define PACKET_LENGTH_REG_IDX             0
+
+#define CLONE_MIRROR_SESSION_ID_REG_IDX   1
+#define CLONE_MIRROR_SESSION_ID_MASK      0x000000000000ffff
+#define CLONE_MIRROR_SESSION_ID_SHIFT     0
+#define CLONE_FIELD_LIST_REG_IDX          1
+#define CLONE_FIELD_LIST_MASK             0x00000000ffff0000
+#define CLONE_FIELD_LIST_SHIFT            16
+#define LF_FIELD_LIST_REG_IDX             1
+#define LF_FIELD_LIST_MASK                0x0000ffff00000000
+#define LF_FIELD_LIST_SHIFT               32
+#define RESUBMIT_FLAG_REG_IDX             1
+#define RESUBMIT_FLAG_MASK                0xffff000000000000
+#define RESUBMIT_FLAG_SHIFT               48
+
+#define RECIRCULATE_FLAG_REG_IDX          2
+#define RECIRCULATE_FLAG_MASK             0x000000000000ffff
+#define RECIRCULATE_FLAG_SHIFT            0
+
+//#define CLONE_SPEC_REG_IDX       1
+
+
+class RegisterAccess {
+ public:
+    static void clear_all(Packet &pkt) {
+        // except do not clear packet length
+        pkt.set_register(1, 0);
+        pkt.set_register(2, 0);
+    }
+    static uint16_t get_clone_mirror_session_id(Packet &pkt) {
+        uint64_t rv = pkt.get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
+        return (uint16_t) ((rv & CLONE_MIRROR_SESSION_ID_MASK) >>
+                           CLONE_MIRROR_SESSION_ID_SHIFT);
+    }
+    static void set_clone_mirror_session_id(Packet &pkt,
+                                            uint16_t mirror_session_id) {
+        uint64_t rv = pkt.get_register(CLONE_MIRROR_SESSION_ID_REG_IDX);
+        rv = ((rv & ~CLONE_MIRROR_SESSION_ID_MASK) |
+              (((uint64_t) mirror_session_id) <<
+               CLONE_MIRROR_SESSION_ID_SHIFT));
+        pkt.set_register(CLONE_MIRROR_SESSION_ID_REG_IDX, rv);
+    }
+    static uint16_t get_clone_field_list(Packet &pkt) {
+        uint64_t rv = pkt.get_register(CLONE_FIELD_LIST_REG_IDX);
+        return (uint16_t) ((rv & CLONE_FIELD_LIST_MASK) >>
+                           CLONE_FIELD_LIST_SHIFT);
+    }
+    static void set_clone_field_list(Packet &pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt.get_register(CLONE_FIELD_LIST_REG_IDX);
+        rv = ((rv & ~CLONE_FIELD_LIST_MASK) |
+              (((uint64_t) field_list_id) << CLONE_FIELD_LIST_SHIFT));
+        pkt.set_register(CLONE_FIELD_LIST_REG_IDX, rv);
+    }
+    static uint16_t get_lf_field_list(Packet &pkt) {
+        uint64_t rv = pkt.get_register(LF_FIELD_LIST_REG_IDX);
+        return (uint16_t) ((rv & LF_FIELD_LIST_MASK) >> LF_FIELD_LIST_SHIFT);
+    }
+    static void set_lf_field_list(Packet &pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt.get_register(LF_FIELD_LIST_REG_IDX);
+        rv = ((rv & ~LF_FIELD_LIST_MASK) |
+              (((uint64_t) field_list_id) << LF_FIELD_LIST_SHIFT));
+        pkt.set_register(LF_FIELD_LIST_REG_IDX, rv);
+    }
+    static uint16_t get_resubmit_flag(Packet &pkt) {
+        uint64_t rv = pkt.get_register(RESUBMIT_FLAG_REG_IDX);
+        return (uint16_t) ((rv & RESUBMIT_FLAG_MASK) >> RESUBMIT_FLAG_SHIFT);
+    }
+    static void set_resubmit_flag(Packet &pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt.get_register(RESUBMIT_FLAG_REG_IDX);
+        rv = ((rv & ~RESUBMIT_FLAG_MASK) |
+              (((uint64_t) field_list_id) << RESUBMIT_FLAG_SHIFT));
+        pkt.set_register(RESUBMIT_FLAG_REG_IDX, rv);
+    }
+    static uint16_t get_recirculate_flag(Packet &pkt) {
+        uint64_t rv = pkt.get_register(RECIRCULATE_FLAG_REG_IDX);
+        return (uint16_t) ((rv & RECIRCULATE_FLAG_MASK) >>
+                           RECIRCULATE_FLAG_SHIFT);
+    }
+    static void set_recirculate_flag(Packet &pkt, uint16_t field_list_id) {
+        uint64_t rv = pkt.get_register(RECIRCULATE_FLAG_REG_IDX);
+        rv = ((rv & ~RECIRCULATE_FLAG_MASK) |
+              (((uint64_t) field_list_id) << RECIRCULATE_FLAG_SHIFT));
+        pkt.set_register(RECIRCULATE_FLAG_REG_IDX, rv);
+    }
+};

--- a/targets/simple_switch/register_access.h
+++ b/targets/simple_switch/register_access.h
@@ -18,6 +18,9 @@
  *
  */
 
+#ifndef SIMPLE_SWITCH_REGISTER_ACCESS_H_
+#define SIMPLE_SWITCH_REGISTER_ACCESS_H_
+
 #define PACKET_LENGTH_REG_IDX             0
 
 #define CLONE_MIRROR_SESSION_ID_REG_IDX   1
@@ -36,8 +39,6 @@
 #define RECIRCULATE_FLAG_REG_IDX          2
 #define RECIRCULATE_FLAG_MASK             0x000000000000ffff
 #define RECIRCULATE_FLAG_SHIFT            0
-
-//#define CLONE_SPEC_REG_IDX       1
 
 
 class RegisterAccess {
@@ -103,3 +104,5 @@ class RegisterAccess {
         pkt.set_register(RECIRCULATE_FLAG_REG_IDX, rv);
     }
 };
+
+#endif  // SIMPLE_SWITCH_REGISTER_ACCESS_H_


### PR DESCRIPTION
…sters

Remove the use of the following 4 fields from BMv2 simple_switch and
simple_switch_grpc.  They no longer need to be in the BMv2 JSON file
for such programs, and clone, recirculate, resubmit, and digest
operations are still able to work without them there, because they are
now stored in a BMv2 "packet register", similar to how the packet
length field currently is.

+ clone_spec
+ resubmit_flag
+ recirculate_flag
+ lf_field_list