### PR TITLE
Remove SimpleSwitchGrpcRunner::mirroring_mapping_add

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -665,15 +665,6 @@ SimpleSwitchGrpcRunner::shutdown() {
   PIGrpcServerShutdown();
 }
 
-int
-SimpleSwitchGrpcRunner::mirroring_mapping_add(int mirror_id,
-  bm::DevMgrIface::port_t egress_port) {
-  SimpleSwitch::MirroringSessionConfig config = {};
-  config.egress_port = egress_port;
-  config.egress_port_valid = true;
-  return simple_switch->mirroring_add_session(mirror_id, config);
-}
-
 void
 SimpleSwitchGrpcRunner::block_until_all_packets_processed() {
   simple_switch->block_until_no_more_packets();

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -70,10 +70,6 @@ class SimpleSwitchGrpcRunner {
   int get_dp_grpc_server_port() {
     return dp_grpc_server_port;
   }
-  // TODO(dushyantarora): Remove this API once P4Runtime supports configuring
-  // mirroring sessions
-  int mirroring_mapping_add(int mirror_id,
-                            bm::DevMgrIface::port_t egress_port);
   void block_until_all_packets_processed();
   bool is_dp_service_active();
 


### PR DESCRIPTION
Now that P4Runtime cloning support has been implemented.