### PR TITLE
Use Python 3 with simple_switch_grpc

### DIFF
--- a/targets/simple_switch_grpc/configure.ac
+++ b/targets/simple_switch_grpc/configure.ac
@@ -9,7 +9,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AC_PROG_CXX
 
-AM_PATH_PYTHON([2.7],, [:])
+AM_PATH_PYTHON([3.5],, [:])
 
 LT_INIT
 


### PR DESCRIPTION
Support for Python 3 was introduced with commit 13d7267 and most of the occurrences of `python` have been replaced with `python3` with commit a633059. This patch updates the autoconf configuration in simple_switch_grpc to use Python 3 as well.