### PR TITLE
Fix type deduction for expressions when importing JSON

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -196,8 +196,15 @@ P4Objects::build_expression(const Json::Value &json_expression,
       expr->push_back_op(opcode);
       *expr_type = ExprType::BOOL;
     } else if (op == "access_field") {
-      build_expression(json_left, expr);
+      build_expression(json_left, expr, &typeL);
+      assert(typeL == ExprType::HEADER);
       expr->push_back_access_field(json_right.asInt());
+      *expr_type = ExprType::DATA;
+    } else if (op == "access_union_header") {
+      build_expression(json_left, expr, &typeL);
+      assert(typeL == ExprType::UNION);
+      expr->push_back_access_field(json_right.asInt());
+      *expr_type = ExprType::HEADER;
     } else {
       // special handling for unary + and -, we set the left operand to 0
       if ((op == "+" || op == "-") && json_left.isNull())


### PR DESCRIPTION
A recent fix for a separate issue
(https://github.com/p4lang/behavioral-model/pull/888) exposed a separate
bug: the type of expressions for which the top-level operator was
"access_field" was not deduced properly (set to UNKNOWN instead of
DATA), which caused bmv2 to assert when building the Action object.

The same issue existed for "access_union_header", which is an operator
introduced more recently (and possibly not used by p4c yet).

Fixes #889