### PR TITLE
Link libsimple_switch_grpc against libpip4info

### DIFF
--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -53,7 +53,7 @@ $(builddir)/../simple_switch/libsimpleswitch_thrift.la
 endif
 
 libsimple_switch_grpc_la_LIBADD += \
--lpifeproto -lpigrpcserver -lpi \
+-lpifeproto -lpigrpcserver -lpi -lpip4info \
 $(GRPC_LIBS) $(PROTOBUF_LIBS)
 
 # dataplane_interface.proto


### PR DESCRIPTION
switch_runner.cpp calls a few functions from that library, such as
pi_p4info_table_id_from_name.

Fixes #933