### PR TITLE
[RFC] psa_switch: Add recirculation/resubmission limit

### DIFF
--- a/include/bm/bm_sim/phv.h
+++ b/include/bm/bm_sim/phv.h
@@ -288,6 +288,15 @@ class PHV {
   const std::string get_field_name(header_id_t header_index,
                                    int field_offset) const;
 
+  void increment_resubmission_counter(void);
+  void increment_recirculation_counter(void);
+
+  uint8_t get_recirculation_counter(void) { return recirculations; }
+  uint8_t get_resubmission_counter(void) { return resubmissions; }
+
+  void reset_recirculation_counter(void) { recirculations = 0; }
+  void reset_resubmission_counter(void) { resubmissions = 0; }
+
  private:
   // To  be used only by PHVFactory
   // all headers need to be pushed back in order (according to header_index) !!!
@@ -329,6 +338,8 @@ class PHV {
   size_t capacity_unions{0};
   size_t capacity_union_stacks{0};
   Debugger::PacketId packet_id;
+  uint8_t recirculations;
+  uint8_t resubmissions;
 };
 
 class PHVFactory {

--- a/src/bm_sim/phv.cpp
+++ b/src/bm_sim/phv.cpp
@@ -37,6 +37,8 @@ PHV::PHV(size_t num_headers, size_t num_header_stacks,
   header_stacks.reserve(num_header_stacks);
   header_unions.reserve(num_header_unions);
   header_union_stacks.reserve(num_header_union_stacks);
+  recirculations = 0;
+  resubmissions = 0;
 }
 
 void
@@ -69,6 +71,18 @@ void
 PHV::reset_headers() {
   for (auto &h : headers)
     h.reset();
+}
+
+void
+PHV::increment_resubmission_counter() {
+  if (resubmissions < UINT8_MAX)
+    resubmissions++;
+}
+
+void
+PHV::increment_recirculation_counter() {
+  if (recirculations < UINT8_MAX)
+    recirculations++;
 }
 
 void

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -98,6 +98,11 @@ class PsaSwitch : public Switch {
   int set_egress_queue_rate(size_t port, const uint64_t rate_pps);
   int set_all_egress_queue_rates(const uint64_t rate_pps);
 
+  void set_max_recirculations(const uint8_t value);
+  void set_max_resubmissions(const uint8_t value);
+  uint8_t get_max_recirculations();
+  uint8_t get_max_resubmissions();
+
   // returns the number of microseconds elapsed since the switch started
   uint64_t get_time_elapsed_us() const;
 
@@ -161,6 +166,10 @@ class PsaSwitch : public Switch {
   static constexpr size_t nb_egress_threads = 4u;
   static constexpr port_t PSA_PORT_RECIRCULATE = 0xfffffffa;
   static packet_id_t packet_id;
+
+  // UINT8_MAX == unlimited
+  uint8_t max_recirculations = UINT8_MAX;
+  uint8_t max_resubmissions = UINT8_MAX;
 
   enum PktInstanceType {
     PACKET_PATH_NORMAL,

--- a/targets/psa_switch/pswitch_CLI.py
+++ b/targets/psa_switch/pswitch_CLI.py
@@ -68,6 +68,44 @@ class PsaSwitchAPI(runtime_CLI.RuntimeAPI):
         mirror_id = int(line)
         self.pswitch_client.mirroring_mapping_delete(mirror_id)
 
+    def do_set_max_recirculations(self, line):
+        ("Set packet recirculation limit: set_max_recirculations <value>\n"
+         "Where value is an integer between 0 and 254, or -1 (or 255) for unlimited")
+        value = int(line)
+        if not (value >= -1 and value <= 255):
+            print("Invalid value: %d" % value)
+        else:
+            self.pswitch_client.set_max_recirculations(value)
+
+    def do_set_max_resubmissions(self, line):
+        ("Set packet resubmission limit: set_max_resubmissions <value>\n"
+         "Where value is an integer between 0 and 254, or -1 (or 255) for unlimited")
+        value = int(line)
+        if not (value >= -1 and value <= 255):
+            print("Invalid value: %d" % value)
+        else:
+            self.pswitch_client.set_max_resubmissions(value)
+
+    def do_get_max_recirculations(self, line):
+        "Get packet recirculation limit"
+        value = self.pswitch_client.get_max_recirculations()
+        if value == -1:
+            print "unlimited (255)"
+        elif value < 0:
+            print value + 2**8  # convert to uint8_t
+        else:
+            print value
+
+    def do_get_max_resubmissions(self, line):
+        "Get packet resubmission limit"
+        value = self.pswitch_client.get_max_resubmissions()
+        if value == -1:
+            print "unlimited (255)"
+        elif value < 0:
+            print value + 2**8  # convert to uint8_t
+        else:
+            print value
+
     def do_get_time_elapsed(self, line):
         "Get time elapsed (in microseconds) since the switch started: get_time_elapsed"
         print self.pswitch_client.get_time_elapsed_us()

--- a/targets/psa_switch/thrift/psa_switch.thrift
+++ b/targets/psa_switch/thrift/psa_switch.thrift
@@ -32,6 +32,11 @@ service PsaSwitch {
   i32 set_egress_queue_rate(1:i32 port_num, 2:i64 rate_pps);
   i32 set_all_egress_queue_rates(1:i64 rate_pps);
 
+  void set_max_recirculations(1:i32 value);
+  void set_max_resubmissions(1:i32 value);
+  byte get_max_recirculations();
+  byte get_max_resubmissions();
+
   // these methods are here as an experiment, prefer get_time_elapsed_us() when
   // possible
   i64 get_time_elapsed_us();

--- a/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
+++ b/targets/psa_switch/thrift/src/PsaSwitch_server.cpp
@@ -88,6 +88,26 @@ class PsaSwitchHandler : virtual public PsaSwitchIf {
     return switch_->set_all_egress_queue_rates(static_cast<uint64_t>(rate_pps));
   }
 
+  void set_max_recirculations(const int32_t value) {
+    bm::Logger::get()->trace("set_max_recirculations");
+    switch_->set_max_recirculations(static_cast<uint8_t> (value));
+  }
+
+  void set_max_resubmissions(const int32_t value) {
+    bm::Logger::get()->trace("set_max_resubmissions");
+    switch_->set_max_resubmissions(static_cast<uint8_t> (value));
+  }
+
+  int8_t get_max_recirculations() {
+    bm::Logger::get()->trace("get_max_recirculations");
+    return static_cast<int8_t> (switch_->get_max_recirculations());
+  }
+
+  int8_t get_max_resubmissions() {
+    bm::Logger::get()->trace("get_max_resubmissions");
+    return static_cast<int8_t> (switch_->get_max_resubmissions());
+  }
+
   int64_t get_time_elapsed_us() {
     bm::Logger::get()->trace("get_time_elapsed_us");
     // cast from unsigned to signed


### PR DESCRIPTION
The PSA specification does not provide a mechanism to prevent a single received packet to continue to recirculate or resubmit indefinitely and implies that targets may impose limits on the number of resubmissions/recirculations. 
 
This PR adds max packet recirculation and resubmission limit with default value set to 255 (unlimited).

Four options are added to `psa_switch_CLI`: `set_max_recirculations`, `set_max_resubmissions`, `get_max_recirculations` and `get_max_resubmissions`. The recirculation/resubmission limit can be changed to a value between 0 and 254, and the special value of 255 (or -1) is used as unlimited.

In addition, two `bit<8>` metadata fields are added to the types `psa_ingress_input_metadata_t` and `psa_egress_input_metadata_t` - `max_recirculations` and `max_resubmissions` - to allow P4 programs to read the current recirculation/resubmission limit set on a target. (https://github.com/rst0git/p4c/tree/psa-max-recirc-resub)

The values of `max_recirculations` and `max_resubmissions` are updated after each recirculation/resubmission to indicate how many more recirculations/resubmissions a packet is allowed to perform. A packet is dropped when the recirculation/resubmission limit has been reached. 