### PR TITLE
Fix handling of non-Data expressions as primitive arguments

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -391,7 +391,7 @@ P4Objects::process_single_param(ActionFn* action_fn,
     build_expression(cfg_parameter["value"], expr, &expr_type);
     expr->build();
     action_fn->parameter_push_back_expression(
-        std::unique_ptr<Expression>(expr));
+        std::unique_ptr<Expression>(expr), expr_type);
   } else if (type == "register") {
     // TODO(antonin): cheap optimization
     // this may not be worth doing, and probably does not belong here


### PR DESCRIPTION
When adding support for returning lvalues in the expression evaluation
engine (https://github.com/p4lang/behavioral-model/pull/839), we
introduced support for using expressions which do not evaluate to a
simple Data value as primitive arguments. In particular, we can use an
expression which evaluates to a Header object as a primitive
argument. However, the code responsible for parsing the bmv2 input JSON
and instantiating Action objects was treating all expressions used as
primitive arguments as "Data expressions", thus causing bmv2 to crash
when it was actually not the case.

Fixes #887