### PR TITLE
Add support for match_kind optional to BMv2 JSON file

### DIFF
--- a/docs/JSON_format.md
+++ b/docs/JSON_format.md
@@ -606,7 +606,7 @@ attributes for these objects are:
   - `support_timeout`: a boolean, `true` iff the match table supports ageing
   - `key`: the lookup key format, represented by a JSON array. Each member of
   the array is a JSON object with the following attributes:
-    - `match_type`: one of `valid`, `exact`, `lpm`, `ternary`, `range`
+    - `match_type`: one of `valid`, `exact`, `lpm`, `optional`, `ternary`, `range`
     - `target`: the field reference as a 2-tuple (or header as a string if
       `match_type` if `valid`)
     - `mask`: the static mask to be applied to the field, or null. Just like for
@@ -677,7 +677,7 @@ these objects are:
 
 The `match_type` for the table needs to follow the following rules:
 - If one match field is `range`, the table `match_type` has to be `range`
-- If one match field is `ternary`, the table `match_type` has to be `ternary`
+- If one match field is `ternary` or `optional`, the table `match_type` has to be `ternary`
 - If one match field is `lpm`, the table `match_type` is either `ternary` or
 `lpm`
 Note that it is not correct to have more than one `lpm` match field in the same
@@ -689,13 +689,13 @@ We describe the format of the match-action entries contained in the `entries`
 JSON array (see table JSON format above). Each entry is a JSON object with the
 following attributes:
 - `match_key`: a JSON array of objects with the following attributes:
-  - `match_type`: one of `valid`, `exact`, `lpm`, `ternary`, `range`
+  - `match_type`: one of `valid`, `exact`, `lpm`, `optional`, `ternary`, `range`
   - the other attributes depend on the `match_type`:
     - for `valid`: we need a `key` attribute which has to be a boolean
     - for `exact`: we need a `key` attribute which has to be a hexstring
     - for `lpm`: we need a `key` attribute which has to be a hexstring and a
     `prefix_length` attribute which has to be an integer
-    - for `ternary`: we need a `key` and a `mask` attributes which both have to
+    - for `ternary` or `optional`: we need a `key` and a `mask` attributes which both have to
     be hexstrings
     - for `range`: we need a `start` and a `end` attribute which both have to be
     hexstrings

--- a/include/bm/bm_sim/match_units.h
+++ b/include/bm/bm_sim/match_units.h
@@ -50,11 +50,14 @@ struct MatchKeyParam {
   // VALID used to be before RANGE, but when RANGE support was added, it was
   // easier (implementation-wise) to put RANGE first. Note that this order only
   // matters for the implementation.
+  // TODO(jafingerhut): Where should OPTIONAL be added in this
+  // sequence, if order is important?
   enum class Type {
     RANGE,
     VALID,
     EXACT,
     LPM,
+    OPTIONAL,
     TERNARY
   };
 

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1469,7 +1469,8 @@ MatchKeyParam::Type match_name_to_match_type(const std::string &name) {
         {"lpm", MatchKeyParam::Type::LPM},
         {"ternary", MatchKeyParam::Type::TERNARY},
         {"valid", MatchKeyParam::Type::VALID},
-        {"range", MatchKeyParam::Type::RANGE} };
+        {"range", MatchKeyParam::Type::RANGE},
+        {"optional", MatchKeyParam::Type::OPTIONAL} };
 
   auto it = map_name_to_match_type.find(name);
   if (it == map_name_to_match_type.end())
@@ -1527,6 +1528,7 @@ std::vector<MatchKeyParam> parse_match_key(
                                cfg_f["prefix_length"].asInt());
         break;
       case MatchKeyParam::Type::TERNARY:
+      case MatchKeyParam::Type::OPTIONAL:
         match_key.emplace_back(match_type,
                                transform_hexstr(cfg_f["key"].asString()),
                                transform_hexstr(cfg_f["mask"].asString()));

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -51,7 +51,7 @@ create_match_unit(const std::string match_type, const size_t size,
   else if (match_type == "lpm")
     match_unit = std::unique_ptr<MULPM>(
         new MULPM(size, match_key_builder, lookup_factory));
-  else if (match_type == "ternary")
+  else if ((match_type == "ternary") || (match_type == "optional"))
     match_unit = std::unique_ptr<MUTernary>(
         new MUTernary(size, match_key_builder, lookup_factory));
   else if (match_type == "range")

--- a/src/bm_sim/match_units.cpp
+++ b/src/bm_sim/match_units.cpp
@@ -66,6 +66,8 @@ MatchKeyParam::type_to_string(Type t) {
       return "LPM";
     case Type::TERNARY:
       return "TERNARY";
+    case Type::OPTIONAL:
+      return "OPTIONAL";
   }
   return "";
 }
@@ -86,6 +88,7 @@ std::ostream& operator<<(std::ostream &out, const MatchKeyParam &p) {
       out << "/" << p.prefix_length;
       break;
     case MatchKeyParam::Type::TERNARY:
+    case MatchKeyParam::Type::OPTIONAL:
       out << " &&& ";
       dump_hexstring(out, p.mask);
       break;
@@ -383,6 +386,7 @@ class MatchKeyBuilderHelper {
           // should only happen for RangeMatchKey
           // range treated the same as ternary
         case MatchKeyParam::Type::TERNARY:
+        case MatchKeyParam::Type::OPTIONAL:
           {
             auto mask_start = key.mask.begin() + byte_offset;
             auto mask_end = mask_start + nbytes;
@@ -468,6 +472,7 @@ class MatchKeyBuilderHelper {
           break;
         case MatchKeyParam::Type::RANGE:
         case MatchKeyParam::Type::TERNARY:
+        case MatchKeyParam::Type::OPTIONAL:
           assert(0);
       }
       first_byte += param.key.size();
@@ -537,6 +542,7 @@ class MatchKeyBuilderHelper {
           break;
         case MatchKeyParam::Type::RANGE:
         case MatchKeyParam::Type::TERNARY:
+        case MatchKeyParam::Type::OPTIONAL:
           key->mask.append(param.mask);
           break;
       }
@@ -584,6 +590,7 @@ MatchKeyBuilder::match_params_sanity_check(
           return false;
         break;
       case MatchKeyParam::Type::TERNARY:
+      case MatchKeyParam::Type::OPTIONAL:
         if (param.mask.size() != nbytes) return false;
         break;
       case MatchKeyParam::Type::RANGE:


### PR DESCRIPTION
Only add a match_type of optional for individual fields of a table
search key.  The overall table match_type is still ternary if any of
the fields are match_type ternary or optional, but none are range.

const entries table fields with match_kind optional are described by
JSON keys "key" and "mask" exactly like table fields with match_kind
ternary are.  There is no difference in syntax, but the value
associated with the "mask" key will always be 0 for a completely
wildcarded field value, or all 1s in every bit position of the entire
field width for an exact match field value.  No other masks will ever
appear.