### PR TITLE
Ensure that bmv2 targets are notified in case of config swap

### DIFF
--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -93,6 +93,11 @@ SwitchWContexts::reset_target_state() {
   reset_target_state_();
 }
 
+void
+SwitchWContexts::swap_notify() {
+  swap_notify_();
+}
+
 std::string
 SwitchWContexts::get_debugger_addr() const {
 #ifdef BM_DEBUG_ON
@@ -467,6 +472,8 @@ SwitchWContexts::do_swap() {
       phv_source->set_phv_factory(cxt_id, &cxt.get_phv_factory());
     rc &= swap_done;
   }
+  // at this stage, we have no more Packet instances in bmv2
+  swap_notify();
 #ifdef BM_DEBUG_ON
   Debugger::get()->config_change();
 #endif

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -142,12 +142,6 @@ PsaSwitch::PsaSwitch(bool enable_swap)
 
 int
 PsaSwitch::receive_(port_t port_num, const char *buffer, int len) {
-
-  // for p4runtime program swap - antonin
-  // putting do_swap call here is ok because blocking this thread will not
-  // block processing of existing packet instances, which is a requirement
-  do_swap();
-
   // we limit the packet buffer to original size + 512 bytes, which means we
   // cannot add more than 512 bytes of header data to the packet, which should
   // be more than enough

--- a/targets/simple_router/simple_router.cpp
+++ b/targets/simple_router/simple_router.cpp
@@ -57,9 +57,6 @@ class SimpleSwitch : public Switch {
   int receive_(port_t port_num, const char *buffer, int len) override {
     static int pkt_id = 0;
 
-    if (this->do_swap() == 0)  // a swap took place
-      swap_happened = true;
-
     auto packet = new_packet_ptr(port_num, pkt_id++, len,
                                  bm::PacketBuffer(2048, buffer, len));
 
@@ -74,6 +71,10 @@ class SimpleSwitch : public Switch {
     t1.detach();
     std::thread t2(&SimpleSwitch::transmit_thread, this);
     t2.detach();
+  }
+
+  void swap_notify_() override {
+    swap_happened = true;
   }
 
  private:

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -96,6 +96,8 @@ class SimpleSwitch : public Switch {
 
   void reset_target_state_() override;
 
+  void swap_notify_() override;
+
   bool mirroring_add_session(mirror_id_t mirror_id,
                              const MirroringSessionConfig &config);
 


### PR DESCRIPTION
In some case, the do_swap() call in simple_switch never returned 0
(because the swap was performed independently of the target), which
meant that the with_queueing_metadata flag was not updated.

This created an issue in the following specific scenario:
 * simple_switch is started with a JSON config that does not include
   queueing metadata fields
 * a JSON config swap is performed (using the runtime_CLI or P4Runtime,
   in the case of simple_switch_grpc), and the new config includes all
   queueing metadata fields
 * queueing metadata fields still show as 0 for all subsequent traffic

To fix this, we get rid of the assumption that targets are in charge of
calling do_swap() themselves, which must data back to when Packet
instantiation was not guarded by a lock (thus requiring the
collaboration of targets to ensure no new Packets were created as the
swap if being performed).

From now targets are notified using the swap_notify_() virtual method,
which targets can override.

Fixes #905