### PR TITLE
Change return type of bm_get_config_md5() to binary

### DIFF
--- a/thrift_src/standard.thrift
+++ b/thrift_src/standard.thrift
@@ -715,7 +715,7 @@ service Standard {
   void bm_reset_state()
 
   string bm_get_config()
-  string bm_get_config_md5()
+  binary bm_get_config_md5()
 
   i32 bm_get_id_from_name(
     1:i32 cxt_id,


### PR DESCRIPTION
In the Thrift interface. Using "binary" makes sense since it seems that
"string" assumes UTF-8 and the md5 checksum value is not a UTF-8
string. It used to work so not sure why this change is required (maybe a
change across Thrift versions?). Changing the type probably breaks
backwards compatibility (e.g. new CLI version and old simple_switch
version), but typically we require all the components to be updated
simultaneously. I am also pretty sure that no one cares about
backwards-compatibility.

Fixes #964