### PR TITLE
Remove ppa:ubuntu-toolchain-r/test from Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ stages:
 matrix:
   include:
     - env: CXX=g++ CC=gcc sswitch_grpc=yes
-    - env: CXX=g++-7 CC=gcc-7 GCOV=gcov-7 sswitch_grpc=no
     - env: CXX=clang++-3.8 CC=clang-3.8 sswitch_grpc=no
-    - env: CXX=clang++-6.0 CC=clang-6.0 sswitch_grpc=no
+    - env: CXX=clang++-8 CC=clang-8 sswitch_grpc=no
     - stage: deploy
       install: skip
       script: docker run --rm -v $(pwd):/data -it hrektts/doxygen doxygen

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,8 @@ ARG sswitch_grpc=yes
 ENV BM_DEPS automake \
             build-essential \
             clang-3.8 \
-            clang-6.0 \
+            clang-8 \
             curl \
-            g++-7 \
             git \
             lcov \
             libjudy-dev \
@@ -46,9 +45,6 @@ ENV BM_RUNTIME_DEPS libboost-program-options1.58.0 \
 COPY . /behavioral-model/
 WORKDIR /behavioral-model/
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
     apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ./autogen.sh && \

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -31,9 +31,6 @@ ENV BM_RUNTIME_DEPS libboost-program-options1.58.0 \
 COPY . /behavioral-model/
 WORKDIR /behavioral-model/
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
     apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
     ./autogen.sh && \
     ./configure --enable-debugger && \

--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -648,7 +648,7 @@ bm::MatchTableAbstract::EntryCommon get_match_entry(
           0, t_name, handle, &entry);
       if (error_code != bm::MatchErrorCode::SUCCESS)
         throw bm_exception(error_code);
-      return entry;
+      return std::move(entry);  // avoid copy
     }
     case bm::MatchTableType::INDIRECT: {
       bm::MatchTableIndirect::Entry entry;
@@ -656,7 +656,7 @@ bm::MatchTableAbstract::EntryCommon get_match_entry(
           0, t_name, handle, &entry);
       if (error_code != bm::MatchErrorCode::SUCCESS)
         throw bm_exception(error_code);
-      return entry;
+      return std::move(entry);  // avoid copy
     }
     case bm::MatchTableType::INDIRECT_WS: {
       bm::MatchTableIndirectWS::Entry entry;
@@ -664,7 +664,7 @@ bm::MatchTableAbstract::EntryCommon get_match_entry(
           0, t_name, handle, &entry);
       if (error_code != bm::MatchErrorCode::SUCCESS)
         throw bm_exception(error_code);
-      return entry;
+      return std::move(entry);  // avoid copy
     }
   }
   return {};

--- a/include/bm/bm_sim/checksums.h
+++ b/include/bm/bm_sim/checksums.h
@@ -38,7 +38,20 @@ class Checksum : public NamedP4Object{
   Checksum(const std::string &name, p4object_id_t id,
            header_id_t header_id, int field_offset);
 
-  virtual ~Checksum() { }
+  virtual ~Checksum() = default;
+
+  //! Deleted copy constructor
+  Checksum(const Checksum &other) = delete;
+  //! Deleted copy assignment operator
+  Checksum &operator=(const Checksum &other) = delete;
+
+  // The following are implictly deleted otherwise because of the user-defined
+  // virtual destructor.
+
+  //! Default move constructor
+  Checksum(Checksum &&other) = default;
+  //! Default assignment operator
+  Checksum &operator=(Checksum &&other) = default;
 
   void update(Packet *pkt) const;
 

--- a/include/bm/bm_sim/control_flow.h
+++ b/include/bm/bm_sim/control_flow.h
@@ -38,8 +38,23 @@ class ControlFlowNode : public NamedP4Object {
   ControlFlowNode(const std::string &name, p4object_id_t id,
                   std::unique_ptr<SourceInfo> source_info)
       : NamedP4Object(name, id, std::move(source_info)) {}
-  virtual ~ControlFlowNode() { }
+
+  virtual ~ControlFlowNode() = default;
+
   virtual const ControlFlowNode *operator()(Packet *pkt) const = 0;
+
+  //! Deleted copy constructor
+  ControlFlowNode(const ControlFlowNode &other) = delete;
+  //! Deleted copy assignment operator
+  ControlFlowNode &operator=(const ControlFlowNode &other) = delete;
+
+  // The following are implictly deleted otherwise because of the user-defined
+  // virtual destructor.
+
+  //! Default move constructor
+  ControlFlowNode(ControlFlowNode &&other) = default;
+  //! Default assignment operator
+  ControlFlowNode &operator=(ControlFlowNode &&other) = default;
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/named_p4object.h
+++ b/include/bm/bm_sim/named_p4object.h
@@ -65,7 +65,7 @@ class NamedP4Object {
   const SourceInfo *get_source_info() const { return source_info.get(); }
 
  protected:
-  const std::string name;
+  std::string name;
   p4object_id_t id;
   std::unique_ptr<SourceInfo> source_info;
 };

--- a/include/bm/bm_sim/parser.h
+++ b/include/bm/bm_sim/parser.h
@@ -342,10 +342,10 @@ class Parser : public NamedP4Object {
   //! Deleted copy assignment operator
   Parser &operator=(const Parser &other) = delete;
 
-  //! Default move constructor
-  Parser(Parser &&other) /*noexcept*/ = default;
-  //! Default move assignment operator
-  Parser &operator=(Parser &&other) /*noexcept*/ = default;
+  //! Deleted move constructor (const member variables)
+  Parser(Parser &&other) = delete;
+  //! Deleted move assignment operator (const member variables)
+  Parser &operator=(Parser &&other) /*noexcept*/ = delete;
 
  private:
   void verify_checksums(Packet *pkt) const;


### PR DESCRIPTION
For some reason, having this PPA makes it impossible to install
clang, it creates a "dependency hell". This is recent a issue and wasn't
present a couple weeks ago. To avoid the issue altogether, rather than
waste a lot of time debugging it, we remove the PPA, which means we no
longer run a CI job with a "recent" version of gcc (gcc 7). We still
test with the default version of gcc for Ubuntu 16.04, along with
clang-3.8 and clang-8 (updated from clang-6.0).

The long-term solution should really be to update the base image from
Ubuntu 16.04 to 20.04 (https://github.com/p4lang/third-party/issues/25).