### PR TITLE
Support lvalue expressions

### DIFF
--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -92,8 +92,6 @@ class P4Objects {
     std::set<std::string> headers;
   };
 
-  enum class ExprType;  // forward declaration
-
  public:
   // NOLINTNEXTLINE(runtime/references)
   explicit P4Objects(std::ostream &outstream, bool verbose_output = false);

--- a/tests/test_conditionals.cpp
+++ b/tests/test_conditionals.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2013-present Barefoot Networks, Inc.
+/* Copyright 2013-2019 Barefoot Networks, Inc.
+ * Copyright 2019 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
@@ -46,7 +47,6 @@ class ConditionalsTest : public ::testing::Test {
   header_id_t testHeader1{0}, testHeader2{1};
 
   header_stack_id_t testHeaderStack{0};
-  size_t stack_depth{2};
 
   ConditionalsTest()
     : testHeaderType("test_t", 0) {
@@ -793,7 +793,6 @@ class ConditionalsUnionTest : public ConditionalsTest {
   header_union_id_t testHeaderUnion1{1};
 
   header_union_stack_id_t testHeaderUnionStack{0};
-  size_t union_stack_depth{2};
 
   ConditionalsUnionTest() {
     phv_factory.push_back_header("test3", testHeader3, testHeaderType);


### PR DESCRIPTION
The bmv2 expression engine can now returns references to bmv2 primitive
objects (Data, Header, ...) when the expression being evaluated is an
lvalue. This means that we can now handle assignments to complex lvalue
expressions which do not statically resolve to a field / header /
union. One example would be an assignment to a header stack field
accessed through a runtime index.

Unit tests were added, although at the moment they do not support all
the possible cases (e.g. expressions which evaluate to a header union).

The JSON version number was bumped up to 2.23. Even though no additions
were made to the format, we now support additional cases and the
documentation now includes an example of a "complex" assignment
statement.

Fixes #838