### PR TITLE
Print error code in logs for invalid runtime operations

### DIFF
--- a/include/bm/bm_sim/match_error_codes.h
+++ b/include/bm/bm_sim/match_error_codes.h
@@ -54,6 +54,8 @@ enum class MatchErrorCode {
   ERROR,
 };
 
+const char *match_error_code_to_string(MatchErrorCode code);
+
 }  // namespace bm
 
 #endif  // BM_BM_SIM_MATCH_ERROR_CODES_H_

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -45,6 +45,7 @@ learning.cpp \
 lookup_structures.cpp \
 logger.cpp \
 lpm_trie.h \
+match_error_codes.cpp \
 match_units.cpp \
 match_tables.cpp \
 md5.c \

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -226,8 +226,8 @@ ActionProfile::add_member(const ActionFn *action_fn, ActionData action_data,
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Added member {} to action profile '{}'", *mbr, get_name());
   } else {
-    BMLOG_ERROR("Error when trying to add member to action profile '{}'",
-                get_name());
+    BMLOG_ERROR("Error when trying to add member to action profile '{}': {}",
+                get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -256,8 +256,8 @@ ActionProfile::delete_member(mbr_hdl_t mbr) {
     BMLOG_DEBUG("Removed member {} from action profile '{}'", mbr, get_name());
   } else {
     BMLOG_ERROR(
-        "Error when trying to remove member {} from action profile '{}'",
-        mbr, get_name());
+        "Error when trying to remove member {} from action profile '{}': {}",
+        mbr, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -288,8 +288,8 @@ ActionProfile::modify_member(mbr_hdl_t mbr, const ActionFn *action_fn,
     BMLOG_DEBUG("Modified member {} from action profile '{}'", mbr, get_name());
   } else {
     BMLOG_ERROR(
-        "Error when trying to modify member {} from action profile '{}'",
-        mbr, get_name());
+        "Error when trying to modify member {} from action profile '{}': {}",
+        mbr, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -316,8 +316,8 @@ ActionProfile::create_group(grp_hdl_t *grp) {
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Created group {} in action profile '{}'", *grp, get_name());
   } else {
-    BMLOG_ERROR("Error when trying to create group in action profile '{}'",
-                get_name());
+    BMLOG_ERROR("Error when trying to create group in action profile '{}': {}",
+                get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -356,8 +356,9 @@ ActionProfile::delete_group(grp_hdl_t grp) {
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Removed group {} from action profile '{}'", grp, get_name());
   } else {
-    BMLOG_ERROR("Error when trying to remove group {} from action profile '{}'",
-                grp, get_name());
+    BMLOG_ERROR(
+        "Error when trying to remove group {} from action profile '{}': {}",
+        grp, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -390,9 +391,9 @@ ActionProfile::add_member_to_group(mbr_hdl_t mbr, grp_hdl_t grp) {
     BMLOG_DEBUG("Added member {} to group {} in action profile '{}'",
                 mbr, grp, get_name());
   } else {
-    BMLOG_ERROR(
-        "Error when trying to add member {} to group {} in action profile '{}'",
-        mbr, grp, get_name());
+    BMLOG_ERROR("Error when trying to add member {} to group {} in action "
+                "profile '{}': {}", mbr, grp, get_name(),
+                match_error_code_to_string(rc));
   }
 
   return rc;
@@ -426,7 +427,8 @@ ActionProfile::remove_member_from_group(mbr_hdl_t mbr, grp_hdl_t grp) {
                 mbr, grp, get_name());
   } else {
     BMLOG_ERROR("Error when trying to remove member {} from group {} "
-                "in table '{}'", mbr, grp, get_name());
+                "in table '{}': {}", mbr, grp, get_name(),
+                match_error_code_to_string(rc));
   }
 
   return rc;

--- a/src/bm_sim/match_error_codes.cpp
+++ b/src/bm_sim/match_error_codes.cpp
@@ -1,0 +1,88 @@
+/* Copyright 2021 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas
+ *
+ */
+
+#include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/match_error_codes.h>
+
+namespace bm {
+
+const char *match_error_code_to_string(MatchErrorCode code) {
+  switch (code) {
+    case MatchErrorCode::SUCCESS:
+      return "SUCCESS";
+    case MatchErrorCode::TABLE_FULL:
+      return "TABLE_FULL";
+    case MatchErrorCode::INVALID_HANDLE:
+      return "INVALID_HANDLE";
+    case MatchErrorCode::EXPIRED_HANDLE:
+      return "EXPIRED_HANDLE";
+    case MatchErrorCode::COUNTERS_DISABLED:
+      return "COUNTERS_DISABLED";
+    case MatchErrorCode::METERS_DISABLED:
+      return "METERS_DISABLED";
+    case MatchErrorCode::AGEING_DISABLED:
+      return "AGEING_DISABLED";
+    case MatchErrorCode::INVALID_TABLE_NAME:
+      return "INVALID_TABLE_NAME";
+    case MatchErrorCode::INVALID_ACTION_NAME:
+      return "INVALID_ACTION_NAME";
+    case MatchErrorCode::WRONG_TABLE_TYPE:
+      return "WRONG_TABLE_TYPE";
+    case MatchErrorCode::INVALID_MBR_HANDLE:
+      return "INVALID_MBR_HANDLE";
+    case MatchErrorCode::MBR_STILL_USED:
+      return "MBR_STILL_USED";
+    case MatchErrorCode::MBR_ALREADY_IN_GRP:
+      return "MBR_ALREADY_IN_GRP";
+    case MatchErrorCode::MBR_NOT_IN_GRP:
+      return "MBR_NOT_IN_GRP";
+    case MatchErrorCode::INVALID_GRP_HANDLE:
+      return "INVALID_GRP_HANDLE";
+    case MatchErrorCode::GRP_STILL_USED:
+      return "GRP_STILL_USED";
+    case MatchErrorCode::EMPTY_GRP:
+      return "EMPTY_GRP";
+    case MatchErrorCode::DUPLICATE_ENTRY:
+      return "DUPLICATE_ENTRY";
+    case MatchErrorCode::BAD_MATCH_KEY:
+      return "BAD_MATCH_KEY";
+    case MatchErrorCode::INVALID_METER_OPERATION:
+      return "INVALID_METER_OPERATION";
+    case MatchErrorCode::DEFAULT_ACTION_IS_CONST:
+      return "DEFAULT_ACTION_IS_CONST";
+    case MatchErrorCode::DEFAULT_ENTRY_IS_CONST:
+      return "DEFAULT_ENTRY_IS_CONST";
+    case MatchErrorCode::NO_DEFAULT_ENTRY:
+      return "NO_DEFAULT_ENTRY";
+    case MatchErrorCode::INVALID_ACTION_PROFILE_NAME:
+      return "INVALID_ACTION_PROFILE_NAME";
+    case MatchErrorCode::NO_ACTION_PROFILE_SELECTION:
+      return "NO_ACTION_PROFILE_SELECTION";
+    case MatchErrorCode::IMMUTABLE_TABLE_ENTRIES:
+      return "IMMUTABLE_TABLE_ENTRIES";
+    case MatchErrorCode::BAD_ACTION_DATA:
+      return "BAD_ACTION_DATA";
+    case MatchErrorCode::ERROR:
+      return "UNKNOWN_ERROR";
+  }
+  _BM_UNREACHABLE("Enum value not handled in switch statement");
+}
+
+}  // namespace bm

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -403,7 +403,8 @@ MatchTable::add_entry(const std::vector<MatchKeyParam> &match_key,
     BMLOG_DEBUG("Entry {} added to table '{}'", *handle, get_name());
     BMLOG_DEBUG(dump_entry_string(*handle));
   } else {
-    BMLOG_ERROR("Error when trying to add entry to table '{}'", get_name());
+    BMLOG_ERROR("Error when trying to add entry to table '{}': {}",
+                get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -423,8 +424,8 @@ MatchTable::delete_entry(entry_handle_t handle) {
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Removed entry {} from table '{}'", handle, get_name());
   } else {
-    BMLOG_ERROR("Error when trying to remove entry {} from table '{}'",
-                handle, get_name());
+    BMLOG_ERROR("Error when trying to remove entry {} from table '{}': {}",
+                handle, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -453,8 +454,8 @@ MatchTable::modify_entry(entry_handle_t handle,
     BMLOG_DEBUG("Modified entry {} in table '{}'", handle, get_name());
     BMLOG_DEBUG(dump_entry_string(handle));
   } else {
-    BMLOG_ERROR("Error when trying to modify entry {} in table '{}'",
-                handle, get_name());
+    BMLOG_ERROR("Error when trying to modify entry {} in table '{}': {}",
+                handle, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -737,7 +738,8 @@ MatchTableIndirect::add_entry(const std::vector<MatchKeyParam> &match_key,
     BMLOG_DEBUG("Entry {} added to table '{}'", *handle, get_name());
     BMLOG_DEBUG(dump_entry_string(*handle));
   } else {
-    BMLOG_ERROR("Error when trying to add entry to table '{}'", get_name());
+    BMLOG_ERROR("Error when trying to add entry to table '{}': {}",
+                get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -764,8 +766,8 @@ MatchTableIndirect::delete_entry(entry_handle_t handle) {
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Entry {} removed from table '{}'", handle, get_name());
   } else {
-    BMLOG_ERROR("Error when trying to remove entry {} from table '{}'",
-                handle, get_name());
+    BMLOG_ERROR("Error when trying to remove entry {} from table '{}': {}",
+                handle, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -800,8 +802,8 @@ MatchTableIndirect::modify_entry(entry_handle_t handle, mbr_hdl_t mbr) {
     BMLOG_DEBUG("Modified entry {} in table '{}'", handle, get_name());
     BMLOG_DEBUG(dump_entry_string(handle));
   } else {
-    BMLOG_ERROR("Error when trying to modify entry {} in table '{}'",
-                handle, get_name());
+    BMLOG_ERROR("Error when trying to modify entry {} in table '{}': {}",
+                handle, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -831,8 +833,9 @@ MatchTableIndirect::set_default_member(mbr_hdl_t mbr) {
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Set default member for table '{}' to {}", get_name(), mbr);
   } else {
-    BMLOG_ERROR("Error when trying to set default member for table '{}' to {}",
-                get_name(), mbr);
+    BMLOG_ERROR(
+        "Error when trying to set default member for table '{}' to {}: {}",
+        get_name(), mbr, match_error_code_to_string(rc));
   }
 
   return rc;
@@ -1016,7 +1019,8 @@ MatchTableIndirectWS::add_entry_ws(const std::vector<MatchKeyParam> &match_key,
     BMLOG_DEBUG("Entry {} added to table '{}'", *handle, get_name());
     BMLOG_DEBUG(dump_entry_string(*handle));
   } else {
-    BMLOG_ERROR("Error when trying to add entry to table '{}'", get_name());
+    BMLOG_ERROR("Error when trying to add entry to table '{}': {}",
+                get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -1054,8 +1058,8 @@ MatchTableIndirectWS::modify_entry_ws(entry_handle_t handle, grp_hdl_t grp) {
     BMLOG_DEBUG("Modified entry {} in table '{}'", handle, get_name());
     BMLOG_DEBUG(dump_entry_string(handle));
   } else {
-    BMLOG_ERROR("Error when trying to modify entry {} in table '{}'",
-                handle, get_name());
+    BMLOG_ERROR("Error when trying to modify entry {} in table '{}': {}",
+                handle, get_name(), match_error_code_to_string(rc));
   }
 
   return rc;
@@ -1086,8 +1090,9 @@ MatchTableIndirectWS::set_default_group(grp_hdl_t grp) {
   if (rc == MatchErrorCode::SUCCESS) {
     BMLOG_DEBUG("Set default group for table '{}' to {}", get_name(), grp);
   } else {
-    BMLOG_ERROR("Error when trying to set default group for table '{}' to {}",
-                get_name(), grp);
+    BMLOG_ERROR(
+        "Error when trying to set default group for table '{}' to {}: {}",
+        get_name(), grp, match_error_code_to_string(rc));
   }
 
   return rc;


### PR DESCRIPTION
This is especially useful when using P4Runtime, as PI does not preserve
the error code returned by bmv2 in case of invalid runtime operation
(e.g. when trying to insert a duplicate table entry). While most sanity
checks are performed at the P4Runtime server, in some cases (e.g. to
troubleshoot a bmv2 bug), it is useful to be able to inspect the bmv2
logs and see what the exact error is.

See https://github.com/p4lang/PI/issues/530