### PR TITLE
Support header and struct for logging (fixes #2201 from p4c)

### DIFF
--- a/include/bm/bm_sim/core/primitives.h
+++ b/include/bm/bm_sim/core/primitives.h
@@ -82,9 +82,9 @@ class exit_ : public ActionPrimitive<> {
 };
 
 struct log_msg : public ActionPrimitive<const std::string &,
-                                        const std::vector<Data> > {
+                              const std::vector<const DataRepresentation*> > {
   void operator ()(const std::string &format,
-                   const std::vector<Data> data_vector);
+                   const std::vector<const DataRepresentation*> data_vector);
 };
 
 }  // namespace core

--- a/include/bm/bm_sim/core/primitives.h
+++ b/include/bm/bm_sim/core/primitives.h
@@ -82,9 +82,9 @@ class exit_ : public ActionPrimitive<> {
 };
 
 struct log_msg : public ActionPrimitive<const std::string &,
-                              const std::vector<const DataRepresentation*> > {
+                      const std::vector<const StringRepresentationIface*> > {
   void operator ()(const std::string &format,
-                   const std::vector<const DataRepresentation*> data_vector);
+              const std::vector<const StringRepresentationIface*> data_vector);
 };
 
 }  // namespace core

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -39,14 +39,14 @@ namespace bm {
 
 using bignum::Bignum;
 
-// DataRepresentation is used to represent data for log_msg.
+// StringRepresentationIface is used to represent data for log_msg.
 // if log_msg is to support a data type, the class for that type
 // should inherit this class and override show method.
 // For now the subclasses are Data, Header and List.
-class DataRepresentation {
+class StringRepresentationIface {
  public:
-  virtual ~DataRepresentation() {}
-  virtual std::string show() const = 0;
+  virtual ~StringRepresentationIface() {}
+  virtual std::string get_string_repr() const = 0;
 };
 
 
@@ -67,7 +67,7 @@ class DataRepresentation {
 //! Note that Data includes a Bignum (for arbitrary arithmetic). Therefore,
 //! operations involving Data can be rather costly. In particular, constructing
 //! a Data instance involves a heap memory allocation.
-class Data : public DataRepresentation {
+class Data : public StringRepresentationIface {
  public:
   Data() {}
 
@@ -228,7 +228,7 @@ class Data : public DataRepresentation {
     return s;
   }
 
-  std::string get_string_repr() const {
+  std::string get_string_repr() const override {
     assert(arith);
     return value.convert_to<std::string>();
   }
@@ -435,9 +435,6 @@ class Data : public DataRepresentation {
     return out;
   }
 
-  std::string show() const override {
-    return get_string_repr();
-  }
   // Copy constructor
   //! NC
   Data(const Data &other)

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -39,6 +39,17 @@ namespace bm {
 
 using bignum::Bignum;
 
+// DataRepresentation is used to represent data for log_msg.
+// if log_msg is to support a data type, the class for that type
+// should inherit this class and override show method.
+// For now the subclasses are Data, Header and List.
+class DataRepresentation {
+ public:
+  virtual ~DataRepresentation() {}
+  virtual std::string show() const = 0;
+};
+
+
 //! Data is a very important class in bmv2. It can be used to represent an
 //! arbitrarily large number. It is also the base class for the Field and
 //! Register classes. Arithmetic expressions are evaluated using Data as
@@ -56,7 +67,7 @@ using bignum::Bignum;
 //! Note that Data includes a Bignum (for arbitrary arithmetic). Therefore,
 //! operations involving Data can be rather costly. In particular, constructing
 //! a Data instance involves a heap memory allocation.
-class Data {
+class Data : public DataRepresentation {
  public:
   Data() {}
 
@@ -424,6 +435,9 @@ class Data {
     return out;
   }
 
+  std::string show() const override {
+    return get_string_repr();
+  }
   // Copy constructor
   //! NC
   Data(const Data &other)

--- a/include/bm/bm_sim/headers.h
+++ b/include/bm/bm_sim/headers.h
@@ -146,7 +146,7 @@ class HeaderType : public NamedP4Object {
 
 //! Used to represent P4 header instances. It includes a vector of Field
 //! objects.
-class Header : public NamedP4Object, public DataRepresentation {
+class Header : public NamedP4Object, public StringRepresentationIface {
  public:
   using iterator = std::vector<Field>::iterator;
   using const_iterator = std::vector<Field>::const_iterator;
@@ -288,33 +288,7 @@ class Header : public NamedP4Object, public DataRepresentation {
   // the metadata variable:
   //  metadata = 0 for the header
   //  metadata = 1 for the structure.
-  std::string show() const override {
-    std::string format = "{";
-    if (!is_metadata() && !is_valid()) {
-      // header is not valid
-      format.append("'" + get_field_name(fields.size()-1) + "': " + "0}");
-      return format;
-    }
-
-    if (!is_metadata()) {
-      // if it is a header, the valid field is added
-      format.append("'" + get_field_name(fields.size()-1) + "': " +
-          fields[fields.size()-1].get_string_repr() + ", ");
-    }
-
-    for (size_t i = 0; i < fields.size()-1; i++) {
-      // if it is a structure, the _padding field is skipped
-      if (get_field_name(i).substr(0, 8).compare("_padding") == 0) {
-        continue;
-      }
-      format.append("'" + get_field_name(i) + "': " +
-          fields[i].get_string_repr() + ", ");
-    }
-
-    format.erase(format.size()-2, format.size());
-    format.append("}");
-    return format;
-  }
+  std::string get_string_repr() const override;
 
   Header(const Header &other) = delete;
   Header &operator=(const Header &other) = delete;
@@ -360,7 +334,7 @@ class Header : public NamedP4Object, public DataRepresentation {
 // This is a helper class.
 // For now, this class is only used to represent the list, tuple and
 // structure with headers required for log_msg.
-class List : public DataRepresentation {
+class List : public StringRepresentationIface {
  public:
   List(std::vector<std::pair<int, Data>> vec_data,
       std::vector<std::pair<int, header_id_t>> vec_header_id) {
@@ -388,41 +362,7 @@ class List : public DataRepresentation {
     headers.clear();
   }
 
-  std::string show() const override {
-    std::string format = "{";
-    int i = 0, j = 0;
-    int num_data = const_values.size();
-    int num_header = header_ids.size();
-
-    while (i < num_data && j < num_header) {
-      if (const_values[i].first < header_ids[j].first) {
-        format.append(const_values[i].second.show() + ", ");
-        i++;
-      } else {
-        if (headers[j]->show().find("is not valid") != std::string::npos) {
-          return headers[j]->show();
-        }
-        format.append(headers[j]->show() + ", ");
-        j++;
-      }
-    }
-    while (i < num_data) {
-      format.append(const_values[i].second.show() + ", ");
-      i++;
-    }
-    while (j < num_header) {
-      if (headers[j]->show().find("is not valid") != std::string::npos) {
-          return headers[j]->show();
-        }
-      format.append(headers[j]->show() + ", ");
-      j++;
-    }
-
-    format.erase(format.size()-2, format.size());
-    format.append("}");
-
-    return format;
-  }
+  std::string get_string_repr() const override;
 
   List(const List &other) = delete;
   List &operator=(const List &other) = delete;

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -259,6 +259,14 @@ ActionFn::parameter_push_back_string(const std::string &str) {
   params.push_back(param);
 }
 
+void ActionFn::parameter_push_back_list(std::unique_ptr<List> str) {
+  ActionParam param;
+  param.tag = ActionParam::LIST;
+  lists.push_back(std::move(str));
+  param.list = lists.back().get();
+  params.push_back(param);
+}
+
 void
 ActionFn::parameter_start_vector() {
   ActionParam param;

--- a/src/bm_sim/core/primitives.cpp
+++ b/src/bm_sim/core/primitives.cpp
@@ -139,7 +139,7 @@ exit_::operator ()() {
 
 void
 log_msg::operator ()(const std::string &format,
-                     const std::vector<Data> data_vector) {
+                     const std::vector<const DataRepresentation*> data_vector) {
   std::string str = format;
   std::string::size_type open = 0;  // position of the opened bracket
   std::string::size_type end = 0;  // position of the matching closed bracket
@@ -168,8 +168,8 @@ log_msg::operator ()(const std::string &format,
     } else {
       if (counter < data_vector.size()) {
         str.replace(open, end - open + 1,
-                    data_vector[counter].get_string_repr());
-        open += data_vector[counter++].get_string_repr().size();
+                    data_vector[counter]->show());
+        open += data_vector[counter++]->show().size();
       } else {
         counter++;
         open += end - open;

--- a/src/bm_sim/core/primitives.cpp
+++ b/src/bm_sim/core/primitives.cpp
@@ -139,7 +139,7 @@ exit_::operator ()() {
 
 void
 log_msg::operator ()(const std::string &format,
-                     const std::vector<const DataRepresentation*> data_vector) {
+            const std::vector<const StringRepresentationIface*> data_vector) {
   std::string str = format;
   std::string::size_type open = 0;  // position of the opened bracket
   std::string::size_type end = 0;  // position of the matching closed bracket
@@ -168,8 +168,8 @@ log_msg::operator ()(const std::string &format,
     } else {
       if (counter < data_vector.size()) {
         str.replace(open, end - open + 1,
-                    data_vector[counter]->show());
-        open += data_vector[counter++]->show().size();
+                    data_vector[counter]->get_string_repr());
+        open += data_vector[counter++]->get_string_repr().size();
       } else {
         counter++;
         open += end - open;

--- a/src/bm_sim/headers.cpp
+++ b/src/bm_sim/headers.cpp
@@ -342,4 +342,57 @@ Header::set_union_membership(HeaderUnion *header_union, size_t idx) {
   union_membership.reset(new UnionMembership(header_union, idx));
 }
 
+std::string Header::get_string_repr() const {
+    std::string format = "{";
+
+    if (!is_metadata()) {
+      // if it is a header, the valid field is added
+      format.append("'" + get_field_name(fields.size()-1) + "': " +
+          fields[fields.size()-1].get_string_repr() + ", ");
+    }
+
+    for (size_t i = 0; i < fields.size()-1; i++) {
+      // if it is a structure, the _padding field is skipped
+      if (get_field_name(i).substr(0, 8).compare("_padding") == 0) {
+        continue;
+      }
+      format.append("'" + get_field_name(i) + "': " +
+          fields[i].get_string_repr() + ", ");
+    }
+
+    format.erase(format.size()-2, format.size());
+    format.append("}");
+    return format;
+  }
+
+  std::string List::get_string_repr() const {
+    std::string format = "{";
+    int i = 0, j = 0;
+    int num_data = const_values.size();
+    int num_header = header_ids.size();
+
+    while (i < num_data && j < num_header) {
+      if (const_values[i].first < header_ids[j].first) {
+        format.append(const_values[i].second.get_string_repr() + ", ");
+        i++;
+      } else {
+        format.append(headers[j]->get_string_repr() + ", ");
+        j++;
+      }
+    }
+    while (i < num_data) {
+      format.append(const_values[i].second.get_string_repr() + ", ");
+      i++;
+    }
+    while (j < num_header) {
+      format.append(headers[j]->get_string_repr() + ", ");
+      j++;
+    }
+
+    format.erase(format.size()-2, format.size());
+    format.append("}");
+
+    return format;
+  }
+
 }  // namespace bm

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,7 +70,8 @@ test_enums \
 test_core_primitives \
 test_control_flow \
 test_assert_assume \
-test_log_msg
+test_log_msg \
+test_log_msg_header
 
 check_PROGRAMS = $(TESTS) test_all
 
@@ -112,6 +113,7 @@ test_core_primitives_SOURCES = $(common_source) test_core_primitives.cpp
 test_control_flow_SOURCES    = $(common_source) test_control_flow.cpp
 test_assert_assume_SOURCES   = $(common_source) test_assert_assume.cpp
 test_log_msg_SOURCES         = $(common_source) test_log_msg.cpp
+test_log_msg_header_SOURCES  = $(common_source) test_log_msg_header.cpp
 
 test_all_SOURCES = $(common_source) \
 test_actions.cpp \
@@ -150,7 +152,8 @@ test_enums.cpp \
 test_core_primitives.cpp \
 test_control_flow.cpp \
 test_assert_assume.cpp \
-test_log_msg.cpp
+test_log_msg.cpp \
+test_log_msg_header.cpp
 
 EXTRA_DIST = \
 testdata/en0.pcap \

--- a/tests/test_log_msg_header.cpp
+++ b/tests/test_log_msg_header.cpp
@@ -1,0 +1,527 @@
+/* Copyright 2019 RT-RK Computer Based System
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_sim/actions.h>
+#include <bm/bm_sim/core/primitives.h>
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/phv.h>
+#include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/P4Objects.h>
+
+#include <vector>
+#include <string>
+#include <fstream>
+#include <sstream>
+
+#include <boost/filesystem.hpp>
+
+#include "jsoncpp/json.h"
+
+using bm::PHVFactory;
+using bm::ActionFn;
+using bm::ActionFnEntry;
+using bm::PHVSourceIface;
+using bm::ActionPrimitive_;
+using bm::ActionOpcodesMap;
+using bm::Data;
+using bm::Packet;
+using bm::P4Objects;
+using bm::LookupStructureFactory;
+
+namespace fs = boost::filesystem;
+
+
+using namespace bm;
+class LogTest : public ::testing::Test {
+ protected:
+  PHVFactory phv_factory;
+  std::unique_ptr<PHV> phv;
+
+  P4Objects objects;
+
+
+  HeaderType testHeaderType;
+  header_id_t testHeader1{0}, testHeader2{1}, testHeader3{2};
+
+  ActionFn testActionFn;
+  ActionFnEntry testActionFnEntry;
+
+  std::unique_ptr<PHVSourceIface> phv_source{nullptr};
+  std::unique_ptr<Packet> pkt{nullptr};
+
+  LogTest()
+      : testHeaderType("test_t", 0),
+        testActionFn("test_primitive", 0, 1),
+        testActionFnEntry(&testActionFn),
+        phv_source(PHVSourceIface::make_phv_source()) {
+          testHeaderType.push_back_field("f16", 16);
+          testHeaderType.push_back_field("f48", 48);
+          phv_factory.push_back_header("test1", testHeader1, testHeaderType);
+          phv_factory.push_back_header("test2", testHeader2, testHeaderType);
+          phv_factory.push_back_header(
+            "test3", testHeader3, testHeaderType, true);
+        }
+
+  virtual void SetUp() {
+    phv_source->set_phv_factory(0, &phv_factory);
+    pkt = std::unique_ptr<Packet>(new Packet(
+        Packet::make_new(phv_source.get())));
+    phv = phv_factory.create();
+  }
+};
+
+namespace {
+
+struct CheckLogs {
+  CheckLogs() {
+    bm::Logger::set_logger_ostream(ss);
+  }
+
+  ~CheckLogs() {
+    bm::Logger::unset_logger();
+  }
+
+  bool contains(const char *expected) const {
+    auto actual = str();
+    auto found = actual.find(expected);
+    return found != std::string::npos;
+  }
+
+  std::string str() const {
+    return ss.str();
+  }
+
+  std::stringstream ss;
+};
+
+}  // namespace
+
+
+
+TEST_F(LogTest, LogMessageInvalidHeader) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 0);
+  testActionFn.parameter_push_back_const(Data(4));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 1);
+  testActionFn.parameter_push_back_const(Data(5));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 2);
+  testActionFn.parameter_push_back_const(Data(0));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_header(testHeader2);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains("x = {'$valid$': 0, 'f16': 4, 'f48': 5}"));
+}
+
+
+TEST_F(LogTest, LogMessageDataInvalidHeader) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);
+  testActionFn.parameter_push_back_const(Data(3));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 1);
+  testActionFn.parameter_push_back_const(Data(5));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 2);
+  testActionFn.parameter_push_back_const(Data(0));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x1 = {}, x2 = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_const(Data("0x04"));
+  testActionFn.parameter_push_back_header(testHeader1);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains("x1 = 4, x2 = {'$valid$': 0, 'f16': 3, 'f48': 5}"));
+}
+
+
+TEST_F(LogTest, LogMessageHeader) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 0);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 1);
+  testActionFn.parameter_push_back_const(Data(9));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_header(testHeader2);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains("x = {'$valid$': 1, 'f16': 2, 'f48': 9}"));
+}
+
+TEST_F(LogTest, LogMessageDataHeader) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 0);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 1);
+  testActionFn.parameter_push_back_const(Data(3));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x1 = {}, x2 = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_const(Data(1));
+  testActionFn.parameter_push_back_header(testHeader2);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains("x1 = 1, x2 = {'$valid$': 1, 'f16': 2, 'f48': 3}"));
+}
+
+TEST_F(LogTest, LogMessageTwoHeaders) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);
+  testActionFn.parameter_push_back_const(Data(4));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 1);
+  testActionFn.parameter_push_back_const(Data(5));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 0);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 1);
+  testActionFn.parameter_push_back_const(Data(3));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader2, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x1 = {}, x2 = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_header(testHeader1);
+  testActionFn.parameter_push_back_header(testHeader2);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains(
+    "x1 = {'$valid$': 1, 'f16': 4, 'f48': 5}, "
+    "x2 = {'$valid$': 1, 'f16': 2, 'f48': 3}"));
+}
+
+TEST_F(LogTest, LogMessageDataStruct) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader3, 0);
+  testActionFn.parameter_push_back_const(Data(4));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader3, 1);
+  testActionFn.parameter_push_back_const(Data(9));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x1 = {}, x2 = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_const(Data(1));
+  testActionFn.parameter_push_back_header(testHeader3);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains("x1 = 1, x2 = {'f16': 4, 'f48': 9}"));
+}
+
+TEST_F(LogTest, LogMessageHeaderStruct) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);
+  testActionFn.parameter_push_back_const(Data(4));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 1);
+  testActionFn.parameter_push_back_const(Data(5));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader3, 0);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader3, 1);
+  testActionFn.parameter_push_back_const(Data(3));
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x1 = {}, x2 = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_header(testHeader1);
+  testActionFn.parameter_push_back_header(testHeader3);
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains(
+    "x1 = {'$valid$': 1, 'f16': 4, 'f48': 5}, x2 = {'f16': 2, 'f48': 3}"));
+}
+
+TEST_F(LogTest, LogMessageStructWithHeader) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);
+  testActionFn.parameter_push_back_const(Data(1));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 1);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  std::vector<std::pair<int, Data>> vec_data{};
+  std::vector<std::pair<int, header_id_t>> vec_header_id{};
+  vec_data.push_back(std::make_pair(0, Data(3)));
+  vec_data.push_back(std::make_pair(1, Data(5)));
+  vec_header_id.push_back(std::make_pair(2, testHeader1));
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_list(
+        std::unique_ptr<List>(new List(vec_data, vec_header_id)));
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains(
+    "x = {3, 5, {'$valid$': 1, 'f16': 1, 'f48': 2}}"));
+}
+
+TEST_F(LogTest, LogMessageStructWithHeader2) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader3, 0);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader3, 1);
+  testActionFn.parameter_push_back_const(Data(3));
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);
+  testActionFn.parameter_push_back_const(Data(4));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 1);
+  testActionFn.parameter_push_back_const(Data(5));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  std::vector<std::pair<int, Data>> vec_data{};
+  std::vector<std::pair<int, header_id_t>> vec_header_id{};
+  vec_data.push_back(std::make_pair(0, Data(3)));
+  vec_header_id.push_back(std::make_pair(1, testHeader3));
+  vec_data.push_back(std::make_pair(2, Data(4)));
+  vec_header_id.push_back(std::make_pair(3, testHeader1));
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_list(
+        std::unique_ptr<List>(new List(vec_data, vec_header_id)));
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains(
+    "x = {3, {'f16': 2, 'f48': 3}, 4, {'$valid$': 1, 'f16': 4, 'f48': 5}}"));
+}
+
+TEST_F(LogTest, LogMessageStructWithHeader3) {
+  CheckLogs logs;
+  std::unique_ptr<ActionPrimitive_> primitive;
+  std::unique_ptr<ActionPrimitive_> primitive1;
+
+
+  std::string primitive_name1("assign");
+  primitive1 = ActionOpcodesMap::get_instance()->get_primitive("assign");
+  ASSERT_NE(nullptr, primitive1);
+
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 0);
+  testActionFn.parameter_push_back_const(Data(1));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 1);
+  testActionFn.parameter_push_back_const(Data(2));
+  testActionFn.push_back_primitive(primitive1.get());
+  testActionFn.parameter_push_back_field(testHeader1, 2);
+  testActionFn.parameter_push_back_const(Data(1));
+
+
+  std::string primitive_name("log_msg");
+  primitive = ActionOpcodesMap::get_instance()->get_primitive("log_msg");
+  ASSERT_NE(nullptr, primitive);
+
+  std::vector<std::pair<int, Data>> vec_data{};
+  std::vector<std::pair<int, header_id_t>> vec_header_id{};
+  vec_data.push_back(std::make_pair(0, Data(3)));
+  vec_data.push_back(std::make_pair(2, Data(5)));
+  vec_header_id.push_back(std::make_pair(1, testHeader1));
+
+  testActionFn.push_back_primitive(primitive.get());
+  testActionFn.parameter_push_back_string("x = {}");
+  testActionFn.parameter_start_vector();
+  testActionFn.parameter_push_back_list(
+        std::unique_ptr<List>(new List(vec_data, vec_header_id)));
+  testActionFn.parameter_end_vector();
+
+  testActionFnEntry(pkt.get());
+
+  EXPECT_TRUE(logs.contains(
+    "x = {3, {'$valid$': 1, 'f16': 1, 'f48': 2}, 5}"));
+}
+
+TEST_F(LogTest, InitObjects) {
+  fs::path json_path = fs::path(TESTDATADIR) / fs::path("log_msg.json");
+  std::ifstream is(json_path.string());
+  LookupStructureFactory factory;
+  ASSERT_EQ(0, objects.init_objects(&is, &factory));
+}

--- a/tests/testdata/log_msg.json
+++ b/tests/testdata/log_msg.json
@@ -1,0 +1,322 @@
+{
+  "header_types" : [
+    {
+      "name" : "Structure1",
+      "id" : 1,
+      "fields" : [
+        ["val1", 7, false],
+        ["val2", 7, false],
+        ["_padding", 2, false]
+      ]
+    },
+    {
+      "name" : "Header",
+      "id" : 2,
+      "fields" : [
+        ["val1", 4, false],
+        ["val2", 4, false]
+      ]
+    },
+    {
+      "name" : "ethernet_t",
+      "id" : 4,
+      "fields" : [
+        ["dstAddr", 48, false],
+        ["srcAddr", 48, false],
+        ["etherType", 16, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "str1_0",
+      "id" : 0,
+      "header_type" : "Structure1",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr1_0",
+      "id" : 1,
+      "header_type" : "Header",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "str3_0_val5",
+      "id" : 2,
+      "header_type" : "Structure1",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "ethernet",
+      "id" : 5,
+      "header_type" : "ethernet_t",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "ethernet"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "default",
+              "value" : null,
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "test.p4",
+        "line" : 75,
+        "column" : 8,
+        "source_fragment" : "deparserImpl"
+      },
+      "order" : ["ethernet"],
+      "primitives" : []
+    }
+  ],
+  "actions" : [
+    {
+      "name" : "test55",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["str1_0", "val1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 55,
+            "column" : 8,
+            "source_fragment" : "Structure1 str1 = {2, 3};"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["str1_0", "val2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x03"
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 55,
+            "column" : 8,
+            "source_fragment" : "Structure1 str1 = {2, 3};"
+          }
+        },
+        {
+          "op" : "log_msg",
+          "parameters" : [
+            {
+              "type" : "string",
+              "value" : "str1 = {}"
+            },
+            {
+              "type" : "parameters_vector",
+              "value" : [
+                {
+                  "type" : "header",
+                  "value" : "str1_0"
+                }
+              ]
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 56,
+            "column" : 8,
+            "source_fragment" : "        log_msg(\\\"str1 = {}\\\", {str1});"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr1_0", "val1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x04"
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 57,
+            "column" : 8,
+            "source_fragment" : "Header hdr1 = {4, 1};"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr1_0", "val2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x01"
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 57,
+            "column" : 8,
+            "source_fragment" : "Header hdr1 = {4, 1};"
+          }
+        },
+        {
+          "op" : "log_msg",
+          "parameters" : [
+            {
+              "type" : "string",
+              "value" : "str2 = {}"
+            },
+            {
+              "type" : "parameters_vector",
+              "value" : [
+                [
+                  {
+                    "type" : "hexstr",
+                    "value" : "0x03"
+                  },
+                  {
+                    "type" : "header",
+                    "value" : "hdr1_0"
+                  }
+                ]
+              ]
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 59,
+            "column" : 8,
+            "source_fragment" : "        log_msg(\\\"str2 = {}\\\", {str2});"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["str3_0_val5", "val1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 55,
+            "column" : 28,
+            "source_fragment" : "2, 3 }; ..."
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["str3_0_val5", "val2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x03"
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 55,
+            "column" : 31,
+            "source_fragment" : "3 }; ..."
+          }
+        },
+        {
+          "op" : "log_msg",
+          "parameters" : [
+            {
+              "type" : "string",
+              "value" : "str3 = {}"
+            },
+            {
+              "type" : "parameters_vector",
+              "value" : [
+                [
+                  {
+                    "type" : "hexstr",
+                    "value" : "0x03"
+                  },
+                  {
+                    "type" : "header",
+                    "value" : "hdr1_0"
+                  },
+                  {
+                    "type" : "bool",
+                    "value" : false
+                  },
+                  {
+                    "type" : "header",
+                    "value" : "str3_0_val5"
+                  }
+                ]
+              ]
+            }
+          ],
+          "source_info" : {
+            "filename" : "test.p4",
+            "line" : 61,
+            "column" : 8,
+            "source_fragment" : "        log_msg(\\\"str3 = {}\\\", {str3});"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR is related to p4lang/p4c#2596 PR in p4c.

Example 1:
header Hdr {
	int<4> a;
	bit<4> b;
}
Hdr h = {3,5};
log_msg("h = {}", {h});
Output: h = {'a': 3, 'b': 5, '$valid$': 1}

Example 2:
struct Str {
	int<4> a;
	bit<4> b;
	bool c;
}
Str s = {3,5,true};
log_msg("s = {}", {s});
Output: s = {'a': 3, 'b': 5, 'c': 1}