### PR TITLE
Use updated P4Runtime server C API in simple_switch_grpc

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -25,7 +25,6 @@
 
 #include <bm/PI/pi.h>
 
-#include <PI/frontends/proto/device_mgr.h>
 #include <PI/frontends/proto/logging.h>
 
 #include <PI/proto/pi_server.h>
@@ -63,8 +62,6 @@ namespace sswitch_runtime {
 #endif  // WITH_THRIFT
 
 namespace sswitch_grpc {
-
-using pi::fe::proto::DeviceMgr;
 
 using grpc::ServerContext;
 using grpc::Status;
@@ -506,7 +503,7 @@ SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(
       dp_grpc_server_addr(dp_grpc_server_addr),
       dp_service(nullptr),
       dp_grpc_server(nullptr) {
-  DeviceMgr::init();
+  PIGrpcServerInit();
 }
 
 int
@@ -680,7 +677,6 @@ SimpleSwitchGrpcRunner::is_dp_service_active() {
 
 SimpleSwitchGrpcRunner::~SimpleSwitchGrpcRunner() {
   PIGrpcServerCleanup();
-  DeviceMgr::destroy();
 }
 
 void


### PR DESCRIPTION
DeviceMgr::init is now called by PIGrpcServerInit (new API function) and
DeviceMgr::destroy is called by PIGrpcServerCleanup.

See https://github.com/p4lang/PI/pull/513