### PR TITLE
Fix GroupSelectionIface implementation used by PI

### DIFF
--- a/PI/src/group_selection.cpp
+++ b/PI/src/group_selection.cpp
@@ -57,6 +57,8 @@ GroupSelection::remove_member_from_group(grp_hdl_t grp, mbr_hdl_t mbr) {
   std::lock_guard<std::mutex> lock(mutex);
   auto &group = groups[grp];
   group.remove_member(mbr);
+  // Remove group from map when it is empty to avoid using up memory.
+  if (group.size() == 0) groups.erase(grp);
 }
 
 mbr_hdl_t
@@ -102,6 +104,11 @@ GroupSelection::GroupInfo::get_from_hash(hash_t h) const {
   auto active_count = activated_members.count();
   auto index = static_cast<size_t>(h % active_count);
   return activated_members.get_nth(index);
+}
+
+size_t
+GroupSelection::GroupInfo::size() const {
+  return members.size();
 }
 
 }  // namespace pibmv2

--- a/PI/src/group_selection.h
+++ b/PI/src/group_selection.h
@@ -56,6 +56,7 @@ class GroupSelection : public bm::ActionProfile::GroupSelectionIface {
     void add_member(mbr_hdl_t mbr);
     void remove_member(mbr_hdl_t mbr);
     mbr_hdl_t get_from_hash(hash_t h) const;
+    size_t size() const;
 
    private:
     bm::RandAccessUIntSet activated_members{};

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -339,8 +339,11 @@ ActionProfile::delete_group(grp_hdl_t grp) {
       // the ref count for the members. Note that we do not allow deletion of a
       // member which is in a group
       GroupInfo &group_info = grp_mgr.at(grp);
-      for (auto mbr : group_info)
+      for (auto mbr : group_info) {
         index_ref_count.decrease(IndirectIndex::make_mbr_index(mbr));
+
+        grp_selector->remove_member_from_group(grp, mbr);
+      }
 
       int error = grp_handles.release_handle(grp);
       _BM_UNUSED(error);

--- a/targets/simple_switch_grpc/tests/test_ternary.cpp
+++ b/targets/simple_switch_grpc/tests/test_ternary.cpp
@@ -65,7 +65,7 @@ class SimpleSwitchGrpcTest_Ternary : public SimpleSwitchGrpcBaseTest {
   }
 
   p4v1::Entity make_entry(const std::string &v, const std::string &mask,
-                        int32_t priority, int a_id) const {
+                          int32_t priority, int a_id) const {
     p4v1::Entity entity;
     auto table_entry = entity.mutable_table_entry();
     table_entry->set_table_id(t_id);


### PR DESCRIPTION
PI uses a custom GroupSelectionIface implementation to support watch
ports for P4Runtime action profile group members.

Before this fix, membership information in the GroupSelectionIface
implementation wasn't cleaned up properly when a group was deleted,
which means that when a new group was created with the same id (but
different membership), table lookups would yield invalid members and
bmv2 would assert.

The fix consists in making the appropriate method calls to remove each
member from the group when the group is being deleted.

Fixes #893