### PR TITLE
[psa_switch] supporting meter extern

### DIFF
--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -8,7 +8,7 @@ THRIFT_IDL = $(srcdir)/thrift/psa_switch.thrift
 
 noinst_LTLIBRARIES = libpsaswitch.la
 
-libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp
+libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp
 
 libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -1,0 +1,52 @@
+/* Copyright 2020-present Cornell University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Yunhe Liu (yunheliu@cs.cornell.edu)
+ *
+ */
+
+#include "psa_meter.h"
+#include <iostream>
+
+namespace bm {
+
+namespace psa {
+
+void
+PSA_Meter::execute(const Data &index, Data &value) {
+    unsigned int color_out = _meter->execute_meter(get_packet(), index.get<size_t>(), (unsigned int) 0);
+    value.set((size_t)color_out);
+}
+
+Meter &
+PSA_Meter::get_Meter(size_t idx) {
+  return _meter->get_meter(idx);
+}
+
+const Meter &
+PSA_Meter::get_Meter(size_t idx) const {
+  return _meter->get_meter(idx);
+}
+
+BM_REGISTER_EXTERN_W_NAME(Meter, PSA_Meter);
+BM_REGISTER_EXTERN_W_NAME_METHOD(Meter, PSA_Meter, execute, const Data &, Data &);
+
+}  // namespace bm::psa
+
+}  // namespace bm
+
+int import_meters(){
+  return 0;
+}

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -42,7 +42,7 @@ PSA_Meter::init() {
 
 void
 PSA_Meter::execute(const Data &index, Data &value) {
-    unsigned int color_out = _meter->execute_meter(get_packet(), index.get<size_t>(), static_cast<unsigned int>(0));
+    auto color_out = _meter->execute_meter(get_packet(), index.get<size_t>(), static_cast<unsigned int>(0));
 
     // color adjustment for PSA:
     // bmv2 meter implementation assign higher value for busier flow:
@@ -52,15 +52,20 @@ PSA_Meter::execute(const Data &index, Data &value) {
     // (PSA-specification) RED = 0, GREEN = 1, YELLOW = 2.
     // The following code maps color_out (bmv2-meter) to
     // psa_color_out (PSA-specification).
-    unsigned int psa_color_out = 1;
-    if (color_out == 0)
-        psa_color_out = 1;
-    else if (color_out == 1)
-        psa_color_out = 2;
-    else if (color_out == 2)
-        psa_color_out = 0;
+    auto psa_color_out = 1;
+    switch(color_out) {
+        case 0 :
+            psa_color_out = 1;
+            break;
+        case 1 :
+            psa_color_out = 2;
+            break;
+        case 2 :
+            psa_color_out = 0;
+            break;
+    }
 
-    value.set(static_cast<size_t>(psa_color_out));
+    value.set(psa_color_out);
 }
 
 Meter &

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -52,7 +52,7 @@ PSA_Meter::execute(const Data &index, Data &value) {
     // (PSA-specification) RED = 0, GREEN = 1, YELLOW = 2.
     // The following code maps color_out (bmv2-meter) to
     // psa_color_out (PSA-specification).
-    auto psa_color_out = 1;
+    bm::Meter::color_t psa_color_out = 1;
     switch(color_out) {
         case 0 :
             psa_color_out = 1;

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -56,6 +56,11 @@ PSA_Meter::get_meter(size_t idx) const {
   return _meter->get_meter(idx);
 }
 
+Meter::MeterErrorCode
+PSA_Meter::set_rates(const std::vector<Meter::rate_config_t> &configs) {
+    return _meter->set_rates(configs);
+}
+
 BM_REGISTER_EXTERN_W_NAME(Meter, PSA_Meter);
 BM_REGISTER_EXTERN_W_NAME_METHOD(Meter, PSA_Meter, execute, const Data &, Data &);
 

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -52,7 +52,7 @@ PSA_Meter::execute(const Data &index, Data &value) {
     // (PSA-specification) RED = 0, GREEN = 1, YELLOW = 2.
     // The following code maps color_out (bmv2-meter) to
     // psa_color_out (PSA-specification).
-    unsigned int psa_color_out;
+    unsigned int psa_color_out = 1;
     if (color_out == 0)
         psa_color_out = 1;
     else if (color_out == 1)

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -29,7 +29,7 @@ PSA_Meter::init() {
     bm::MeterArray::MeterType meter_type;
     if (type == "bytes") {
         meter_type = bm::MeterArray::MeterType::BYTES;
-    } else if (type == "packets") {
+    } else {
         meter_type = bm::MeterArray::MeterType::PACKETS;
     }
     _meter = std::unique_ptr<MeterArray>(

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -25,18 +25,34 @@ namespace bm {
 namespace psa {
 
 void
+PSA_Meter::init() {
+    bm::MeterArray::MeterType meter_type;
+    if (type == "bytes") {
+        meter_type = bm::MeterArray::MeterType::BYTES;
+    } else if (type == "packets") {
+        meter_type = bm::MeterArray::MeterType::PACKETS;
+    }
+    _meter = std::unique_ptr<MeterArray>(
+        new MeterArray(get_name() + ".$impl",
+                         spec_id,
+                         meter_type,
+                         rate_count.get<size_t>(),
+                         n_meters.get<size_t>()));
+}
+
+void
 PSA_Meter::execute(const Data &index, Data &value) {
     unsigned int color_out = _meter->execute_meter(get_packet(), index.get<size_t>(), (unsigned int) 0);
     value.set((size_t)color_out);
 }
 
 Meter &
-PSA_Meter::get_Meter(size_t idx) {
+PSA_Meter::get_meter(size_t idx) {
   return _meter->get_meter(idx);
 }
 
 const Meter &
-PSA_Meter::get_Meter(size_t idx) const {
+PSA_Meter::get_meter(size_t idx) const {
   return _meter->get_meter(idx);
 }
 

--- a/targets/psa_switch/externs/psa_meter.h
+++ b/targets/psa_switch/externs/psa_meter.h
@@ -45,7 +45,9 @@ class PSA_Meter : public bm::ExternType {
     } else if (type == "packets") {
         meter_type = bm::MeterArray::MeterType::PACKETS;
     } else {
-        // TODO: error reporting
+        // TODO: Here Meter is made default as a BYTES meter.
+        // However, what really should been done here is error handling.
+        meter_type = bm::MeterArray::MeterType::BYTES;
     }
     _meter = std::unique_ptr<MeterArray>(
         new MeterArray(get_name() + ".$impl",

--- a/targets/psa_switch/externs/psa_meter.h
+++ b/targets/psa_switch/externs/psa_meter.h
@@ -46,7 +46,7 @@ class PSA_Meter : public bm::ExternType {
 
   const Meter &get_meter(size_t idx) const;
 
-  const Meter &get_Meter(size_t idx) const;
+  Meter::MeterErrorCode set_rates(const std::vector<Meter::rate_config_t> &configs);
 
   size_t size() const { return _meter->size(); };
 

--- a/targets/psa_switch/externs/psa_meter.h
+++ b/targets/psa_switch/externs/psa_meter.h
@@ -37,39 +37,14 @@ class PSA_Meter : public bm::ExternType {
     BM_EXTERN_ATTRIBUTE_ADD(is_direct);
     BM_EXTERN_ATTRIBUTE_ADD(rate_count);
   }
-  
-  void init() override {
-    bm::MeterArray::MeterType meter_type;
-    if (type == "bytes") {
-        meter_type = bm::MeterArray::MeterType::BYTES;
-    } else if (type == "packets") {
-        meter_type = bm::MeterArray::MeterType::PACKETS;
-    } else {
-        // TODO: Here Meter is made default as a BYTES meter.
-        // However, what really should been done here is error handling.
-        meter_type = bm::MeterArray::MeterType::BYTES;
-    }
-    _meter = std::unique_ptr<MeterArray>(
-        new MeterArray(get_name() + ".$impl",
-                         spec_id,
-                         meter_type,
-                         rate_count.get<size_t>(),
-                         n_meters.get<size_t>()));
 
-        // Default trTriColor meter rates
-        // 2 packets per second, burst size of 3
-        Meter::rate_config_t committed_rate = {0.000002, 3};
-        // 10 packets per second, burst size of 1
-        Meter::rate_config_t peak_rate = {0.00001, 1};
-        Meter::MeterErrorCode error = _meter->set_rates({committed_rate, peak_rate});
-        if (error != bm::MeterArray::MeterErrorCode::SUCCESS) {
-            // TODO return error handling
-        }
-  }
+  void init() override;
 
   void execute(const Data &index, Data &value);
 
-  Meter &get_Meter(size_t idx);
+  Meter &get_meter(size_t idx);
+
+  const Meter &get_meter(size_t idx) const;
 
   const Meter &get_Meter(size_t idx) const;
 

--- a/targets/psa_switch/externs/psa_meter.h
+++ b/targets/psa_switch/externs/psa_meter.h
@@ -60,7 +60,9 @@ class PSA_Meter : public bm::ExternType {
         // 10 packets per second, burst size of 1
         Meter::rate_config_t peak_rate = {0.00001, 1};
         Meter::MeterErrorCode error = _meter->set_rates({committed_rate, peak_rate});
-        // TODO return error handling
+        if (error != bm::MeterArray::MeterErrorCode::SUCCESS) {
+            // TODO return error handling
+        }
   }
 
   void execute(const Data &index, Data &value);

--- a/targets/psa_switch/externs/psa_meter.h
+++ b/targets/psa_switch/externs/psa_meter.h
@@ -1,0 +1,86 @@
+/* Copyright 2020-present Cornell University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Yunhe Liu (yunheliu@cs.cornell.edu)
+ *
+ */
+
+#ifndef PSA_SWITCH_PSA_METER_H_
+#define PSA_SWITCH_PSA_METER_H_
+
+#include <bm/bm_sim/extern.h>
+#include <bm/bm_sim/meters.h>
+
+namespace bm {
+
+namespace psa {
+
+class PSA_Meter : public bm::ExternType {
+ public:
+  static constexpr p4object_id_t spec_id = 0xfffffffe;
+
+  BM_EXTERN_ATTRIBUTES {
+    BM_EXTERN_ATTRIBUTE_ADD(n_meters);
+    BM_EXTERN_ATTRIBUTE_ADD(type);
+    BM_EXTERN_ATTRIBUTE_ADD(is_direct);
+    BM_EXTERN_ATTRIBUTE_ADD(rate_count);
+  }
+  
+  void init() override {
+    bm::MeterArray::MeterType meter_type;
+    if (type == "bytes") {
+        meter_type = bm::MeterArray::MeterType::BYTES;
+    } else if (type == "packets") {
+        meter_type = bm::MeterArray::MeterType::PACKETS;
+    } else {
+        // TODO: error reporting
+    }
+    _meter = std::unique_ptr<MeterArray>(
+        new MeterArray(get_name() + ".$impl",
+                         spec_id,
+                         meter_type,
+                         rate_count.get<size_t>(),
+                         n_meters.get<size_t>()));
+
+        // Default trTriColor meter rates
+        // 2 packets per second, burst size of 3
+        Meter::rate_config_t committed_rate = {0.000002, 3};
+        // 10 packets per second, burst size of 1
+        Meter::rate_config_t peak_rate = {0.00001, 1};
+        Meter::MeterErrorCode error = _meter->set_rates({committed_rate, peak_rate});
+        // TODO return error handling
+  }
+
+  void execute(const Data &index, Data &value);
+
+  Meter &get_Meter(size_t idx);
+
+  const Meter &get_Meter(size_t idx) const;
+
+  size_t size() const { return _meter->size(); };
+
+ private:
+  Data n_meters;
+  std::string type;
+  Data is_direct;
+  Data rate_count;
+  Data color;
+  std::unique_ptr<MeterArray> _meter;
+};
+
+}  // namespace bm::psa
+
+}  // namespace bm
+#endif

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -64,6 +64,7 @@ REGISTER_HASH(bmv2_hash);
 
 extern int import_primitives();
 extern int import_counters();
+extern int import_meters();
 
 namespace bm {
 
@@ -136,6 +137,7 @@ PsaSwitch::PsaSwitch(bool enable_swap)
 
   import_primitives();
   import_counters();
+  import_meters();
 }
 
 #define PACKET_LENGTH_REG_IDX 0

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -35,6 +35,7 @@
 #include <functional>
 
 #include "externs/psa_counter.h"
+#include "externs/psa_meter.h"
 
 // TODO(antonin)
 // experimental support for priority queueing

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -155,6 +155,48 @@ class PsaSwitch : public Switch {
     return counter->reset_counters();
   }
 
+  MeterErrorCode
+  meter_array_set_rates(
+      cxt_id_t cxt_id, const std::string &meter_name,
+      const std::vector<Meter::rate_config_t> &configs) override {
+    auto *context = get_context(cxt_id);
+    auto *ex = context->get_extern_instance(meter_name).get();
+    if (!ex) return Meter::MeterErrorCode::INVALID_METER_NAME;
+    auto *meter = static_cast<PSA_Meter*>(ex);
+    meter->set_rates(configs);
+    return Meter::MeterErrorCode::SUCCESS;
+  }
+
+  MeterErrorCode
+  meter_set_rates(cxt_id_t cxt_id,
+                  const std::string &meter_name, size_t idx,
+                  const std::vector<Meter::rate_config_t> &configs) override {
+    auto *context = get_context(cxt_id);
+    auto *ex = context->get_extern_instance(meter_name).get();
+    if (!ex) return Meter::MeterErrorCode::INVALID_METER_NAME;
+    auto *meter = static_cast<PSA_Meter*>(ex);
+    if (idx >= meter->size())
+      return Meter::MeterErrorCode::INVALID_INDEX;
+    meter->get_meter(idx).set_rates(configs);
+    return Meter::MeterErrorCode::SUCCESS;
+  }
+
+  MeterErrorCode
+  meter_get_rates(cxt_id_t cxt_id,
+                  const std::string &meter_name, size_t idx,
+                  std::vector<Meter::rate_config_t> *configs) override {
+    auto *context = get_context(cxt_id);
+    auto *ex = context->get_extern_instance(meter_name).get();
+    if (!ex) return Meter::MeterErrorCode::INVALID_METER_NAME;
+    auto *meter = static_cast<PSA_Meter*>(ex);
+    if (idx >= meter->size())
+      return Meter::MeterErrorCode::INVALID_INDEX;
+    auto conf_vec = meter->get_meter(idx).get_rates();
+    for (auto conf : conf_vec)
+        configs->push_back(conf);
+    return Meter::MeterErrorCode::SUCCESS;
+  }
+
   // TODO(derek): override RuntimeInterface methods not yet supported
   //              by psa_switch and log an error msg / return error code
 

--- a/targets/psa_switch/pswitch_CLI.py
+++ b/targets/psa_switch/pswitch_CLI.py
@@ -93,7 +93,7 @@ def load_json_psa(json):
             if name == "is_direct":
                 meter_array.is_direct = value == True
             # TODO set meter_array.binding for direct_meter
-            # direct_meter not supported on PSA yet
+            # direct_meter not supported on psa_switch yet
             elif name == "n_meters":
                 meter_array.size = value
             elif name == "type":

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -332,16 +332,23 @@ def load_json_str(json_str):
                                                   json_["header_types"])
                 table.key += [(field_name, match_type, bitwidth)]
 
-    for j_meter in get_json_key("meter_arrays"):
+    for j_meter in get_json_key("extern_instances"):
         meter_array = MeterArray(j_meter["name"], j_meter["id"])
-        if "is_direct" in j_meter and j_meter["is_direct"]:
-            meter_array.is_direct = True
-            meter_array.binding = j_meter["binding"]
-        else:
-            meter_array.is_direct = False
-            meter_array.size = j_meter["size"]
-        meter_array.type_ = MeterType.from_str(j_meter["type"])
-        meter_array.rate_count = j_meter["rate_count"]
+        attribute_values = j_meter.get("attribute_values", [])
+        for attr in attribute_values:
+            name = attr.get("name", [])
+            val_type = attr.get("type", [])
+            value = attr.get("value", [])
+            if name == "is_direct":
+                meter_array.is_direct = value == True
+            # TODO set meter_array.binding for direct_meter
+            # direct_meter not supported on PSA yet
+            elif name == "n_meters":
+                meter_array.size = value
+            elif name == "type":
+                meter_array.type_ = value
+            elif name == "rate_count":
+                meter_array.rate_count = value
 
     for j_counter in get_json_key("counter_arrays"):
         counter_array = CounterArray(j_counter["name"], j_counter["id"])

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -332,23 +332,42 @@ def load_json_str(json_str):
                                                   json_["header_types"])
                 table.key += [(field_name, match_type, bitwidth)]
 
-    for j_meter in get_json_key("extern_instances"):
-        meter_array = MeterArray(j_meter["name"], j_meter["id"])
-        attribute_values = j_meter.get("attribute_values", [])
-        for attr in attribute_values:
-            name = attr.get("name", [])
-            val_type = attr.get("type", [])
-            value = attr.get("value", [])
-            if name == "is_direct":
-                meter_array.is_direct = value == True
-            # TODO set meter_array.binding for direct_meter
-            # direct_meter not supported on PSA yet
-            elif name == "n_meters":
-                meter_array.size = value
-            elif name == "type":
-                meter_array.type_ = value
-            elif name == "rate_count":
-                meter_array.rate_count = value
+    # If extern_instances exists in input json file,
+    # the json file follows PSA format.
+    # Else the json file follows v1model format.
+    if get_json_key("extern_instances"):
+        # PSA meter
+        for j_meter in get_json_key("extern_instances"):
+            if j_meter["type"] != "Meter":
+                continue
+            meter_array = MeterArray(j_meter["name"], j_meter["id"])
+            attribute_values = j_meter.get("attribute_values", [])
+            for attr in attribute_values:
+                name = attr.get("name", [])
+                val_type = attr.get("type", [])
+                value = attr.get("value", [])
+                if name == "is_direct":
+                    meter_array.is_direct = value == True
+                # TODO set meter_array.binding for direct_meter
+                # direct_meter not supported on PSA yet
+                elif name == "n_meters":
+                    meter_array.size = value
+                elif name == "type":
+                    meter_array.type_ = value
+                elif name == "rate_count":
+                    meter_array.rate_count = value
+    else:
+        # v1model meter
+        for j_meter in get_json_key("meter_arrays"):
+            meter_array = MeterArray(j_meter["name"], j_meter["id"])
+            if "is_direct" in j_meter and j_meter["is_direct"]:
+                meter_array.is_direct = True
+                meter_array.binding = j_meter["binding"]
+            else:
+                meter_array.is_direct = False
+                meter_array.size = j_meter["size"]
+            meter_array.type_ = MeterType.from_str(j_meter["type"])
+            meter_array.rate_count = j_meter["rate_count"]
 
     for j_counter in get_json_key("counter_arrays"):
         counter_array = CounterArray(j_counter["name"], j_counter["id"])

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -260,7 +260,7 @@ def reset_config():
 
     SUFFIX_LOOKUP_MAP.clear()
 
-def load_json_str(json_str):
+def load_json_str(json_str, architecture_spec=None):
 
     def get_header_type(header_name, j_headers):
         for h in j_headers:
@@ -367,6 +367,10 @@ def load_json_str(json_str):
         parse_vset = ParseVSet(j_parse_vset["name"], j_parse_vset["id"])
         parse_vset.bitwidth = j_parse_vset["compressed_bitwidth"]
 
+    if architecture_spec is not None:
+        # call architecture specific json parsing code
+        architecture_spec(json_)
+
     # Builds a dictionary mapping (object type, unique suffix) to the object
     # (Table, Action, etc...). In P4_16 the object name is the fully-qualified
     # name, which can be quite long, which is why we accept unique suffixes as
@@ -390,8 +394,6 @@ def load_json_str(json_str):
     for key, c in suffix_count.items():
         if c > 1:
             del SUFFIX_LOOKUP_MAP[key]
-
-    return json_
 
 class UIn_Error(Exception):
     def __init__(self, info=""):
@@ -2509,8 +2511,8 @@ class RuntimeAPI(cmd.Cmd):
     def complete_set_crc32_parameters(self, text, line, start_index, end_index):
         return self._complete_crc(text, 32)
 
-def load_json_config(standard_client=None, json_path=None):
-    return load_json_str(utils.get_json_config(standard_client, json_path))
+def load_json_config(standard_client=None, json_path=None, architecture_spec=None):
+    load_json_str(utils.get_json_config(standard_client, json_path), architecture_spec)
 
 def main():
     args = get_parser().parse_args()


### PR DESCRIPTION
Supporting psa-meter extern:
1. Added a wrapper for psa-meter to use `bm_sim/meter` implementation
2. Added default `meter_rates` into psa_meter constructor so user can run `meter_execute()` without having set `meter_rates` with runtimeCmd for now.

Has not implemented psa-meter RuntimeCmd yet.

Update 7-11-2020:   

All psa-meter RuntimeCmd implemented:  
- `meter-array-set_rates`  
- `meter_set_rates`  
- `meter_get_rates`  

Color adjustment for PSA:

- bmv2 meter implementation assign higher value for busier flow, see [this](https://github.com/p4lang/behavioral-model/blob/master/include/bm/bm_sim/meters.h#L153): GREEN = 0, YELLOW = 1, RED = 2.  
- PSA specification order enums differently, see [this](https://github.com/p4lang/p4c/blob/master/p4include/psa.p4#L649): RED = 0, GREEN = 1, YELLOW = 2.

Added mapping from bmv2-meter color to PSA specification color: (bmv2->psa) 0->1, 1->2, 2->0.