### PR TITLE
Fix build with recent Protobuf & gRPC versions

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -34,7 +34,7 @@
 #include <PI/target/pi_imp.h>
 #include <PI/target/pi_learn_imp.h>
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -23,16 +23,12 @@
 
 #include <bm/bm_sim/dev_mgr.h>
 
+#include <grpcpp/server.h>
+
 #include <memory>
 #include <string>
 
 class SimpleSwitch;
-
-namespace grpc {
-
-class Server;
-
-}  // namespace grpc
 
 namespace bm {
 

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <google/rpc/code.pb.h>
 

--- a/targets/simple_switch_grpc/tests/example.cpp
+++ b/targets/simple_switch_grpc/tests/example.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <google/rpc/code.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_action_profile.cpp
+++ b/targets/simple_switch_grpc/tests/test_action_profile.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_basic.cpp
+++ b/targets/simple_switch_grpc/tests/test_basic.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/v1/p4runtime.grpc.pb.h>
 

--- a/targets/simple_switch_grpc/tests/test_counter.cpp
+++ b/targets/simple_switch_grpc/tests/test_counter.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_digest.cpp
+++ b/targets/simple_switch_grpc/tests/test_digest.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_gnmi.cpp
+++ b/targets/simple_switch_grpc/tests/test_gnmi.cpp
@@ -20,7 +20,7 @@
 
 #include <bm/bm_sim/logger.h>
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <gnmi/gnmi.grpc.pb.h>
 #include <p4/bm/dataplane_interface.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
+++ b/targets/simple_switch_grpc/tests/test_grpc_dp.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 

--- a/targets/simple_switch_grpc/tests/test_idle_timeout.cpp
+++ b/targets/simple_switch_grpc/tests/test_idle_timeout.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <google/protobuf/util/message_differencer.h>
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_meter.cpp
+++ b/targets/simple_switch_grpc/tests/test_meter.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_optional.cpp
+++ b/targets/simple_switch_grpc/tests/test_optional.cpp
@@ -21,7 +21,7 @@
 // TODO(antonin): we should try to unify this test suite with the "ternary" one,
 // as pretty much all of the code is exactly the same.
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_packet_io.cpp
+++ b/targets/simple_switch_grpc/tests/test_packet_io.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/v1/p4runtime.grpc.pb.h>
 #include <PI/proto/pi_server.h>

--- a/targets/simple_switch_grpc/tests/test_pre.cpp
+++ b/targets/simple_switch_grpc/tests/test_pre.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <google/rpc/status.pb.h>
 #include <p4/bm/dataplane_interface.grpc.pb.h>

--- a/targets/simple_switch_grpc/tests/test_ternary.cpp
+++ b/targets/simple_switch_grpc/tests/test_ternary.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 #include <p4/bm/dataplane_interface.grpc.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>


### PR DESCRIPTION
When testing with Protobuf 3.12 and gRPC 1.30, the build failed because
of a change in the gRPC header (a grpc::Server typedef was introduced as
a replacement for the grpc::Server class, which means our forward
declaration was no longer correct).

We also replace all grpc++ include statements with grpcpp include
statements. grpc++ headers are deprecated since gRPC 1.10 (the official
gRPC version for p4lang software is 1.17).

Fixes #925