### PR TITLE
Make code build with recent Thrift versions (post 0.12.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You also need to install the following from source. Feel free to use the
 install scripts under travis/.
 
 - [thrift 0.9.2](https://github.com/apache/thrift/releases/tag/0.9.2) or later
-  (up to 0.12.1)
+  (tested up to 0.12.1)
 - [nanomsg 1.0.0](https://github.com/nanomsg/nanomsg/releases/tag/1.0.0) or
   later
 

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,27 @@ AS_IF([test "$want_thrift" = yes], [
     AC_CHECK_HEADER([thrift/stdcxx.h], [
         AC_DEFINE([HAVE_THRIFT_STDCXX_H], [], [Found Thrift stdcxx wrapper])
     ], [])
+
+    AC_MSG_CHECKING(for thrift version)
+    AC_RUN_IFELSE(
+        [AC_LANG_SOURCE(
+          [[#include <thrift/config.h>
+            #include <stdio.h>
+            int main() {
+              int major, minor, revision;
+              if (sscanf(PACKAGE_VERSION, "%d.%d.%d", &major, &minor, &revision) != 3)
+                return 1;
+              int version = major * 10000 + minor * 100 + revision;
+              printf("%d\n", version);
+              return 0;
+            }
+        ]])],
+        [THRIFT_VERSION=`./conftest$EXEEXT`],
+        [AC_MSG_RESULT(error)
+         AC_MSG_ERROR(Cannot determine thrift version)]
+    )
+    AC_DEFINE_UNQUOTED([THRIFT_VERSION], [$THRIFT_VERSION],
+                       [Thrift version string extracted from thrift/config.h])
 ])
 
 AS_IF([test "$want_pi" = yes], [

--- a/include/bm/thrift/stdcxx.h
+++ b/include/bm/thrift/stdcxx.h
@@ -5,11 +5,15 @@
 
 namespace thrift_provider = apache::thrift;
 
+#if BM_THRIFT_VERSION < 1300
 #ifdef BM_HAVE_THRIFT_STDCXX_H
 #include <thrift/stdcxx.h>
 namespace stdcxx = thrift_provider::stdcxx;
 #else
 namespace stdcxx = boost;
-#endif
+#endif  // BM_HAVE_THRIFT_STDCXX_H
+#else
+namespace stdcxx = std;
+#endif  // BM_THRIFT_VERSION < 1300
 
 #endif

--- a/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
+++ b/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
@@ -21,21 +21,12 @@
 #ifndef BM_PDFIXED_INT_PD_CONN_MGR_H_
 #define BM_PDFIXED_INT_PD_CONN_MGR_H_
 
-#include <bm/config.h>
-
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportUtils.h>
 #include <thrift/protocol/TMultiplexedProtocol.h>
 
-namespace thrift_provider = apache::thrift;
-
-#ifdef BM_HAVE_THRIFT_STDCXX_H
-#include <thrift/stdcxx.h>
-namespace stdcxx = thrift_provider::stdcxx;
-#else
-namespace stdcxx = boost;
-#endif
+#include <bm/thrift/stdcxx.h>
 
 #include <mutex>
 #include <iostream>

--- a/pdfixed/thrift-src/pdfixed_rpc_server.cpp
+++ b/pdfixed/thrift-src/pdfixed_rpc_server.cpp
@@ -1,5 +1,3 @@
-#include <bm/config.h>
-
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/server/TThreadedServer.h>
@@ -7,14 +5,7 @@
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/processor/TMultiplexedProcessor.h>
 
-namespace thrift_provider = apache::thrift;
-
-#ifdef BM_HAVE_THRIFT_STDCXX_H
-#include <thrift/stdcxx.h>
-namespace stdcxx = thrift_provider::stdcxx;
-#else
-namespace stdcxx = boost;
-#endif
+#include <bm/thrift/stdcxx.h>
 
 using namespace ::thrift_provider;
 using namespace ::thrift_provider::protocol;


### PR DESCRIPTION
Starting with version 0.13.0, Thrift removes thrift/stdcxx.h and
defaults to std::shared_ptr unconditionally. We handle this case by
reading the Thrift version from thrift/config.h in configure.ac.

Fixes #734