### PR TITLE
Add support for parser value sets (PVS) to runtime_CLI

### DIFF
--- a/docs/runtime_CLI.md
+++ b/docs/runtime_CLI.md
@@ -418,6 +418,50 @@ configuration of a clone session.
 ```
 TODO: port_add
 TODO: port_remove
+```
+
+### pvs_add, pvs_clear, pvs_get, pvs_remove
+
+These commands are used to control an instance of a P4 parser value
+set. `pvs_add` is used to add an entry to a value set, `pvs_remove` is used to
+remove an entry, `pvs_clear` is used to remove *all* entries, and `pvs_get` is
+used to list all entries.
+
+P4 allows a value_set to take a struct as the type parameter, such as in the
+following example:
+```
+struct vsk_t {
+    bit<16> f1;
+    bit<7> f2;
+}
+value_set<vsk_t>(4) pvs;
+select (<X>) {
+    pvs: accept;
+    _: reject;
+}
+```
+When adding or removing an entry, you must provide a single integer value, which
+must fit within the value set's "compressed bitwidth", or the CLI will display
+an error. When a value set's entries consist of multiple individual fields, as
+is the case in the example above, the "compressed bitwidth" is defined as the
+sum of the bitwidths of all these individual fields, without padding. When the
+type parameter for the value set is an integer (signed or unsigned), or a struct
+with a single field, the "compressed bitwidth" is simply the bitwidth of the
+integer / field.
+
+In the future, the CLI may provide a more intuitive interface and enable you to
+provide individual integer values for the different fields which constitute the
+value set entry. However, at the moment, you need to concatenate them yourself.
+
+Note that `pvs_add` will not warn you if the value you are adding already
+exists, and neither will `pvs_remove` if the value you want to remove does not
+exist in the value set.
+
+The bmv2 value set implementation does *not* support match types other than
+exact.
+
+
+```
 TODO: register_read
 TODO: register_reset
 TODO: register_write
@@ -441,6 +485,14 @@ shown.
 
 No parameters.  Shows the port numbers, the interface names they are associated
 with, and their status (e.g. up or down).
+
+
+### show_pvs
+
+No parameters.  For every parser value set in the currently loaded P4 program,
+shows the name and the expected bitwidth of entries.  When adding entries with
+the `pvs_add` command, the user must provide integer values no larger than this
+bitwidth.
 
 
 ### show_tables

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -393,6 +393,13 @@ class Context final {
   parse_vset_remove(const std::string &parse_vset_name,
                     const ByteContainer &value);
 
+  ParseVSet::ErrorCode
+  parse_vset_get(const std::string &parse_vset_name,
+                 std::vector<ByteContainer> *values);
+
+  ParseVSet::ErrorCode
+  parse_vset_clear(const std::string &parse_vset_name);
+
   P4Objects::IdLookupErrorCode p4objects_id_from_name(
       P4Objects::ResourceType type, const std::string &name,
       p4object_id_t *id) const;

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -159,6 +159,8 @@ class ParseVSetIface {
   virtual size_t size() const = 0;
 };
 
+class ParseVSetBase;  // forward declaration
+
 // Note that as of today, all parse states using a vset have to be configured
 // before any value can be added to a vset (otherwise the value won't be present
 // in the shadow copies). This can be easily changed if the need arises in the
@@ -173,6 +175,8 @@ class ParseVSet : public NamedP4Object, public ParseVSetIface {
   ParseVSet(const std::string &name, p4object_id_t id,
             size_t compressed_bitwidth);
 
+  ~ParseVSet();
+
   void add(const ByteContainer &v) override;
 
   void remove(const ByteContainer &v) override;
@@ -185,6 +189,8 @@ class ParseVSet : public NamedP4Object, public ParseVSetIface {
 
   size_t get_compressed_bitwidth() const;
 
+  std::vector<ByteContainer> get() const;
+
  private:
   void add_shadow(ParseVSetIface *shadow);
 
@@ -194,7 +200,7 @@ class ParseVSet : public NamedP4Object, public ParseVSetIface {
   // (each shadow has its own).
   mutable std::mutex shadows_mutex{};
   std::vector<ParseVSetIface *> shadows{};
-  std::unique_ptr<ParseVSetIface> base{nullptr};
+  std::unique_ptr<ParseVSetBase> base;
 };
 
 class ParseSwitchCaseIface {

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -368,6 +368,13 @@ class RuntimeInterface {
   parse_vset_remove(cxt_id_t cxt_id, const std::string &parse_vset_name,
                     const ByteContainer &value) = 0;
 
+  virtual ParseVSet::ErrorCode
+  parse_vset_get(cxt_id_t cxt_id, const std::string &parse_vset_name,
+                 std::vector<ByteContainer> *values) = 0;
+
+  virtual ParseVSet::ErrorCode
+  parse_vset_clear(cxt_id_t cxt_id, const std::string &parse_vset_name) = 0;
+
   virtual ErrorCode
   load_new_config(const std::string &new_config) = 0;
 

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -788,6 +788,18 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).parse_vset_remove(parse_vset_name, value);
   }
 
+  ParseVSet::ErrorCode
+  parse_vset_get(cxt_id_t cxt_id, const std::string &parse_vset_name,
+                 std::vector<ByteContainer> *values) override {
+    return contexts.at(cxt_id).parse_vset_get(parse_vset_name, values);
+  }
+
+  ParseVSet::ErrorCode
+  parse_vset_clear(cxt_id_t cxt_id,
+                   const std::string &parse_vset_name) override {
+    return contexts.at(cxt_id).parse_vset_clear(parse_vset_name);
+  }
+
   RuntimeInterface::ErrorCode
   reset_state() override;
 

--- a/src/bm_runtime/Standard_server.cpp
+++ b/src/bm_runtime/Standard_server.cpp
@@ -1059,6 +1059,32 @@ public:
     }
   }
 
+  void bm_parse_vset_get(std::vector<BmParseVSetValue> & _return, const int32_t cxt_id, const std::string& parse_vset_name) {
+    Logger::get()->trace("bm_parse_vset_get");
+    std::vector<ByteContainer> entries;
+    ParseVSet::ErrorCode error_code = switch_->parse_vset_get(
+        cxt_id, parse_vset_name, &entries);
+    if(error_code != ParseVSet::ErrorCode::SUCCESS) {
+      InvalidParseVSetOperation ipo;
+      ipo.code = (ParseVSetOperationErrorCode::type) error_code;
+      throw ipo;
+    }
+    for (const auto &entry: entries) {
+      _return.emplace_back(entry.data(), entry.size());
+    }
+  }
+
+  void bm_parse_vset_clear(const int32_t cxt_id, const std::string& parse_vset_name) {
+    Logger::get()->trace("bm_parse_vset_clear");
+    ParseVSet::ErrorCode error_code = switch_->parse_vset_clear(
+        cxt_id, parse_vset_name);
+    if(error_code != ParseVSet::ErrorCode::SUCCESS) {
+      InvalidParseVSetOperation ipo;
+      ipo.code = (ParseVSetOperationErrorCode::type) error_code;
+      throw ipo;
+    }
+  }
+
   void bm_dev_mgr_add_port(const std::string& iface_name, const int32_t port_num, const std::string& pcap_path) {
     Logger::get()->trace("bm_dev_mgr_add_port");
     DevMgrIface::PortExtras port_extras;

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1238,9 +1238,18 @@ P4Objects::init_parsers(const Json::Value &cfg_root, InitState *init_state) {
           if (cfg_mask.isNull()) {
             parse_state->add_switch_case_vset(vset, next_state);
           } else {
-            const string mask_hexstr = cfg_mask.asString();
+            ByteContainer mask(cfg_mask.asString());
+            auto expected_width = (vset->get_compressed_bitwidth() + 7) / 8;
+            if (mask.size() != expected_width) {
+              throw json_exception(
+                  EFormat() << "Parser transition mask for value set has "
+                            << "incorrect width, expected width is "
+                            << expected_width << " bytes "
+                            << "but actual width is " << mask.size()
+                            << " bytes", cfg_transition);
+            }
             parse_state->add_switch_case_vset_with_mask(
-                vset, ByteContainer(mask_hexstr), next_state);
+                vset, ByteContainer(mask), next_state);
           }
         }
       }

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -659,9 +659,28 @@ ParseVSet::ErrorCode
 Context::parse_vset_remove(const std::string &parse_vset_name,
                            const ByteContainer &value) {
   boost::shared_lock<boost::shared_mutex> lock(request_mutex);
-  ParseVSet *parse_vset = p4objects_rt->get_parse_vset_rt(parse_vset_name);
+  auto *parse_vset = p4objects_rt->get_parse_vset_rt(parse_vset_name);
   if (!parse_vset) return ParseVSet::ErrorCode::INVALID_PARSE_VSET_NAME;
   parse_vset->remove(value);
+  return ParseVSet::ErrorCode::SUCCESS;
+}
+
+ParseVSet::ErrorCode
+Context::parse_vset_get(const std::string &parse_vset_name,
+                        std::vector<ByteContainer> *values) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  auto *parse_vset = p4objects_rt->get_parse_vset_rt(parse_vset_name);
+  if (!parse_vset) return ParseVSet::ErrorCode::INVALID_PARSE_VSET_NAME;
+  *values = parse_vset->get();
+  return ParseVSet::ErrorCode::SUCCESS;
+}
+
+ParseVSet::ErrorCode
+Context::parse_vset_clear(const std::string &parse_vset_name) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  auto *parse_vset = p4objects_rt->get_parse_vset_rt(parse_vset_name);
+  if (!parse_vset) return ParseVSet::ErrorCode::INVALID_PARSE_VSET_NAME;
+  parse_vset->clear();
   return ParseVSet::ErrorCode::SUCCESS;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -170,4 +170,6 @@ testdata/config_options.json \
 testdata/one_extern.json \
 testdata/unions_e2e_options_bos.json \
 testdata/unions_e2e_options_count.json \
-testdata/test_logging.json
+testdata/test_logging.json \
+testdata/pvs_struct_2.p4 \
+testdata/pvs_struct_2.json

--- a/tests/testdata/pvs_struct_2.json
+++ b/tests/testdata/pvs_struct_2.json
@@ -1,0 +1,467 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 16, false],
+        ["tmp_0", 3, false],
+        ["key_0", 32, false],
+        ["_padding_0", 5, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "data_h",
+      "id" : 2,
+      "fields" : [
+        ["da", 32, false],
+        ["db", 32, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "data",
+      "id" : 2,
+      "header_type" : "data_h",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "userMetadata.data[0]",
+      "id" : 3,
+      "header_type" : "data_h",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "userMetadata.data[1]",
+      "id" : 4,
+      "header_type" : "data_h",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "userMetadata.data",
+      "id" : 0,
+      "header_type" : "data_h",
+      "size" : 2,
+      "header_ids" : [3, 4]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "data"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "&",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["data", "da"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0xffff"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_0"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "&",
+                          "left" : {
+                            "type" : "expression",
+                            "value" : {
+                              "op" : "&",
+                              "left" : {
+                                "type" : "expression",
+                                "value" : {
+                                  "op" : ">>",
+                                  "left" : {
+                                    "type" : "field",
+                                    "value" : ["data", "db"]
+                                  },
+                                  "right" : {
+                                    "type" : "hexstr",
+                                    "value" : "0x5"
+                                  }
+                                }
+                              },
+                              "right" : {
+                                "type" : "hexstr",
+                                "value" : "0xffffffff"
+                              }
+                            }
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x07"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0x07"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "parse_vset",
+              "value" : "MyParser.pvs",
+              "mask" : null,
+              "next_state" : null
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x081001",
+              "mask" : null,
+              "next_state" : "foo"
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["scalars", "tmp"]
+            },
+            {
+              "type" : "field",
+              "value" : ["scalars", "tmp_0"]
+            }
+          ]
+        },
+        {
+          "name" : "foo",
+          "id" : 1,
+          "parser_ops" : [],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [
+    {
+      "name" : "MyParser.pvs",
+      "id" : 0,
+      "compressed_bitwidth" : 19
+    }
+  ],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "tests/testdata/pvs_struct_2.p4",
+        "line" : 67,
+        "column" : 8,
+        "source_fragment" : "MyDeparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "NoAction",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "MyIngress.set_data",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "pvs_struct_2l51",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["scalars", "key_0"]
+            },
+            {
+              "type" : "field",
+              "value" : ["userMetadata.data[0]", "da"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "tests/testdata/pvs_struct_2.p4",
+            "line" : 51,
+            "column" : 16,
+            "source_fragment" : "meta.data[0].da"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "tests/testdata/pvs_struct_2.p4",
+        "line" : 46,
+        "column" : 8,
+        "source_fragment" : "MyIngress"
+      },
+      "init_table" : "tbl_pvs_struct_2l51",
+      "tables" : [
+        {
+          "name" : "tbl_pvs_struct_2l51",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "tests/testdata/pvs_struct_2.p4",
+            "line" : 51,
+            "column" : 16,
+            "source_fragment" : "meta.data[0].da"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["pvs_struct_2l51"],
+          "base_default_next" : "MyIngress.t",
+          "next_tables" : {
+            "pvs_struct_2l51" : "MyIngress.t"
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "MyIngress.t",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "tests/testdata/pvs_struct_2.p4",
+            "line" : 49,
+            "column" : 10,
+            "source_fragment" : "t"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "name" : "meta.data[0].da",
+              "target" : ["scalars", "key_0"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1, 0],
+          "actions" : ["MyIngress.set_data", "NoAction"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "MyIngress.set_data" : null,
+            "NoAction" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : false,
+            "action_data" : [],
+            "action_entry_const" : false
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "tests/testdata/pvs_struct_2.p4",
+        "line" : 58,
+        "column" : 8,
+        "source_fragment" : "MyEgress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./pvs_struct_2.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/tests/testdata/pvs_struct_2.p4
+++ b/tests/testdata/pvs_struct_2.p4
@@ -1,0 +1,71 @@
+// P4 program originally written by Andy Fingerhut (@jafingerhut) for the
+// p4lang/p4c testsuite, as pvs-struct-2-bmv2.p4.
+
+#include <v1model.p4>
+
+header data_h {
+  bit<32> da;
+  bit<32> db;
+}
+
+struct my_packet {
+  data_h data;
+}
+
+struct my_metadata {
+  data_h[2] data;
+}
+
+struct value_set_t {
+    bit<16> field;
+    bit<3> field2;
+}
+
+parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+
+    value_set<value_set_t>(4) pvs;
+
+    state start {
+        b.extract(p.data);
+        transition select(p.data.da[15:0], p.data.db[7:5]) {
+            pvs: accept;
+            (0x810, 0x1) : foo;
+        }
+    }
+
+    state foo {
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
+  apply { }
+}
+
+
+control MyIngress(inout my_packet p, inout my_metadata meta, inout standard_metadata_t s) {
+    action set_data() {
+    }
+    table t {
+        actions = { set_data; }
+        key = { meta.data[0].da : exact;}
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control MyEgress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  apply {
+  }
+}
+
+control MyComputeChecksum(inout my_packet p, inout my_metadata m) {
+  apply { }
+}
+
+control MyDeparser(packet_out b, in my_packet p) {
+  apply { }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -670,6 +670,16 @@ service Standard {
     3:BmParseVSetValue value
   ) throws (1:InvalidParseVSetOperation ouch)
 
+  list<BmParseVSetValue> bm_parse_vset_get(
+    1:i32 cxt_id,
+    2:string parse_vset_name
+  ) throws (1:InvalidParseVSetOperation ouch)
+
+  void bm_parse_vset_clear(
+    1:i32 cxt_id,
+    2:string parse_vset_name
+  ) throws (1:InvalidParseVSetOperation ouch)
+
 
   // device manager
 


### PR DESCRIPTION
We now provide the following commands: pvs_add, pvs_remove, pvs_get,
pvs_clear. Implementing pvs_get and pvs_clear required adding the
equivalent RPCs to the Thrift API.

This commit also adds a bmv2 JSON sanity check for the "mask" attribute,
when it is used in a PVS parser transition.

The included JSON file, pvs_struct_2.json, was used to test the
implementation of the CLI commands. It was generated from a P4 program
written by @jafingerhut for the compiler testsuite.

Fixes #855