### PR TITLE
Fix simple_switch_grpc tests after PI update

### DIFF
--- a/targets/simple_switch_grpc/tests/example.cpp
+++ b/targets/simple_switch_grpc/tests/example.cpp
@@ -126,7 +126,7 @@ test() {
   {
     auto param = action->add_params();
     param->set_param_id(p1_id);
-    param->set_value(std::string("\x00\x09", 2));
+    param->set_value(std::string("\x09", 1));  // canonical representation
   }
 
   // add entry

--- a/targets/simple_switch_grpc/tests/test_basic.cpp
+++ b/targets/simple_switch_grpc/tests/test_basic.cpp
@@ -96,7 +96,7 @@ TEST_F(SimpleSwitchGrpcTest_Basic, Entries) {
   {
     auto param = action->add_params();
     param->set_param_id(p1_id);
-    param->set_value(std::string("\x00\x09", 2));
+    param->set_value(std::string("\x09", 1));  // canonical representation
   }
 
   // add entry


### PR DESCRIPTION
Tests should use the canonical bytestring representation.