### PR TITLE
Support for group member activate / deactivate in PI implementation

### DIFF
--- a/PI/Makefile.am
+++ b/PI/Makefile.am
@@ -19,7 +19,11 @@ src/common.cpp \
 src/action_helpers.h \
 src/action_helpers.cpp \
 src/direct_res_spec.h \
-src/direct_res_spec.cpp
+src/direct_res_spec.cpp \
+src/group_selection.h \
+src/group_selection.cpp \
+src/device_state.h \
+src/device_state.cpp
 
 lib_LTLIBRARIES = libbmpi.la
 

--- a/PI/src/device_state.cpp
+++ b/PI/src/device_state.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "device_state.h"
+
+#include <bm/bm_sim/switch.h>
+#include <PI/p4info.h>
+
+#include <string>
+
+#include "common.h"
+
+namespace pibmv2 {
+
+DeviceState::DeviceState(const pi_p4info_t *p4info) {
+  for (auto act_prof_id = pi_p4info_act_prof_begin(p4info);
+       act_prof_id != pi_p4info_act_prof_end(p4info);
+       act_prof_id = pi_p4info_act_prof_next(p4info, act_prof_id)) {
+    auto selector = std::make_shared<GroupSelection>();
+    act_prof_selection.emplace(act_prof_id, selector);
+    const std::string name(pi_p4info_any_name_from_id(p4info, act_prof_id));
+    pibmv2::switch_->set_group_selector(0, name, selector);
+  }
+}
+
+DeviceLock *device_lock = nullptr;
+DeviceState *device_state = nullptr;
+
+}  // namespace pibmv2

--- a/PI/src/device_state.h
+++ b/PI/src/device_state.h
@@ -1,0 +1,83 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_DEVICE_STATE_H_
+#define SRC_DEVICE_STATE_H_
+
+#include <PI/p4info.h>
+
+#include <memory>
+#include <unordered_map>
+
+#include "group_selection.h"
+
+namespace pibmv2 {
+
+struct DummyMutex {
+  DummyMutex() = default;
+  DummyMutex(const DummyMutex &) = delete;
+  DummyMutex &operator=(const DummyMutex &) = delete;
+  DummyMutex(DummyMutex &&) = delete;
+  DummyMutex &operator=(DummyMutex &&) = delete;
+};
+
+template <typename T>
+struct DummyLock {
+  explicit DummyLock(const T &) { }
+  // avoid "set but not used" warning when calling DeviceLock::unique_lock()
+  ~DummyLock() { }
+  DummyLock(const DummyLock &) = delete;
+  DummyLock &operator=(const DummyLock &) = delete;
+  DummyLock(DummyLock &&) = default;
+  DummyLock &operator=(DummyLock &&) = default;
+};
+
+class DeviceLock {
+ public:
+  // TODO(antonin): the right thing to do would probably be to lock the device
+  // properly but since this code is only really used by the P4Runtime server
+  // implementation (p4lang/PI) which is thread safe (and ensures that no API
+  // calls are made concurrently with pi_update_device_start), there is no real
+  // need to lock the device again here.
+  using Mutex = DummyMutex;
+  using UniqueLock = DummyLock<Mutex>;
+  using SharedLock = DummyLock<Mutex>;
+
+  UniqueLock unique_lock() { return UniqueLock(mutex); }
+  SharedLock shared_lock() { return SharedLock(mutex); }
+
+ private:
+  mutable DummyMutex mutex;
+};
+
+class DeviceState {
+ public:
+  explicit DeviceState(const pi_p4info_t *p4info);
+
+  std::unordered_map<pi_p4_id_t, std::shared_ptr<GroupSelection> >
+  act_prof_selection;
+};
+
+extern DeviceLock *device_lock;
+extern DeviceState *device_state;
+
+}  // namespace pibmv2
+
+#endif  // SRC_DEVICE_STATE_H_

