### PR TITLE
Add more commands to runtime cli

### DIFF
--- a/docs/runtime_CLI.md
+++ b/docs/runtime_CLI.md
@@ -348,7 +348,7 @@ processing.  Each of the clones is processed independently from each
 other, and independently from the original packet.
 
 Search for occurrences of the word "clone" in [this
-article](https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md#pseudocode-for-what-happens-at-the-end-of-ingress-and-egress-processing)
+article](simple_switch.md#pseudocode-for-what-happens-at-the-end-of-ingress-and-egress-processing)
 for more details on how `simple_switch` deals with cloned packets.
 
 `simple_switch` supports 32,768 independent clone sessions, numbered

--- a/docs/runtime_CLI.md
+++ b/docs/runtime_CLI.md
@@ -11,6 +11,9 @@ TODO: act_prof_modify_member
 TODO: act_prof_remove_member_from_group
 TODO: counter_read
 TODO: counter_reset
+TODO: counter_write
+TODO: get_time_elapsed
+TODO: get_time_since_epoch
 TODO: help
 TODO: load_new_config_file
 ```
@@ -164,7 +167,7 @@ LAGS
 Here we see that group 1113 has one node associated with it.  `L1h` is
 an abbreviation for `L1 handle`, which you may see in the
 simple_switch log messages, and means the same thing as a node handle.
-We see the rid value of 5, where rid is an abbrevation of
+We see the rid value of 5, where rid is an abbreviation of
 `egress_rid`, and we see the list of ports 0 and 3.
 
 In the current configuration of simple_switch, sending a packet to be
@@ -317,6 +320,99 @@ the meter type is packets, the rate is entered in packets/microsecond and
 burst_size is the number of packets.
 
 
+### mirroring_add, mirroring_add_mc, mirroring_delete, mirroring_get
+
+When any of these events happened during packet processing:
+
++ Your P4_16 v1model architecture program called `clone` or `clone3`
+  extern functions during ingress or egress processing, and now
+  ingress or egress processing has completed
++ Your P4_14 program called `clone_ingress_pkt_to_egress` during
+  ingress processing, which is now complete
++ Your P4_14 program called `clone_egress_pkt_to_egress` during egress
+  processing, which is now complete
+
+then not only will the current "original" packet continue with
+whatever it normally does, as if your program had not called a clone
+operation, but the PRE (Packet Replication Engine) part of
+`simple_switch` will also create zero or more copies, or clones, of
+the current packet, and cause them to be enqueued in the packet buffer
+such that later each of the cloned packet(s) will perform egress
+processing.  Each of the clones is processed independently from each
+other, and independently from the original packet.
+
+Search for occurrences of the word "clone" in [this
+article](https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md#pseudocode-for-what-happens-at-the-end-of-ingress-and-egress-processing)
+for more details on how `simple_switch` deals with cloned packets.
+
+TBD: How many clone sessions are supported by `simple_switch`, without
+using any special default compilation options nor modifications to the
+source code?
+
+`simple_switch` supports 1023 independent clone sessions, numbered
+from 1 up to 1023, also called mirroring sessions.  When a packet is
+cloned, you specify which clone session you want it to use in the P4
+program call of the clone operation.
+
+The purpose of the `mirroring` commands is to configure which port or
+ports the cloned packets are sent to.  This state is configured
+independently for each clone session numeric id.
+
+By default, when `simple_switch` starts, every clone session id is in
+an unconfigured state.  Any clone operation done for a clone session
+id that is in this unconfigured state will create 0 clone packets,
+i.e. the packet processing behavior will be the same as if you did not
+call a clone operation at all.
+
+If you use the command `mirroring_add 5 7`, the configuration of clone
+session id number 5 is changed such that future clone operations that
+use clone session 5 will create a single clone packet destined for
+egress port 7.
+
+```
+RuntimeCmd: help mirroring_add
+Add mirroring session to unicast port: mirroring_add <mirror_id> <egress_port>
+
+RuntimeCmd: mirroring_add 5 7
+
+RuntimeCmd: mirroring_get 5
+MirroringSessionConfig(mgid=None, port=7)
+```
+
+Using the command `mirroring_add_mc 5 22` modifies the configuration
+of clone session id number 5 such that future clone operations that
+use clone session 5 will create as many clones as the multicast group
+id 22 is configured to create.  See the `mc_mgrp_create` and related
+multicast group configuration commands for how to configure a
+multicast group.
+
+```
+RuntimeCmd: help mirroring_add_mc
+Add mirroring session to multicast group: mirroring_add_mc <mirror_id> <mgrp>
+
+RuntimeCmd: mirroring_add_mc 5 22
+
+RuntimeCmd: mirroring_get 5
+MirroringSessionConfig(mgid=22, port=None)
+```
+
+The command `mirroring_delete 5` returns the clone session id number 5
+to its original unconfigured state.
+
+```
+RuntimeCmd: help mirroring_delete
+Delete mirroring session: mirroring_delete <mirror_id>
+
+RuntimeCmd: mirroring_delete 5
+
+RuntimeCmd: mirroring_get 5
+Invalid mirroring operation (SESSION_NOT_FOUND)
+```
+
+The `mirroring_get` command can be used to show the current
+configuration of a clone session.
+
+
 ```
 TODO: port_add
 TODO: port_remove
@@ -327,6 +423,8 @@ TODO: reset_state
 TODO: serialize_state
 TODO: set_crc16_parameters
 TODO: set_crc32_parameters
+TODO: set_queue_depth
+TODO: set_queue_rate
 TODO: shell
 ```
 

--- a/docs/runtime_CLI.md
+++ b/docs/runtime_CLI.md
@@ -12,8 +12,8 @@ TODO: act_prof_remove_member_from_group
 TODO: counter_read
 TODO: counter_reset
 TODO: counter_write
-TODO: get_time_elapsed
-TODO: get_time_since_epoch
+TODO: get_time_elapsed [simple_switch_CLI only]
+TODO: get_time_since_epoch [simple_switch_CLI only]
 TODO: help
 TODO: load_new_config_file
 ```
@@ -322,6 +322,8 @@ burst_size is the number of packets.
 
 ### mirroring_add, mirroring_add_mc, mirroring_delete, mirroring_get
 
+[simple_switch_CLI only]
+
 When any of these events happened during packet processing:
 
 + Your P4_16 v1model architecture program called `clone` or `clone3`
@@ -345,12 +347,8 @@ Search for occurrences of the word "clone" in [this
 article](https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md#pseudocode-for-what-happens-at-the-end-of-ingress-and-egress-processing)
 for more details on how `simple_switch` deals with cloned packets.
 
-TBD: How many clone sessions are supported by `simple_switch`, without
-using any special default compilation options nor modifications to the
-source code?
-
-`simple_switch` supports 1023 independent clone sessions, numbered
-from 1 up to 1023, also called mirroring sessions.  When a packet is
+`simple_switch` supports 32,768 independent clone sessions, numbered
+from 0 up to 32,767, also called mirroring sessions.  When a packet is
 cloned, you specify which clone session you want it to use in the P4
 program call of the clone operation.
 
@@ -423,8 +421,8 @@ TODO: reset_state
 TODO: serialize_state
 TODO: set_crc16_parameters
 TODO: set_crc32_parameters
-TODO: set_queue_depth
-TODO: set_queue_rate
+TODO: set_queue_depth [simple_switch_CLI only]
+TODO: set_queue_rate [simple_switch_CLI only]
 TODO: shell
 ```
 

--- a/docs/runtime_CLI.md
+++ b/docs/runtime_CLI.md
@@ -1,3 +1,7 @@
+Most of the commands in here are common to runtime_CLI and
+simple_switch_CLI, but a few exist only in simple_switch_CLI.  Those
+are marked [simple_switch_CLI only].
+
 ```
 TODO: act_prof_add_member_to_group
 TODO: act_prof_create_group
@@ -25,7 +29,7 @@ ingress P4 code can assign values to a few fields in standard_metadata
 that control whether the packet is dropped, sent via unicast to one
 output port, or multicast replicated to a list of 0 or more output
 ports.  See
-[here](https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md#pseudocode-for-what-happens-at-the-end-of-ingress-and-egress-processing)
+[here](simple_switch.md#pseudocode-for-what-happens-at-the-end-of-ingress-and-egress-processing)
 for more details on how `simple_switch` decides between these
 alternatives.
 

--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -202,7 +202,7 @@ After-ingress pseudocode - the short version:
 
 ```
 if (a clone primitive action was called) {
-    make a clone of the packet with details configured for the clone session
+    create clone(s) of the packet with details configured for the clone session
 }
 if (digest to generate) {   // because your code called generate_digest
     send a digest message to the control plane software
@@ -229,25 +229,38 @@ if (a clone primitive action was called) {
     // `clone_ingress_pkt_to_egress` primitive action in a P4_14
     // program, during ingress processing.
 
-    Make a clone of the packet destined for the egress_port configured
-    in the clone (aka mirror) session id number that was given when the
-    last clone primitive action was called.
+    Create zero or more clones of the packet.  The cloned packet(s)
+    will be enqueued in the packet buffer, destined for the egress
+    port(s) configured in the clone session whose numeric id was given
+    as the value of the `session` parameter when the last clone
+    primitive action was called.
 
-    The packet contents will be the same as when it most recently
-    began the ingress processing, where the clone operation was
-    performed, without any modifications that may have been made
-    during the execution of that ingress code.  (That may not be the
-    packet as originally received by the switch, if the packet reached
-    this occurrence of ingress processing via a recirculate operation,
-    for example.)
+    Each cloned packet will later perform egress processing,
+    independently from whatever the original packet does next, and if
+    multiple cloned packets are created via the same clone operation,
+    independently from each other.
+
+    The contents of the cloned packet(s) will be the same as the
+    packet when it most recently began ingress processing, where the
+    clone operation was performed, without any modifications that may
+    have been made during the execution of that ingress code.  (That
+    may not be the packet as originally received by the switch, if the
+    packet reached this occurrence of ingress processing via a
+    recirculate operation, for example.)
 
     If it was a clone3 (P4_16) or clone_ingress_pkt_to_egress (P4_14)
     action, also preserve the final ingress values of the metadata
     fields specified in the field list argument, except assign
     instance_type a value of PKT_INSTANCE_TYPE_INGRESS_CLONE.
 
-    The cloned packet will continue processing at the beginning of
-    your egress code.
+    Each cloned packet will be processed by your parser code again.
+    In many cases this will result in exactly the same headers being
+    parsed as when the packet was most recently parsed, but if your
+    parser code uses the value of standard_metadata.instance_type to
+    affect its behavior, it could be different.
+
+    After this parsing is done, each clone will continue processing at
+    the beginning of your egress code.
     // fall through to code below
 }
 if (digest to generate) {
@@ -291,7 +304,7 @@ After-egress pseudocode - the short version:
 
 ```
 if (a clone primitive action was called) {
-    make a clone of the packet with details configured for the clone session
+    create clone(s) of the packet with details configured for the clone session
 }
 if (egress_spec == DROP_PORT) {  // e.g. because your code called drop/mark_to_drop
     Drop packet.
@@ -313,20 +326,33 @@ if (a clone primitive action was called) {
     // `clone_egress_pkt_to_egress` primitive action in a P4_14
     // program, during egress processing.
 
-    Make a clone of the packet destined for the egress_port configured
-    in the clone (aka mirror) session id number that was given when the
-    last clone or clone3 primitive action was called.
+    Create zero or more clones of the packet.  The cloned packet(s)
+    will be enqueued in the packet buffer, destined for the egress
+    port(s) configured in the clone session whose numeric id was given
+    as the value of the `session` parameter when the last clone
+    primitive action was called.
 
-    The packet contents will be as constructed by the deparser after
-    egress processing, with any modifications made to the packet
-    during both ingress and egress processing.
+    Each cloned packet will later perform egress processing,
+    independently from whatever the original packet does next, and if
+    multiple cloned packets are created via the same clone operation,
+    independently from each other.
+
+    The contents of the cloned packet(s) will be as they are at the
+    end of egress processing, including any changes made to the values
+    of fields in headers, whether headers were made valid or invalid.
+    Your deparser code will _not_ be executed for the egress-to-egress
+    cloned packets, nor will egress-to-egress cloned packets execute
+    your parser code again.
 
     If it was a clone3 (P4_16) or clone_egress_pkt_to_egress (P4_14)
     action, also preserve the final egress values of the metadata
     fields specified in the field list argument, except assign
-    instance_type a value of PKT_INSTANCE_TYPE_EGRESS_CLONE.
+    instance_type a value of PKT_INSTANCE_TYPE_EGRESS_CLONE.  Each
+    cloned packet will have the same standard_metadata fields
+    overwritten that all packets that begin egress processing do,
+    e.g. egress_port, egress_spec, egress_global_timestamp, etc.
 
-    The cloned packet will continue processing at the beginning of
+    Each cloned packet will continue processing at the beginning of
     your egress code.
     // fall through to code below
 }

--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -339,10 +339,10 @@ if (a clone primitive action was called) {
 
     The contents of the cloned packet(s) will be as they are at the
     end of egress processing, including any changes made to the values
-    of fields in headers, whether headers were made valid or invalid.
-    Your deparser code will _not_ be executed for the egress-to-egress
-    cloned packets, nor will egress-to-egress cloned packets execute
-    your parser code again.
+    of fields in headers, and whether headers were made valid or
+    invalid.  Your deparser code will _not_ be executed for
+    egress-to-egress cloned packets, nor will your parser code be
+    executed for them.
 
     If it was a clone3 (P4_16) or clone_egress_pkt_to_egress (P4_14)
     action, also preserve the final egress values of the metadata


### PR DESCRIPTION
Also make several corrections and clarifications to the documentation
describing how cloned packets are handled by simple_switch, and add
several simple_switch_CLI commands that were not added earlier.

Also add several simple_switch_CLI commands that were not added earlier.