### PR TITLE
Use correct pcap files to dump ingress and egress traffic

### DIFF
--- a/src/BMI/bmi_port.c
+++ b/src/BMI/bmi_port.c
@@ -254,8 +254,10 @@ static int _bmi_port_interface_add(bmi_port_mgr_t *port_mgr,
 
   port->ifname = strdup(ifname);
 
-  if (pcap_input_dump) bmi_interface_add_dumper(bmi, pcap_input_dump, 1);
-  if (pcap_output_dump) bmi_interface_add_dumper(bmi, pcap_output_dump, 0);
+  if (pcap_input_dump)
+    bmi_interface_add_dumper(bmi, pcap_input_dump, bmi_input_dumper);
+  if (pcap_output_dump)
+    bmi_interface_add_dumper(bmi, pcap_output_dump, bmi_output_dumper);
 
   port->bmi = bmi;
 


### PR DESCRIPTION
Because of a typo, the files were swapped, with `*_in.pcap` files used
to dump egress packets, and "`*_out.pcap` files used to dump ingress
packets.

Fixes #980