### PR TITLE
Implement new PI functions

### DIFF
--- a/PI/src/common.h
+++ b/PI/src/common.h
@@ -85,6 +85,14 @@ class Buffer {
   std::vector<char> data_{};
 };
 
+// We return a dummy value (0xff..ff) for the default handle. bmv2 currently
+// does not support direct resources (direct counter / direct meter) for default
+// entries so we will return an error if this handle is used to read / write
+// direct resource configurations.
+static inline constexpr pi_entry_handle_t get_default_handle() {
+  return static_cast<pi_entry_handle_t>(-1);
+}
+
 }  // namespace pibmv2
 
 #endif  // SRC_COMMON_H_

--- a/PI/src/pi_counter_imp.cpp
+++ b/PI/src/pi_counter_imp.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/switch.h>
 
 #include <PI/p4info.h>
@@ -126,6 +127,13 @@ pi_status_t _pi_counter_read_direct(pi_session_handle_t session_handle,
   _BM_UNUSED(session_handle);
   _BM_UNUSED(flags);
 
+  // bmv2 currently does not support direct counters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    bm::Logger::get()->error(
+        "[PI] bmv2 does not support direct counters for default entries");
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
+
   const auto *p4info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(p4info != nullptr);
   std::string t_name = get_direct_t_name(p4info, counter_id);
@@ -145,6 +153,13 @@ pi_status_t _pi_counter_write_direct(pi_session_handle_t session_handle,
                                      pi_entry_handle_t entry_handle,
                                      const pi_counter_data_t *counter_data) {
   _BM_UNUSED(session_handle);
+
+  // bmv2 currently does not support direct counters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    bm::Logger::get()->error(
+        "[PI] bmv2 does not support direct counters for default entries");
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
 
   const auto *p4info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(p4info != nullptr);

--- a/PI/src/pi_meter_imp.cpp
+++ b/PI/src/pi_meter_imp.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/switch.h>
 
 #include <PI/p4info.h>
@@ -95,6 +96,13 @@ pi_status_t _pi_meter_read_direct(pi_session_handle_t session_handle,
                                   pi_meter_spec_t *meter_spec) {
   _BM_UNUSED(session_handle);
 
+  // bmv2 currently does not support direct neters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    bm::Logger::get()->error(
+        "[PI] bmv2 does not support direct meters for default entries");
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
+
   const auto *p4info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(p4info != nullptr);
   std::string t_name = get_direct_t_name(p4info, meter_id);
@@ -114,6 +122,13 @@ pi_status_t _pi_meter_set_direct(pi_session_handle_t session_handle,
                                  pi_entry_handle_t entry_handle,
                                  const pi_meter_spec_t *meter_spec) {
   _BM_UNUSED(session_handle);
+
+  // bmv2 currently does not support direct neters for default entries
+  if (entry_handle == pibmv2::get_default_handle()) {
+    bm::Logger::get()->error(
+        "[PI] bmv2 does not support direct meters for default entries");
+    return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
+  }
 
   const auto *p4info = pibmv2::get_device_info(dev_tgt.dev_id);
   assert(p4info != nullptr);

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -53,7 +53,7 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
     argv.push_back("45459");
 #endif  // WITH_THRIFT
     // you can uncomment this when debugging
-    // argv.push_back("--log-console");
+    argv.push_back("--log-console");
     argv.push_back(start_json);
     auto argc = static_cast<int>(argv.size());
     parser.parse(argc, const_cast<char **>(argv.data()), nullptr);


### PR DESCRIPTION
Ability to read single match table entries with:
 * pi_table_entries_fetch_one
 * pi_table_entries_fetch_wkey

Ability to read single action profile members / groups with:
 * pi_act_prof_mbr_fetch
 * pi_act_prof_grp_fetch

Also added a dummy implementation for
pi_table_default_action_get_handle. Note that at the moment bmv2 does
not support direct resources (meter / counter) for default entries, so
the handle which is returned by this function is very much useless.