--- a/PI/src/group_selection.cpp
+++ b/PI/src/group_selection.cpp
@@ -1,0 +1,107 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include "group_selection.h"
+
+#include <bm/bm_sim/action_profile.h>
+#include <bm/bm_sim/match_error_codes.h>
+
+namespace pibmv2 {
+
+using bm::MatchErrorCode;
+using mbr_hdl_t = bm::ActionProfile::mbr_hdl_t;
+using grp_hdl_t = bm::ActionProfile::grp_hdl_t;
+
+MatchErrorCode
+GroupSelection::activate_member(grp_hdl_t grp, mbr_hdl_t mbr) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto it = groups.find(grp);
+  if (it == groups.end()) return MatchErrorCode::MBR_NOT_IN_GRP;
+  return it->second.activate_member(mbr);
+}
+
+MatchErrorCode
+GroupSelection::deactivate_member(grp_hdl_t grp, mbr_hdl_t mbr) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto it = groups.find(grp);
+  if (it == groups.end()) return MatchErrorCode::MBR_NOT_IN_GRP;
+  return it->second.deactivate_member(mbr);
+}
+
+void
+GroupSelection::add_member_to_group(grp_hdl_t grp, mbr_hdl_t mbr) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto &group = groups[grp];
+  group.add_member(mbr);
+}
+
+void
+GroupSelection::remove_member_from_group(grp_hdl_t grp, mbr_hdl_t mbr) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto &group = groups[grp];
+  group.remove_member(mbr);
+}
+
+mbr_hdl_t
+GroupSelection::get_from_hash(grp_hdl_t grp, hash_t h) const {
+  std::lock_guard<std::mutex> lock(mutex);
+  return groups.at(grp).get_from_hash(h);
+}
+
+void
+GroupSelection::reset() {
+  std::lock_guard<std::mutex> lock(mutex);
+  groups.clear();
+}
+
+MatchErrorCode
+GroupSelection::GroupInfo::activate_member(mbr_hdl_t mbr) {
+  if (members.count(mbr) == 0) return MatchErrorCode::MBR_NOT_IN_GRP;
+  return (activated_members.add(mbr) == 1) ?
+      MatchErrorCode::SUCCESS : MatchErrorCode::ERROR;
+}
+
+MatchErrorCode
+GroupSelection::GroupInfo::deactivate_member(mbr_hdl_t mbr) {
+  if (members.count(mbr) == 0) return MatchErrorCode::MBR_NOT_IN_GRP;
+  return (activated_members.remove(mbr) == 1) ?
+      MatchErrorCode::SUCCESS : MatchErrorCode::ERROR;
+}
+
+void
+GroupSelection::GroupInfo::add_member(mbr_hdl_t mbr) {
+  members.insert(mbr);
+  activated_members.add(mbr);
+}
+
+void
+GroupSelection::GroupInfo::remove_member(mbr_hdl_t mbr) {
+  members.erase(mbr);
+  activated_members.remove(mbr);
+}
+
+mbr_hdl_t
+GroupSelection::GroupInfo::get_from_hash(hash_t h) const {
+  auto active_count = activated_members.count();
+  auto index = static_cast<size_t>(h % active_count);
+  return activated_members.get_nth(index);
+}
+
+}  // namespace pibmv2

--- a/PI/src/group_selection.h
+++ b/PI/src/group_selection.h
@@ -1,0 +1,71 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#ifndef SRC_GROUP_SELECTION_H_
+#define SRC_GROUP_SELECTION_H_
+
+#include <bm/bm_sim/action_profile.h>
+#include <bm/bm_sim/match_error_codes.h>
+#include <bm/bm_sim/ras.h>
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace pibmv2 {
+
+class GroupSelection : public bm::ActionProfile::GroupSelectionIface {
+ public:
+  using mbr_hdl_t = bm::ActionProfile::mbr_hdl_t;
+  using grp_hdl_t = bm::ActionProfile::grp_hdl_t;
+  using MatchErrorCode = bm::MatchErrorCode;
+
+  MatchErrorCode activate_member(grp_hdl_t grp, mbr_hdl_t mbr);
+  MatchErrorCode deactivate_member(grp_hdl_t grp, mbr_hdl_t mbr);
+
+ private:
+  using hash_t = bm::ActionProfile::hash_t;
+
+  void add_member_to_group(grp_hdl_t grp, mbr_hdl_t mbr) override;
+  void remove_member_from_group(grp_hdl_t grp, mbr_hdl_t mbr) override;
+
+  mbr_hdl_t get_from_hash(grp_hdl_t grp, hash_t h) const override;
+
+  void reset() override;
+
+  class GroupInfo {
+   public:
+    MatchErrorCode activate_member(mbr_hdl_t mbr);
+    MatchErrorCode deactivate_member(mbr_hdl_t mbr);
+    void add_member(mbr_hdl_t mbr);
+    void remove_member(mbr_hdl_t mbr);
+    mbr_hdl_t get_from_hash(hash_t h) const;
+
+   private:
+    bm::RandAccessUIntSet activated_members{};
+    std::unordered_set<mbr_hdl_t> members;
+  };
+
+  mutable std::mutex mutex{};
+  std::unordered_map<grp_hdl_t, GroupInfo> groups{};
+};
+
+}  // namespace pibmv2
+
+#endif  // SRC_GROUP_SELECTION_H_

