### PR TITLE
Make thrift's installation friendly for chinese user

### DIFF
--- a/travis/install-thrift.sh
+++ b/travis/install-thrift.sh
@@ -6,7 +6,6 @@ source $THIS_DIR/common.sh
 check_lib libthrift libthrift-0.9.2
 
 set -e
-# Modified By Polly
 # Make it possible to get thrift in China
 # wget http://archive.apache.org/dist/thrift/0.9.2/thrift-0.9.2.tar.gz
 # tar -xzvf thrift-0.9.2.tar.gz

--- a/travis/install-thrift.sh
+++ b/travis/install-thrift.sh
@@ -6,8 +6,11 @@ source $THIS_DIR/common.sh
 check_lib libthrift libthrift-0.9.2
 
 set -e
-wget http://archive.apache.org/dist/thrift/0.9.2/thrift-0.9.2.tar.gz
-tar -xzvf thrift-0.9.2.tar.gz
+# Modified By Polly
+# Make it possible to get thrift in China
+# wget http://archive.apache.org/dist/thrift/0.9.2/thrift-0.9.2.tar.gz
+# tar -xzvf thrift-0.9.2.tar.gz
+git clone -b 0.9.2 https://github.com/apache/thrift.git thrift-0.9.2
 cd thrift-0.9.2
 ./configure --with-cpp=yes --with-c_glib=no --with-java=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no
 make -j2 && sudo make install

--- a/travis/install-thrift.sh
+++ b/travis/install-thrift.sh
@@ -11,6 +11,7 @@ set -e
 # tar -xzvf thrift-0.9.2.tar.gz
 git clone -b 0.9.2 https://github.com/apache/thrift.git thrift-0.9.2
 cd thrift-0.9.2
+./bootstrap.sh
 ./configure --with-cpp=yes --with-c_glib=no --with-java=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no
 make -j2 && sudo make install
 cd lib/py


### PR DESCRIPTION
When I started to lean P4 in China, it is hard to build the environment, the shell script always interrupt, then I find it is thrift's problem.
Change the install-thrift.sh
To get thrift from git instead of .org web site
Wish you to accept this request to make more chinese to join the P4 study 