### PR TITLE
Stop using deprecated version of DeviceMgr::init in sswitch_grpc

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -506,7 +506,7 @@ SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(
       dp_grpc_server_addr(dp_grpc_server_addr),
       dp_service(nullptr),
       dp_grpc_server(nullptr) {
-  DeviceMgr::init(256);
+  DeviceMgr::init();
 }
 
 int


### PR DESCRIPTION
PI stopped requiring the max number of devices to be provided at
initialization time. DeviceMgr::init was recently updated to reflect
that, by introducing an overload of DeviceMgr::init with no parameters,
and deprecating the old overload.