### PR TITLE
Add support for optional match type to simple_switch_grpc

### DIFF
--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -103,6 +103,7 @@ std::vector<bm::MatchKeyParam> build_key(pi_p4_id_t table_id,
         }
         break;
       case PI_P4INFO_MATCH_TYPE_TERNARY:
+      case PI_P4INFO_MATCH_TYPE_OPTIONAL:
         {
           std::string k(mk_data, nbytes);
           mk_data += nbytes;

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -39,7 +39,8 @@ test_ternary.cpp \
 test_pre.cpp \
 test_digest.cpp \
 test_idle_timeout.cpp \
-test_action_profile.cpp
+test_action_profile.cpp \
+test_optional.cpp
 if WITH_SYSREPO
 test_gtest_SOURCES += test_gnmi.cpp
 endif
@@ -62,4 +63,5 @@ ternary.p4 ternary.json ternary.proto.txt \
 multicast.p4 multicast.json multicast.proto.txt \
 clone.p4 clone.json clone.proto.txt \
 digest.p4 digest.json digest.proto.txt \
-action_profile.p4 action_profile.json action_profile.proto.txt
+action_profile.p4 action_profile.json action_profile.proto.txt \
+optional.p4 optional.json optional.proto.txt

--- a/targets/simple_switch_grpc/tests/test_optional.cpp
+++ b/targets/simple_switch_grpc/tests/test_optional.cpp
@@ -1,0 +1,195 @@
+/* Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas
+ *
+ */
+
+// TODO(antonin): we should try to unify this test suite with the "ternary" one,
+// as pretty much all of the code is exactly the same.
+
+#include <grpc++/grpc++.h>
+
+#include <p4/bm/dataplane_interface.grpc.pb.h>
+#include <p4/v1/p4runtime.grpc.pb.h>
+
+#include <google/protobuf/util/message_differencer.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "base_test.h"
+
+namespace p4v1 = ::p4::v1;
+
+namespace sswitch_grpc {
+
+namespace testing {
+
+namespace {
+
+using google::protobuf::util::MessageDifferencer;
+
+constexpr char optional_json[] = TESTDATADIR "/optional.json";
+constexpr char optional_proto[] = TESTDATADIR "/optional.proto.txt";
+
+class SimpleSwitchGrpcTest_Optional : public SimpleSwitchGrpcBaseTest {
+ protected:
+  SimpleSwitchGrpcTest_Optional()
+      : SimpleSwitchGrpcBaseTest(optional_proto),
+        dataplane_channel(grpc::CreateChannel(
+            dp_grpc_server_addr, grpc::InsecureChannelCredentials())),
+        dataplane_stub(p4::bm::DataplaneInterface::NewStub(
+            dataplane_channel)) { }
+
+  void SetUp() override {
+    SimpleSwitchGrpcBaseTest::SetUp();
+    update_json(optional_json);
+    t_id = get_table_id(p4info, "ingress.opt");
+    mf_id = get_mf_id(p4info, "ingress.opt", "h.hdr.f1");
+    a_nop_id = get_action_id(p4info, "NoAction");
+    a_s1_id = get_action_id(p4info, "ingress.send_1");
+    a_s2_id = get_action_id(p4info, "ingress.send_2");
+  }
+
+  p4v1::Entity make_entry(const std::string &v, bool wildcard,
+                        int32_t priority, int a_id) const {
+    p4v1::Entity entity;
+    auto table_entry = entity.mutable_table_entry();
+    table_entry->set_table_id(t_id);
+    if (!wildcard) {
+      auto match = table_entry->add_match();
+      match->set_field_id(mf_id);
+      auto optional = match->mutable_optional();
+      optional->set_value(v);
+    }
+    table_entry->set_priority(priority);
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(a_id);
+    return entity;
+  }
+
+  grpc::Status add_entry(const p4v1::Entity &entry) const {
+    return insert(entry);
+  }
+
+  grpc::Status remove_entry(const p4v1::Entity &entry) const {
+    return remove(entry);
+  }
+
+  grpc::Status read_entry(const p4v1::Entity &entry,
+                          p4v1::ReadResponse *rep) const {
+    return read(entry, rep);
+  }
+
+  grpc::Status send_and_receive(const std::string &pkt, int ig_port,
+                                p4::bm::PacketStreamResponse *rcv_pkt) {
+    static uint64_t id = 1;
+    p4::bm::PacketStreamRequest request;
+    request.set_id(id++);
+    request.set_device_id(device_id);
+    request.set_port(ig_port);
+    request.set_packet(pkt);
+    ClientContext context;
+    auto stream = dataplane_stub->PacketStream(&context);
+    stream->Write(request);
+    stream->Read(rcv_pkt);
+    stream->WritesDone();
+    return stream->Finish();
+  }
+
+  std::shared_ptr<grpc::Channel> dataplane_channel{nullptr};
+  std::unique_ptr<p4::bm::DataplaneInterface::Stub> dataplane_stub{nullptr};
+  int t_id;
+  int mf_id;
+  int a_nop_id;
+  int a_s1_id;
+  int a_s2_id;
+};
+
+TEST_F(SimpleSwitchGrpcTest_Optional, ReadEntry) {
+  int priority = 128;
+  auto entity = make_entry("\xaa\xbb", false, priority, a_s1_id);
+  {
+    auto status = add_entry(entity);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    p4v1::ReadResponse rep;
+    auto status = read_entry(entity, &rep);
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(1u, rep.entities().size());
+    EXPECT_TRUE(MessageDifferencer::Equals(entity, rep.entities().Get(0)));
+  }
+}
+
+TEST_F(SimpleSwitchGrpcTest_Optional, BothEntries) {
+  int priority_lo = 128, priority_hi = 333;
+  int ig_port = 3;
+  const std::string v("\xaa\xbb");
+  std::string pkt_match("\xaa\xbb");
+  std::string pkt_no_match("\xaa\xbc");
+  p4::bm::PacketStreamResponse rcv_pkt;
+  auto entity_lo = make_entry(v, true, priority_lo, a_s1_id);
+  {
+    auto status = add_entry(entity_lo);
+    EXPECT_TRUE(status.ok());
+  }
+  auto entity_hi = make_entry(v, false, priority_hi, a_s2_id);
+  {
+    auto status = add_entry(entity_hi);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    auto status = send_and_receive(pkt_match, ig_port, &rcv_pkt);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(2, rcv_pkt.port());  // non-wildcard entry
+  }
+  {
+    auto status = send_and_receive(pkt_no_match, ig_port, &rcv_pkt);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(1, rcv_pkt.port());  // wildcard entry
+  }
+  // we delete non-wildcard entry
+  {
+    auto status = remove_entry(entity_hi);
+    EXPECT_TRUE(status.ok());
+  }
+  {
+    auto status = send_and_receive(pkt_match, ig_port, &rcv_pkt);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(1, rcv_pkt.port());  // wildcard entry
+  }
+}
+
+// zero is not a valid priority value in P4Runtime
+TEST_F(SimpleSwitchGrpcTest_Optional, PriorityZero) {
+  int priority = 0;
+  std::string pkt("\xaa\xbb");
+  p4::bm::PacketStreamResponse rcv_pkt;
+  auto entity = make_entry("\xaa\xbb", "\xff\xff", priority, a_s1_id);
+  auto status = add_entry(entity);
+  EXPECT_FALSE(status.ok());
+}
+
+}  // namespace
+
+}  // namespace testing
+
+}  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/testdata/optional.json
+++ b/targets/simple_switch_grpc/tests/testdata/optional.json
@@ -1,0 +1,304 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "Hdr",
+      "id" : 2,
+      "fields" : [
+        ["f1", 16, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr",
+      "id" : 2,
+      "header_type" : "Hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "hdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "optional.p4",
+        "line" : 55,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : ["hdr"],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "NoAction",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "ingress.send_1",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0001"
+            }
+          ],
+          "source_info" : {
+            "filename" : "optional.p4",
+            "line" : 41,
+            "column" : 22,
+            "source_fragment" : "sm.egress_spec = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "ingress.send_2",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["standard_metadata", "egress_spec"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0002"
+            }
+          ],
+          "source_info" : {
+            "filename" : "optional.p4",
+            "line" : 42,
+            "column" : 22,
+            "source_fragment" : "sm.egress_spec = 2"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "optional.p4",
+        "line" : 40,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "ingress.opt",
+      "tables" : [
+        {
+          "name" : "ingress.opt",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "optional.p4",
+            "line" : 43,
+            "column" : 10,
+            "source_fragment" : "opt"
+          },
+          "key" : [
+            {
+              "match_type" : "ternary",
+              "name" : "h.hdr.f1",
+              "target" : ["hdr", "f1"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "ternary",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0, 1, 2],
+          "actions" : ["NoAction", "ingress.send_1", "ingress.send_2"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "NoAction" : null,
+            "ingress.send_1" : null,
+            "ingress.send_2" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : false,
+            "action_data" : [],
+            "action_entry_const" : false
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "optional.p4",
+        "line" : 51,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "optional.p4",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/targets/simple_switch_grpc/tests/testdata/optional.p4
+++ b/targets/simple_switch_grpc/tests/testdata/optional.p4
@@ -1,0 +1,59 @@
+/* Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header Hdr {
+    bit<16> f1;
+}
+
+struct Headers {
+    Hdr hdr;
+}
+
+struct Meta { }
+
+parser p(packet_in b, out Headers h,
+         inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.hdr);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action send_1() { sm.egress_spec = 1; }
+    action send_2() { sm.egress_spec = 2; }
+    table opt {
+        key = { h.hdr.f1 : optional; }
+        actions = { NoAction; send_1; send_2; }
+        default_action = NoAction();
+    }
+    apply { opt.apply(); }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply { }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply { b.emit(h.hdr); }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/targets/simple_switch_grpc/tests/testdata/optional.proto.txt
+++ b/targets/simple_switch_grpc/tests/testdata/optional.proto.txt
@@ -1,0 +1,47 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33607135
+    name: "ingress.opt"
+    alias: "opt"
+  }
+  match_fields {
+    id: 1
+    name: "h.hdr.f1"
+    bitwidth: 16
+    match_type: OPTIONAL
+  }
+  action_refs {
+    id: 16800567
+  }
+  action_refs {
+    id: 16806341
+  }
+  action_refs {
+    id: 16813617
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16806341
+    name: "ingress.send_1"
+    alias: "send_1"
+  }
+}
+actions {
+  preamble {
+    id: 16813617
+    name: "ingress.send_2"
+    alias: "send_2"
+  }
+}


### PR DESCRIPTION
The change required in the PI implementation is very minor. The diff is
large because we are adding a test to simple_switch_grpc.