### PR TITLE
[psa_switch] supporting extern psa-random

### DIFF
--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -8,7 +8,12 @@ THRIFT_IDL = $(srcdir)/thrift/psa_switch.thrift
 
 noinst_LTLIBRARIES = libpsaswitch.la
 
-libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp externs/psa_random.h externs/psa_random.cpp
+libpsaswitch_la_SOURCES = \
+psa_switch.cpp psa_switch.h \
+primitives.cpp \
+externs/psa_counter.h externs/psa_counter.cpp \
+externs/psa_meter.h externs/psa_meter.cpp \
+externs/psa_random.h externs/psa_random.cpp
 
 libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -8,7 +8,7 @@ THRIFT_IDL = $(srcdir)/thrift/psa_switch.thrift
 
 noinst_LTLIBRARIES = libpsaswitch.la
 
-libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp
+libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp externs/psa_random.h externs/psa_random.cpp
 
 libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/targets/psa_switch/externs/psa_random.cpp
+++ b/targets/psa_switch/externs/psa_random.cpp
@@ -18,30 +18,45 @@
  */
 
 #include "psa_random.h"
-#include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/logger.h>
 
 #include <random>
 #include <thread>
+#include <iostream>
 
 namespace bm {
 
 namespace psa {
 
 void
+PSA_Random::init() {
+  valid_range = true;
+  min_val = min.get_uint64();
+  max_val = max.get_uint64();
+  range = max_val - min_val + 1;
+
+  if (range <= 0) {
+    valid_range = false;
+    Logger::get()->warn("Error: PSA extern random range must be positive.");
+  }
+
+  if ((range & (range - 1)) != 0) {
+    valid_range = false;
+    Logger::get()->warn("Error: PSA extern random range must be a power of 2.");
+  }
+}
+
+void
 PSA_Random::read(Data &value) {
-    int min_val = min.get_int();
-    int max_val = max.get_int();
+  if (!valid_range)
+    return;
 
-    int range = max_val - min_val + 1;
-    _BM_ASSERT((range > 0) && "[Error] Random number range must be positive.");
-    _BM_ASSERT(((range & (range - 1)) == 0) && "[Error] Random number range must be a power of 2.");
-
-    using engine = std::default_random_engine;
-    using hash = std::hash<std::thread::id>;
-    static thread_local engine generator(hash()(std::this_thread::get_id()));
-    using distrib64 = std::uniform_int_distribution<uint64_t>;
-    distrib64 distribution(min_val, max_val);
-    value.set(distribution(generator));
+  using engine = std::default_random_engine;
+  using hash = std::hash<std::thread::id>;
+  static thread_local engine generator(hash()(std::this_thread::get_id()));
+  using distrib64 = std::uniform_int_distribution<uint64_t>;
+  distrib64 distribution(min_val, max_val);
+  value.set(distribution(generator));
 }
 
 BM_REGISTER_EXTERN_W_NAME(Random, PSA_Random);

--- a/targets/psa_switch/externs/psa_random.cpp
+++ b/targets/psa_switch/externs/psa_random.cpp
@@ -35,15 +35,18 @@ PSA_Random::init() {
   max_val = max.get_uint64();
   range = max_val - min_val + 1;
 
-  if (range <= 0) {
+  if (min_val > max_val) {
     valid_range = false;
     Logger::get()->warn("Error: PSA extern random range must be positive.");
   }
 
+  /* Even though PSA spec mentioned range should be a power of 2 for
+   * max portability, bmv2 does not have to impose this restriction.
   if ((range & (range - 1)) != 0) {
     valid_range = false;
     Logger::get()->warn("Error: PSA extern random range must be a power of 2.");
   }
+  */
 }
 
 void

--- a/targets/psa_switch/externs/psa_random.cpp
+++ b/targets/psa_switch/externs/psa_random.cpp
@@ -1,0 +1,56 @@
+/* Copyright 2020-present Cornell University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Yunhe Liu (yunheliu@cs.cornell.edu)
+ *
+ */
+
+#include "psa_random.h"
+#include <bm/bm_sim/_assert.h>
+
+#include <random>
+#include <thread>
+
+namespace bm {
+
+namespace psa {
+
+void
+PSA_Random::read(Data &value) {
+    int min_val = min.get_int();
+    int max_val = max.get_int();
+
+    int range = max_val - min_val + 1;
+    _BM_ASSERT((range > 0) && "[Error] Random number range must be positive.");
+    _BM_ASSERT(((range & (range - 1)) == 0) && "[Error] Random number range must be a power of 2.");
+
+    using engine = std::default_random_engine;
+    using hash = std::hash<std::thread::id>;
+    static thread_local engine generator(hash()(std::this_thread::get_id()));
+    using distrib64 = std::uniform_int_distribution<uint64_t>;
+    distrib64 distribution(min_val, max_val);
+    value.set(distribution(generator));
+}
+
+BM_REGISTER_EXTERN_W_NAME(Random, PSA_Random);
+BM_REGISTER_EXTERN_W_NAME_METHOD(Random, PSA_Random, read, Data &);
+
+}  // namespace bm::psa
+
+}  // namespace bm
+
+int import_random(){
+  return 0;
+}

--- a/targets/psa_switch/externs/psa_random.cpp
+++ b/targets/psa_switch/externs/psa_random.cpp
@@ -30,30 +30,17 @@ namespace psa {
 
 void
 PSA_Random::init() {
-  valid_range = true;
   min_val = min.get_uint64();
   max_val = max.get_uint64();
-  range = max_val - min_val + 1;
+  _BM_ASSERT((max_val > min_val) && "[Error] Random number range must be positive.");
 
-  if (min_val > max_val) {
-    valid_range = false;
-    Logger::get()->warn("Error: PSA extern random range must be positive.");
-  }
-
-  /* Even though PSA spec mentioned range should be a power of 2 for
-   * max portability, bmv2 does not have to impose this restriction.
-  if ((range & (range - 1)) != 0) {
-    valid_range = false;
-    Logger::get()->warn("Error: PSA extern random range must be a power of 2.");
-  }
-  */
+  /* Note: Even though PSA spec mentioned range should be a power of 2 for
+   * max portability, bmv2 does not impose this restriction.
+   */
 }
 
 void
 PSA_Random::read(Data &value) {
-  if (!valid_range)
-    return;
-
   using engine = std::default_random_engine;
   using hash = std::hash<std::thread::id>;
   static thread_local engine generator(hash()(std::this_thread::get_id()));

--- a/targets/psa_switch/externs/psa_random.h
+++ b/targets/psa_switch/externs/psa_random.h
@@ -35,11 +35,17 @@ class PSA_Random : public bm::ExternType {
     BM_EXTERN_ATTRIBUTE_ADD(max);
   }
 
+  void init() override;
+
   void read(Data &value);
 
  private:
   Data min;
   Data max;
+  uint64_t min_val;
+  uint64_t max_val;
+  uint64_t range;
+  bool valid_range;
 };
 
 }  // namespace bm::psa

--- a/targets/psa_switch/externs/psa_random.h
+++ b/targets/psa_switch/externs/psa_random.h
@@ -1,0 +1,48 @@
+/* Copyright 2020-present Cornell University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Yunhe Liu (yunheliu@cs.cornell.edu)
+ *
+ */
+
+#ifndef PSA_SWITCH_PSA_RANDOM_H_
+#define PSA_SWITCH_PSA_RANDOM_H_
+
+#include <bm/bm_sim/extern.h>
+
+namespace bm {
+
+namespace psa {
+
+class PSA_Random : public bm::ExternType {
+ public:
+  static constexpr p4object_id_t spec_id = 0xfffffffd;
+
+  BM_EXTERN_ATTRIBUTES {
+    BM_EXTERN_ATTRIBUTE_ADD(min);
+    BM_EXTERN_ATTRIBUTE_ADD(max);
+  }
+
+  void read(Data &value);
+
+ private:
+  Data min;
+  Data max;
+};
+
+}  // namespace bm::psa
+
+}  // namespace bm
+#endif

--- a/targets/psa_switch/externs/psa_random.h
+++ b/targets/psa_switch/externs/psa_random.h
@@ -28,8 +28,6 @@ namespace psa {
 
 class PSA_Random : public bm::ExternType {
  public:
-  static constexpr p4object_id_t spec_id = 0xfffffffd;
-
   BM_EXTERN_ATTRIBUTES {
     BM_EXTERN_ATTRIBUTE_ADD(min);
     BM_EXTERN_ATTRIBUTE_ADD(max);

--- a/targets/psa_switch/externs/psa_random.h
+++ b/targets/psa_switch/externs/psa_random.h
@@ -42,8 +42,6 @@ class PSA_Random : public bm::ExternType {
   Data max;
   uint64_t min_val;
   uint64_t max_val;
-  uint64_t range;
-  bool valid_range;
 };
 
 }  // namespace bm::psa

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -65,6 +65,7 @@ REGISTER_HASH(bmv2_hash);
 extern int import_primitives();
 extern int import_counters();
 extern int import_meters();
+extern int import_random();
 
 namespace bm {
 
@@ -138,6 +139,7 @@ PsaSwitch::PsaSwitch(bool enable_swap)
   import_primitives();
   import_counters();
   import_meters();
+  import_random();
 }
 
 #define PACKET_LENGTH_REG_IDX 0

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -36,6 +36,7 @@
 
 #include "externs/psa_counter.h"
 #include "externs/psa_meter.h"
+#include "externs/psa_random.h"
 
 // TODO(antonin)
 // experimental support for priority queueing

--- a/targets/psa_switch/pswitch_CLI.py
+++ b/targets/psa_switch/pswitch_CLI.py
@@ -27,26 +27,6 @@ import os
 
 from pswitch_runtime import PsaSwitch
 
-ResType = runtime_CLI.enum('ResType', 'random')
-
-RANDOMS = {}
-
-def psa_reset_config():
-    RANDOMS.clear()
-
-class PsaRandom:
-    def __init__(self, name, id_):
-        self.name = name
-        self.id_ = id_
-        self.min = None
-        self.max = None
-
-        RANDOMS[name] = self
-
-    def random_str(self):
-        return "{0:30} [{1}, {2}]".format(self.name, self.min,
-                                          self.max)
-
 class PsaSwitchAPI(runtime_CLI.RuntimeAPI):
     @staticmethod
     def get_thrift_services():
@@ -98,8 +78,6 @@ class PsaSwitchAPI(runtime_CLI.RuntimeAPI):
 
 def load_json_psa(json):
 
-    psa_reset_config()
-
     def get_json_key(key):
         return json.get(key, [])
 
@@ -122,34 +100,6 @@ def load_json_psa(json):
                 meter_array.type_ = value
             elif name == "rate_count":
                 meter_array.rate_count = value
-
-    for j_random in get_json_key("extern_instances"):
-        if j_random["type"] != "Random":
-            continue
-        psa_random = PsaRandom(j_random["name"], j_random["id"])
-        attribute_values = j_meter.get("attribute_values", [])
-        for attr in attribute_values:
-            name = attr.get("name", [])
-            val_type = attr.get("type", [])
-            value = attr.get("value", [])
-            if name == "min":
-                psa_random.min = value
-            elif name == "max":
-                psa_random.max = value
-
-    suffix_count = runtime_CLI.Counter()
-    for res_type, res_dict in [
-            (ResType.random, RANDOMS)]:
-        for name, res in res_dict.items():
-            suffix = None
-            for s in reversed(name.split('.')):
-                suffix = s if suffix is None else s + '.' + suffix
-                key = (res_type, suffix)
-                runtime_CLI.SUFFIX_LOOKUP_MAP[key] = res
-                suffix_count[key] += 1
-    for key, c in suffix_count.items():
-        if c > 1:
-            del runtime_CLI.SUFFIX_LOOKUP_MAP[key]
 
 def main():
     args = runtime_CLI.get_parser().parse_args()


### PR DESCRIPTION
Supporting extern `psa-random`: 

Used a random function that is almost identical to an existing bmv2 method [modify_field_rng_uniform()](https://github.com/p4lang/behavioral-model/blob/master/targets/psa_switch/primitives.cpp#L45). The only difference is that `modify_field_rng_uniform()` uses `uint_64()` for range(min, max) while this extern use `int` for range(min, max) during random number generation.