### PR TITLE
Fix to ingress_port assigned before ingress control is executed

### DIFF
--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -313,7 +313,8 @@ PsaSwitch::ingress_thread() {
 
     // pass relevant values from ingress parser
     // ingress_timestamp is already set at receive time
-    phv->get_field("psa_ingress_input_metadata.ingress_port").set(ingress_port);
+    phv->get_field("psa_ingress_input_metadata.ingress_port").set(
+        phv->get_field("psa_ingress_parser_input_metadata.ingress_port"));
     phv->get_field("psa_ingress_input_metadata.packet_path").set(
         phv->get_field("psa_ingress_parser_input_metadata.packet_path"));
     phv->get_field("psa_ingress_input_metadata.parser_error").set(


### PR DESCRIPTION
The PSA spec says that ingress_port during ingress control should be
the same as it was sent into the ingress parser.  Without this fix,
ingress_port sent into the ingress control is always the original
input port on which the packet was received, which is incorrect for
recirculated packets.