### PR TITLE
Update build script and README to Thrift version 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ On Ubuntu 16.04, the following packages are required:
 You also need to install the following from source. Feel free to use the
 install scripts under travis/.
 
-- [thrift 0.9.2](https://github.com/apache/thrift/releases/tag/0.9.2) or later
+- [thrift 0.11.0](https://github.com/apache/thrift/releases/tag/0.11.0) or later
   (tested up to 0.12.1)
 - [nanomsg 1.0.0](https://github.com/nanomsg/nanomsg/releases/tag/1.0.0) or
   later

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -6,6 +6,8 @@ then
     # This older package libssl1.0-dev enables compiling Thrift 0.9.2
     # on Ubuntu 18.04.  Package libssl-dev exists, but Thrift 0.9.2
     # fails to compile when it is installed.
+    # TBD whether using this package makes a difference for Ubuntu
+    # 18.04 and Thrift 0.11.0.
     LIBSSL_DEV="libssl1.0-dev"
 else
     LIBSSL_DEV="libssl-dev"

--- a/travis/install-thrift.sh
+++ b/travis/install-thrift.sh
@@ -3,14 +3,14 @@
 THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $THIS_DIR/common.sh
 
-check_lib libthrift libthrift-0.9.2
+check_lib libthrift libthrift-0.11.0
 
 set -e
 # Make it possible to get thrift in China
-# wget http://archive.apache.org/dist/thrift/0.9.2/thrift-0.9.2.tar.gz
-# tar -xzvf thrift-0.9.2.tar.gz
-git clone -b 0.9.2 https://github.com/apache/thrift.git thrift-0.9.2
-cd thrift-0.9.2
+# wget http://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz
+# tar -xzvf thrift-0.11.0.tar.gz
+git clone -b 0.11.0 https://github.com/apache/thrift.git thrift-0.11.0
+cd thrift-0.11.0
 ./bootstrap.sh
 ./configure --with-cpp=yes --with-c_glib=no --with-java=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no
 make -j2 && sudo make install


### PR DESCRIPTION
This version has been officially supported for a while now, and will
likely help in moving from Python2 to Python3.