### PR TITLE
[PSA] add support for extern psa-internetChecksum

### DIFF
--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -8,7 +8,7 @@ THRIFT_IDL = $(srcdir)/thrift/psa_switch.thrift
 
 noinst_LTLIBRARIES = libpsaswitch.la
 
-libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp
+libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp externs/psa_internetChecksum.h externs/psa_internetChecksum.cpp
 
 libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/targets/psa_switch/externs/psa_internetChecksum.cpp
+++ b/targets/psa_switch/externs/psa_internetChecksum.cpp
@@ -1,0 +1,119 @@
+/* Copyright 2020-present Cornell University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Yunhe Liu (yunheliu@cs.cornell.edu)
+ *
+ */
+
+#include "psa_internetChecksum.h"
+#include <bm/bm_sim/logger.h>
+#include <execinfo.h>
+
+#define SUM_LENGTH 16
+
+namespace bm {
+
+namespace psa {
+
+uint16_t
+ones_complement_sum(uint16_t x, uint16_t y) {
+  uint32_t _x, _y, s;
+  uint16_t ret;
+  _x = x;
+  _y = y;
+  s = _x + _y;
+  if (s >> 16 == 1) {
+    s = s + 1;
+  }
+  ret = s;
+  return ret;
+}
+
+void
+PSA_InternetChecksum::init() {
+  sum = 0;
+}
+
+void
+PSA_InternetChecksum::clear() {
+  sum = 0;
+}
+
+void
+PSA_InternetChecksum::add(const Field &field) {
+  int len = field.get_nbits();
+  // TODO give a error if len is not a multiple of 16
+  Data field_val(field);
+
+  int i = 0;
+  while (i < len) {
+    Data tmp(field_val);
+    Data mask(0xffff);
+    tmp.bit_and(tmp, mask);
+    uint16_t d = tmp.get<uint16_t>();
+    sum = ones_complement_sum(sum, d);
+    field_val.bm::Data::shift_right(field_val, SUM_LENGTH);
+    i += SUM_LENGTH;
+  }
+}
+
+void
+PSA_InternetChecksum::subtract(const Field &field) {
+  int len = field.get_nbits();
+  // TODO give a error if len is not a multiple of 16
+  Data field_val(field);
+
+  int i = 0;
+  while (i < len) {
+    Data tmp(field_val);
+    Data mask(0xffff);
+    tmp.bit_and(tmp, mask);
+    uint16_t d = tmp.get<uint16_t>();
+    sum = ones_complement_sum(sum, ~d);
+    field_val.bm::Data::shift_right(field_val, SUM_LENGTH);
+    i += SUM_LENGTH;
+  }
+}
+
+void
+PSA_InternetChecksum::get(Data &sum_val) {
+  sum_val.set(~sum);
+}
+
+void
+PSA_InternetChecksum::get_state(Data &state) {
+  state.set(sum);
+}
+
+void
+PSA_InternetChecksum::set_state(const Data &state) {
+  sum = state.get<uint16_t>();
+}
+
+BM_REGISTER_EXTERN_W_NAME(InternetChecksum, PSA_InternetChecksum);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, clear);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, add, const Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, subtract, const Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get, Data &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get_state, Data &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, set_state, const Data &);
+
+}  // namespace bm::psa
+
+}  // namespace bm
+
+int import_internetChecksum(){
+  return 0;
+}

--- a/targets/psa_switch/externs/psa_internetChecksum.h
+++ b/targets/psa_switch/externs/psa_internetChecksum.h
@@ -1,0 +1,56 @@
+/* Copyright 2020-present Cornell University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Yunhe Liu (yunheliu@cs.cornell.edu)
+ *
+ */
+
+#ifndef PSA_SWITCH_PSA_INTERNETCHECKSUM_H_
+#define PSA_SWITCH_PSA_INTERNETCHECKSUM_H_
+
+#include <bm/bm_sim/extern.h>
+
+namespace bm {
+
+namespace psa {
+
+class PSA_InternetChecksum : public bm::ExternType {
+ public:
+  static constexpr p4object_id_t spec_id = 0xfffffffc;
+
+  BM_EXTERN_ATTRIBUTES {}
+
+  void init() override;
+
+  void clear();
+
+  void add(const Field &field);
+
+  void subtract(const Field &field);
+
+  void get(Data &sum_val);
+
+  void get_state(Data &state);
+
+  void set_state(const Data &state);
+
+ private:
+  uint16_t sum;
+};
+
+}  // namespace bm::psa
+
+}  // namespace bm
+#endif

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -65,6 +65,7 @@ REGISTER_HASH(bmv2_hash);
 extern int import_primitives();
 extern int import_counters();
 extern int import_meters();
+extern int import_internetChecksum();
 
 namespace bm {
 
@@ -138,6 +139,7 @@ PsaSwitch::PsaSwitch(bool enable_swap)
   import_primitives();
   import_counters();
   import_meters();
+  import_internetChecksum();
 }
 
 #define PACKET_LENGTH_REG_IDX 0

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -36,6 +36,7 @@
 
 #include "externs/psa_counter.h"
 #include "externs/psa_meter.h"
+#include "externs/psa_internetChecksum.h"
 
 // TODO(antonin)
 // experimental support for priority queueing


### PR DESCRIPTION
Implemented `internetChecksum` following the suggested implemented given by PSA specification [[please see here](https://p4.org/p4-spec/docs/PSA-v1.1.0.html#appendix-internetchecksum-implementation)].

TODO:
1. Currently `internetChecksum.add()` can only take 1 field instead of a list of fields. For example:

```
InternetChecksum ck;
ck.add(fieldA); // this is supported
ck.add({fieldA, fieldB}) // this is not supported yet
```

I have not found an elegant way to support this. I am not entirely sure whether this should be handled on the p4c end or the bmv2 end. Advices and ideas are greatly appreciated!