--- a/PI/src/pi_act_prof_imp.cpp
+++ b/PI/src/pi_act_prof_imp.cpp
@@ -31,6 +31,7 @@
 
 #include "action_helpers.h"
 #include "common.h"
+#include "device_state.h"
 
 using mbr_hdl_t = bm::RuntimeInterface::mbr_hdl_t;
 using grp_hdl_t = bm::RuntimeInterface::grp_hdl_t;
@@ -182,15 +183,49 @@ pi_status_t _pi_act_prof_grp_set_mbrs(pi_session_handle_t session_handle,
                                       pi_p4_id_t act_prof_id,
                                       pi_indirect_handle_t grp_handle,
                                       size_t num_mbrs,
-                                      const pi_indirect_handle_t *mbr_handles) {
+                                      const pi_indirect_handle_t *mbr_handles,
+                                      const bool *activate) {
   _BM_UNUSED(session_handle);
   _BM_UNUSED(dev_id);
   _BM_UNUSED(act_prof_id);
   _BM_UNUSED(grp_handle);
   _BM_UNUSED(num_mbrs);
   _BM_UNUSED(mbr_handles);
+  _BM_UNUSED(activate);
   // TODO(antonin)
   return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+}
+
+pi_status_t _pi_act_prof_grp_activate_mbr(pi_session_handle_t session_handle,
+                                          pi_dev_id_t dev_id,
+                                          pi_p4_id_t act_prof_id,
+                                          pi_indirect_handle_t grp_handle,
+                                          pi_indirect_handle_t mbr_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  grp_handle = pibmv2::IndirectHMgr::clear_grp_h(grp_handle);
+  auto lock = pibmv2::device_lock->shared_lock();
+  auto error_code = pibmv2::device_state->act_prof_selection.at(act_prof_id)
+      ->activate_member(grp_handle, mbr_handle);
+  if (error_code != bm::MatchErrorCode::SUCCESS)
+    return pibmv2::convert_error_code(error_code);
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_act_prof_grp_deactivate_mbr(pi_session_handle_t session_handle,
+                                            pi_dev_id_t dev_id,
+                                            pi_p4_id_t act_prof_id,
+                                            pi_indirect_handle_t grp_handle,
+                                            pi_indirect_handle_t mbr_handle) {
+  _BM_UNUSED(session_handle);
+  _BM_UNUSED(dev_id);
+  grp_handle = pibmv2::IndirectHMgr::clear_grp_h(grp_handle);
+  auto lock = pibmv2::device_lock->shared_lock();
+  auto error_code = pibmv2::device_state->act_prof_selection.at(act_prof_id)
+      ->deactivate_member(grp_handle, mbr_handle);
+  if (error_code != bm::MatchErrorCode::SUCCESS)
+    return pibmv2::convert_error_code(error_code);
+  return PI_STATUS_SUCCESS;
 }
 
 pi_status_t _pi_act_prof_entries_fetch(pi_session_handle_t session_handle,

--- a/PI/src/pi_imp.cpp
+++ b/PI/src/pi_imp.cpp
@@ -29,11 +29,41 @@
 
 #include <cstring>  // for memset
 #include "common.h"
+#include "device_state.h"
+
+namespace {
+
+bm::PortMonitorIface::PortStatusCb port_status_cb;
+
+void register_port_status_cb(pi_dev_id_t dev_id) {
+  auto cb = [dev_id](bm::PortMonitorIface::port_t port,
+                     bm::PortMonitorIface::PortStatus status) {
+    auto port_ = static_cast<pi_port_t>(port);
+    pi_port_status_t status_;
+    if (status == bm::PortMonitorIface::PortStatus::PORT_UP) {
+      status_ = PI_PORT_STATUS_UP;
+    } else if (status == bm::PortMonitorIface::PortStatus::PORT_DOWN) {
+      status_ = PI_PORT_STATUS_DOWN;
+    } else {
+      // TODO(antonin): log error?
+      return;
+    }
+    pi_port_status_event_notify(dev_id, port_, status_);
+  };
+
+  using PortStatus = bm::PortMonitorIface::PortStatus;
+  port_status_cb = cb;
+  pibmv2::switch_->register_status_cb(PortStatus::PORT_UP, port_status_cb);
+  pibmv2::switch_->register_status_cb(PortStatus::PORT_DOWN, port_status_cb);
+}
+
+}  // namespace
 
 extern "C" {
 
 pi_status_t _pi_init(void *extra) {
   _BM_UNUSED(extra);
+  pibmv2::device_lock = new pibmv2::DeviceLock();
   return PI_STATUS_SUCCESS;
 }
 
@@ -47,6 +77,10 @@ pi_status_t _pi_assign_device(pi_dev_id_t dev_id, const pi_p4info_t *p4info,
     // TODO(antonin): define better error code
     return PI_STATUS_DEV_OUT_OF_RANGE;
   }
+  // register callback for port oper status updates
+  // note that bmv2 currently does not offer the ability to unregister the
+  // callback...
+  register_port_status_cb(dev_id);
   return PI_STATUS_SUCCESS;
 }
 
@@ -56,10 +90,13 @@ pi_status_t _pi_update_device_start(pi_dev_id_t dev_id,
                                     size_t device_data_size) {
   _BM_UNUSED(dev_id);
   _BM_UNUSED(p4info);
+  auto lock = pibmv2::device_lock->unique_lock();
   auto error_code = pibmv2::switch_->load_new_config(
       std::string(device_data, device_data_size));
   if (error_code != bm::RuntimeInterface::ErrorCode::SUCCESS)
     return PI_STATUS_TARGET_ERROR;
+  if (pibmv2::device_state != nullptr) delete pibmv2::device_state;
+  pibmv2::device_state = new pibmv2::DeviceState(p4info);
   return PI_STATUS_SUCCESS;
 }
 
@@ -77,6 +114,8 @@ pi_status_t _pi_remove_device(pi_dev_id_t dev_id) {
 }
 
 pi_status_t _pi_destroy() {
+  if (pibmv2::device_state != nullptr) delete pibmv2::device_state;
+  delete pibmv2::device_lock;
   return PI_STATUS_SUCCESS;
 }
 
@@ -108,6 +147,15 @@ pi_status_t _pi_packetout_send(pi_dev_id_t dev_id, const char *pkt,
   _BM_UNUSED(dev_id);
   if (pibmv2::cpu_port == 0) return PI_STATUS_PACKETOUT_SEND_ERROR;
   pibmv2::switch_->receive(pibmv2::cpu_port, pkt, static_cast<int>(size));
+  return PI_STATUS_SUCCESS;
+}
+
+pi_status_t _pi_port_status_get(pi_dev_id_t dev_id, pi_port_t port,
+                                pi_port_status_t *status) {
+  _BM_UNUSED(dev_id);
+  auto is_up = pibmv2::switch_->port_is_up(
+      static_cast<bm::PortMonitorIface::port_t>(port));
+  *status = is_up ? PI_PORT_STATUS_UP : PI_PORT_STATUS_DOWN;
   return PI_STATUS_SUCCESS;
 }
 

--- a/include/bm/bm_sim/action_profile.h
+++ b/include/bm/bm_sim/action_profile.h
@@ -25,6 +25,7 @@
 #include <boost/thread/shared_mutex.hpp>
 
 #include <iosfwd>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -121,7 +122,7 @@ class ActionProfile : public NamedP4Object {
   }
 
   // give the target some control over the member selection process
-  void set_group_selector(GroupSelectionIface *selector);
+  void set_group_selector(std::shared_ptr<GroupSelectionIface> selector);
 
   // runtime interface
 
@@ -302,6 +303,7 @@ class ActionProfile : public NamedP4Object {
   size_t num_members{0};
   size_t num_groups{0};
   GroupMgr grp_mgr{};
+  std::shared_ptr<GroupSelectionIface> grp_selector_{nullptr};
   GroupSelectionIface *grp_selector{&grp_mgr};
   std::unique_ptr<Calculation> hash{nullptr};
 };

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -49,13 +49,14 @@
 #ifndef BM_BM_SIM_CONTEXT_H_
 #define BM_BM_SIM_CONTEXT_H_
 
-#include <iosfwd>
-#include <mutex>
 #include <atomic>
-#include <string>
-#include <vector>
+#include <iosfwd>
+#include <memory>
+#include <mutex>
 #include <set>
+#include <string>
 #include <typeindex>
+#include <vector>
 
 #include "P4Objects.h"
 #include "action_profile.h"
@@ -401,6 +402,10 @@ class Context final {
   set_crc_custom_parameters(
       const std::string &calc_name,
       const typename CustomCrcMgr<T>::crc_config_t &crc_config);
+
+  bool set_group_selector(
+      const std::string &act_prof_name,
+      std::shared_ptr<ActionProfile::GroupSelectionIface> selector);
 
   // ---------- End runtime interfaces ----------
 

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -78,6 +78,7 @@
 #include <iosfwd>
 #include <condition_variable>
 
+#include "action_profile.h"
 #include "context.h"
 #include "device_id.h"
 #include "queue.h"
@@ -187,6 +188,14 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
   //! force_arith_field() on all fields in the header. See force_arith_field()
   //! for more information.
   void force_arith_header(const std::string &header_name);
+
+  //! Use a custom GroupSelectionIface implementation for dataplane member
+  //! selection for action profile with name \p action_profile_name. Returns
+  //! false in case of failure (if the action profile name is not valid).
+  bool set_group_selector(
+      cxt_id_t cxt_id,
+      const std::string &act_prof_name,
+      std::shared_ptr<ActionProfile::GroupSelectionIface> selector);
 
   //! Get the number of contexts included in this switch
   size_t get_nb_cxts() { return nb_cxts; }

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -24,6 +24,7 @@
 #include <bm/bm_sim/packet.h>
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -515,9 +516,11 @@ ActionProfile::get_num_groups() const {
 }
 
 void
-ActionProfile::set_group_selector(GroupSelectionIface *selector) {
+ActionProfile::set_group_selector(
+    std::shared_ptr<GroupSelectionIface> selector) {
   WriteLock lock = lock_write();
-  grp_selector = selector;
+  grp_selector_ = selector;
+  grp_selector = grp_selector_.get();
 }
 
 bool

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -691,6 +691,17 @@ template CustomCrcErrorCode Context::set_crc_custom_parameters<uint32_t>(
     const std::string &calc_name,
     const CustomCrcMgr<uint32_t>::crc_config_t &crc_config);
 
+bool
+Context::set_group_selector(
+    const std::string &act_prof_name,
+    std::shared_ptr<ActionProfile::GroupSelectionIface> selector) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  auto act_prof = p4objects_rt->get_action_profile_rt(act_prof_name);
+  if (!act_prof) return false;
+  act_prof->set_group_selector(selector);
+  return true;
+}
+
 // ---------- End runtime interfaces ----------
 
 LearnEngineIface *

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -134,6 +134,14 @@ SwitchWContexts::force_arith_header(const std::string &header_name) {
   arith_objects.add_header(header_name);
 }
 
+bool
+SwitchWContexts::set_group_selector(
+    cxt_id_t cxt_id,
+    const std::string &act_prof_name,
+    std::shared_ptr<ActionProfile::GroupSelectionIface> selector) {
+  return contexts.at(cxt_id).set_group_selector(act_prof_name, selector);
+}
+
 int
 SwitchWContexts::init_objects(std::istream *is, device_id_t dev_id,
                               std::shared_ptr<TransportIface> transport) {

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -38,7 +38,8 @@ test_counter.cpp test_meter.cpp \
 test_ternary.cpp \
 test_pre.cpp \
 test_digest.cpp \
-test_idle_timeout.cpp
+test_idle_timeout.cpp \
+test_action_profile.cpp
 if WITH_SYSREPO
 test_gtest_SOURCES += test_gnmi.cpp
 endif
@@ -60,4 +61,5 @@ meter.p4 meter.json meter.proto.txt \
 ternary.p4 ternary.json ternary.proto.txt \
 multicast.p4 multicast.json multicast.proto.txt \
 clone.p4 clone.json clone.proto.txt \
-digest.p4 digest.json digest.proto.txt
+digest.p4 digest.json digest.proto.txt \
+action_profile.p4 action_profile.json action_profile.proto.txt

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -39,6 +39,8 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
  public:
   // We make the switch a shared resource for all tests. This is mainly because
   // simple_switch detaches threads.
+  // TODO(antonin): the issue with this is that tests may affect each other; in
+  // particular tests which modify port operational status.
   void SetUp() override {
     auto &runner = SimpleSwitchGrpcRunner::get_instance(
         true, SimpleSwitchGrpcBaseTest::grpc_server_addr,

--- a/targets/simple_switch_grpc/tests/test_action_profile.cpp
+++ b/targets/simple_switch_grpc/tests/test_action_profile.cpp
@@ -1,0 +1,152 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas (antonin@barefootnetworks.com)
+ *
+ */
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "base_test.h"
+#include "utils.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+constexpr char act_prof_json[] = TESTDATADIR "/action_profile.json";
+constexpr char act_prof_proto[] = TESTDATADIR "/action_profile.proto.txt";
+
+std::string port_to_bytes(int port) {
+  std::string v;
+  v.push_back(static_cast<char>((port >> 8) & 0xff));
+  v.push_back(static_cast<char>(port & 0xff));
+  return v;
+}
+
+class SimpleSwitchGrpcTest_ActionProfile : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_ActionProfile()
+      : SimpleSwitchGrpcBaseTest(act_prof_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(act_prof_json);
+    table_id = get_table_id(p4info, "IndirectWS");
+    action_id = get_action_id(p4info, "send");
+    {  // oneshot programming
+      p4v1::WriteRequest req;
+      auto *update = req.add_updates();
+      update->set_type(p4v1::Update::INSERT);
+      auto *entry = update->mutable_entity()->mutable_table_entry();
+      entry->set_table_id(table_id);
+      auto *mf = entry->add_match();
+      mf->set_field_id(get_mf_id(p4info, "IndirectWS", "h.hdr.in_"));
+      mf->mutable_exact()->set_value("\xab");
+      auto *oneshot =
+          entry->mutable_action()->mutable_action_profile_action_set();
+      for (auto port : {port_1, port_2}) {
+        auto *action_entry = oneshot->add_action_profile_actions();
+        auto *action = action_entry->mutable_action();
+        action->set_action_id(action_id);
+        auto *param = action->add_params();
+        param->set_param_id(get_param_id(p4info, "send", "eg_port"));
+        param->set_value(port_to_bytes(port));
+        action_entry->set_weight(1);
+        action_entry->set_watch(port);
+      }
+      ClientContext context;
+      p4v1::WriteResponse rep;
+      EXPECT_TRUE(Write(&context, req, &rep).ok());
+    }
+  }
+
+  grpc::Status send_and_receive(const std::string &entropy, int *eg_port) {
+    static uint64_t id = 1;
+    std::string pkt = "\xab" /* in_ */ + entropy;
+    p4::bm::PacketStreamRequest request;
+    request.set_id(id++);
+    request.set_device_id(device_id);
+    request.set_port(ig_port);
+    request.set_packet(pkt);
+    p4::bm::PacketStreamResponse response;
+    ClientContext context;
+    auto stream = dataplane_stub->PacketStream(&context);
+    stream->Write(request);
+    stream->Read(&response);
+    *eg_port = response.port();
+    stream->WritesDone();
+    return stream->Finish();
+  }
+
+  Status set_port_oper_status(int port, p4::bm::PortOperStatus oper_status) {
+    p4::bm::SetPortOperStatusRequest req;
+    req.set_device_id(device_id);
+    req.set_port(port);
+    req.set_oper_status(oper_status);
+    ClientContext context;
+    p4::bm::SetPortOperStatusResponse rep;
+    return dataplane_stub->SetPortOperStatus(&context, req, &rep);
+  }
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+  int table_id;
+  int action_id;
+  int port_1{1}, port_2{2};
+  int ig_port{99};
+};
+
+TEST_F(SimpleSwitchGrpcTest_ActionProfile, WatchPort) {
+  std::string entropy("\x01\x02\x03\x04");
+  int eg_port_0, eg_port;
+  EXPECT_TRUE(send_and_receive(entropy, &eg_port_0).ok());
+  EXPECT_TRUE(send_and_receive(entropy, &eg_port).ok());
+  EXPECT_EQ(eg_port, eg_port_0);
+  EXPECT_TRUE(set_port_oper_status(eg_port_0, p4::bm::OPER_STATUS_DOWN).ok());
+  // More than enough time for the member to be deactivated
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_TRUE(send_and_receive(entropy, &eg_port).ok());
+  EXPECT_NE(eg_port, eg_port_0);
+  EXPECT_TRUE(set_port_oper_status(eg_port_0, p4::bm::OPER_STATUS_UP).ok());
+  // More than enough time for the member to be reactivated
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_TRUE(send_and_receive(entropy, &eg_port).ok());
+  EXPECT_EQ(eg_port, eg_port_0);
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/testdata/action_profile.json
+++ b/targets/simple_switch_grpc/tests/testdata/action_profile.json
@@ -1,0 +1,310 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 32, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["recirculate_flag", 32, false],
+        ["parser_error", 32, false],
+        ["_padding", 5, false]
+      ]
+    },
+    {
+      "name" : "hdr_t",
+      "id" : 2,
+      "fields" : [
+        ["in_", 8, false],
+        ["entropy", 32, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr",
+      "id" : 2,
+      "header_type" : "hdr_t",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "hdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "action_profile.p4",
+        "line" : 45,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : ["hdr"]
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "NoAction",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "send",
+      "id" : 1,
+      "runtime_data" : [
+        {
+          "name" : "eg_port",
+          "bitwidth" : 9
+        }
+      ],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "runtime_data",
+              "value" : 0
+            }
+          ],
+          "source_info" : {
+            "filename" : "action_profile.p4",
+            "line" : 55,
+            "column" : 8,
+            "source_fragment" : "sm.egress_spec = eg_port"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "action_profile.p4",
+        "line" : 49,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "IndirectWS",
+      "tables" : [
+        {
+          "name" : "IndirectWS",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "action_profile.p4",
+            "line" : 59,
+            "column" : 10,
+            "source_fragment" : "IndirectWS"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "name" : "h.hdr.in_",
+              "target" : ["hdr", "in_"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "indirect_ws",
+          "action_profile" : "ActProfWS",
+          "max_size" : 512,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1, 0],
+          "actions" : ["send", "NoAction"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "send" : null,
+            "NoAction" : null
+          }
+        }
+      ],
+      "action_profiles" : [
+        {
+          "name" : "ActProfWS",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "action_profile.p4",
+            "line" : 51,
+            "column" : 56,
+            "source_fragment" : "ActProfWS"
+          },
+          "max_size" : 128,
+          "selector" : {
+            "algo" : "crc16",
+            "input" : [
+              {
+                "type" : "field",
+                "value" : ["hdr", "entropy"]
+              }
+            ]
+          }
+        }
+      ],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "action_profile.p4",
+        "line" : 41,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.recirculate_flag",
+      ["standard_metadata", "recirculate_flag"]
+    ]
+  ],
+  "program" : "action_profile.p4",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/targets/simple_switch_grpc/tests/testdata/action_profile.p4
+++ b/targets/simple_switch_grpc/tests/testdata/action_profile.p4
@@ -1,0 +1,74 @@
+/* Copyright 2019-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr_t {
+    bit<8> in_;
+    bit<32> entropy;
+}
+
+struct Headers {
+    hdr_t hdr;
+}
+
+struct Meta {}
+
+parser p(packet_in b, out Headers h,
+         inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.hdr);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {}
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply { b.emit(h); }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name(".ActProfWS")
+    action_selector(HashAlgorithm.crc16, 32w128, 32w16) ActProfWS;
+
+    @name(".send")
+    action send(bit<9> eg_port) {
+        sm.egress_spec = eg_port;
+    }
+
+    @name(".IndirectWS")
+    table IndirectWS {
+        key = {
+            h.hdr.in_ : exact;
+            h.hdr.entropy : selector;
+        }
+        actions = { send; }
+        implementation = ActProfWS;
+        size = 512;
+    }
+
+    apply {
+        IndirectWS.apply();
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/targets/simple_switch_grpc/tests/testdata/action_profile.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/action_profile.proto.txt
@@ -1,0 +1,57 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33586946
+    name: "IndirectWS"
+    alias: "IndirectWS"
+  }
+  match_fields {
+    id: 1
+    name: "h.hdr.in_"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16811746
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  implementation_id: 285237193
+  size: 512
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16811746
+    name: "send"
+    alias: "send"
+  }
+  params {
+    id: 1
+    name: "eg_port"
+    bitwidth: 9
+  }
+}
+action_profiles {
+  preamble {
+    id: 285237193
+    name: "ActProfWS"
+    alias: "ActProfWS"
+  }
+  table_ids: 33586946
+  with_selector: true
+  size: 128
+}
+type_info {
+}

--- a/targets/simple_switch_grpc/tests/utils.cpp
+++ b/targets/simple_switch_grpc/tests/utils.cpp
@@ -83,6 +83,15 @@ int get_digest_id(const p4::config::v1::P4Info &p4info,
   return 0;
 }
 
+int get_act_prof_id(const p4configv1::P4Info &p4info,
+                    const std::string &act_prof_name) {
+  for (const auto &act_prof : p4info.action_profiles()) {
+    const auto &pre = act_prof.preamble();
+    if (pre.name() == act_prof_name) return pre.id();
+  }
+  return 0;
+}
+
 p4configv1::P4Info parse_p4info(const char *path) {
   p4configv1::P4Info p4info;
   std::ifstream istream(path);

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -50,6 +50,9 @@ int get_param_id(const p4::config::v1::P4Info &p4info,
 int get_digest_id(const p4::config::v1::P4Info &p4info,
                   const std::string &digest_name);
 
+int get_act_prof_id(const p4::config::v1::P4Info &p4info,
+                    const std::string &act_prof_name);
+
 p4::config::v1::P4Info parse_p4info(const char *path);
 
 template <typename StreamType, typename MessageType>

--- a/tests/test_tables.cpp
+++ b/tests/test_tables.cpp
@@ -1949,8 +1949,8 @@ TEST_F(TableIndirectWS, CustomGroupSelection) {
   };
 
   ASSERT_EQ(&action_profile, table->get_action_profile());
-  GroupSelection selector(mbrs, grp);
-  action_profile.set_group_selector(&selector);
+  auto selector = std::make_shared<GroupSelection>(mbrs, grp);
+  action_profile.set_group_selector(selector);
 
   grp_hdl_t grp_1;
   mbr_hdl_t mbr_1, mbr_2;


### PR DESCRIPTION
This in turn enables support for P4Runtime watch ports.
We leverage the ability to register a custom "selector" object with bmv2
ActionProfile instances, which takes care of dataplane member selection based on
a hash value computed by bmv2. This "selector" is notified by bmv2 when a member
is added / removed and by PI when a member is activated / deactivated.