### PR TITLE
Improve CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ install:
 
 script:
   - ci_env=`bash <(curl -s https://codecov.io/env)`
-  - docker run $ci_env --env GCOV -w /behavioral-model bm /bin/bash -c "make check -j$(nproc) && ./travis/codecov.sh"
-  - if [ "$sswitch_grpc" = "yes" ]; then docker run -w /behavioral-model/targets/simple_switch_grpc bm make check -j$(nproc); fi
+  - docker run --rm $ci_env --env GCOV -w /behavioral-model bm /bin/bash -c "make check -j$(nproc) && ./travis/codecov.sh"
+  - if [ "$sswitch_grpc" = "yes" ]; then docker run --rm -w /behavioral-model/targets/simple_switch_grpc bm make check -j$(nproc); fi
   - bash tools/check_style.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ install:
 
 script:
   - ci_env=`bash <(curl -s https://codecov.io/env)`
-  - docker run $ci_env --env GCOV -w /behavioral-model bm /bin/bash -c "make check -j2 && ./travis/codecov.sh"
-  - if [ "$sswitch_grpc" = "yes" ]; then docker run -w /behavioral-model/targets/simple_switch_grpc bm make check -j2; fi
+  - docker run $ci_env --env GCOV -w /behavioral-model bm /bin/bash -c "make check -j$(nproc) && ./travis/codecov.sh"
+  - if [ "$sswitch_grpc" = "yes" ]; then docker run -w /behavioral-model/targets/simple_switch_grpc bm make check -j$(nproc); fi
   - bash tools/check_style.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ ENV BM_RUNTIME_DEPS libboost-program-options1.58.0 \
                     python
 COPY . /behavioral-model/
 WORKDIR /behavioral-model/
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
+RUN apt-get update -qq && \
+    apt-get install -qq --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ./autogen.sh && \
     if [ "$GCOV" != "" ]; then ./configure --with-pdfixed --with-pi --with-stress-tests --enable-debugger --enable-coverage --enable-Werror; fi && \
@@ -57,8 +57,8 @@ RUN apt-get update && \
     (test "$sswitch_grpc" = "no") && \
     ldconfig && \
     (test "$IMAGE_TYPE" = "build" && \
-      apt-get purge -y $BM_DEPS && \
-      apt-get autoremove --purge -y && \
+      apt-get purge -qq $BM_DEPS && \
+      apt-get autoremove --purge -qq && \
       rm -rf /behavioral-model /var/cache/apt/* /var/lib/apt/lists/* && \
       echo 'Build image ready') || \
     (test "$IMAGE_TYPE" = "test" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,6 @@ ARG PARENT_VERSION=latest
 FROM p4lang/pi:${PARENT_VERSION}
 LABEL maintainer="Antonin Bas <antonin@barefootnetworks.com>"
 
-# Default to using 2 make jobs, which is a good default for CI. If you're
-# building locally or you know there are more cores available, you may want to
-# override this.
-ARG MAKEFLAGS=-j2
-
 # Select the type of image we're building. Use `build` for a normal build, which
 # is optimized for image size. Use `test` if this image will be used for
 # testing; in this case, the source code and build-only dependencies will not be
@@ -50,13 +45,13 @@ RUN apt-get update && \
     ./autogen.sh && \
     if [ "$GCOV" != "" ]; then ./configure --with-pdfixed --with-pi --with-stress-tests --enable-debugger --enable-coverage --enable-Werror; fi && \
     if [ "$GCOV" = "" ]; then ./configure --with-pdfixed --with-pi --with-stress-tests --enable-debugger --enable-Werror; fi && \
-    make && \
+    make -j$(nproc) && \
     make install-strip && \
     (test "$sswitch_grpc" = "yes" && \
       cd targets/simple_switch_grpc/ && \
       ./autogen.sh && \
       ./configure --enable-Werror && \
-      make && \
+      make -j$(nproc) && \
       make install-strip && \
       cd -) || \
     (test "$sswitch_grpc" = "no") && \

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -25,14 +25,14 @@ ENV BM_RUNTIME_DEPS libboost-program-options1.58.0 \
                     python
 COPY . /behavioral-model/
 WORKDIR /behavioral-model/
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
+RUN apt-get update -qq && \
+    apt-get install -qq --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
     ./autogen.sh && \
     ./configure --enable-debugger && \
     make -j$(nproc) && \
     make install-strip && \
     ldconfig && \
-    apt-get purge -y $BM_DEPS && \
-    apt-get autoremove --purge -y && \
+    apt-get purge -qq $BM_DEPS && \
+    apt-get autoremove --purge -qq && \
     rm -rf /behavioral-model /var/cache/apt/* /var/lib/apt/lists/* && \
     echo 'Build image ready'

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -3,11 +3,6 @@ LABEL maintainer="Antonin Bas <antonin@barefootnetworks.com>"
 LABEL description="This Docker image does not have any dependency on PI or P4 \
 Runtime, it only builds bmv2 simple_switch."
 
-# Default to using 2 make jobs, which is a good default for CI. If you're
-# building locally or you know there are more cores available, you may want to
-# override this.
-ARG MAKEFLAGS=-j2
-
 ENV BM_DEPS automake \
             build-essential \
             curl \
@@ -34,7 +29,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends $BM_DEPS $BM_RUNTIME_DEPS && \
     ./autogen.sh && \
     ./configure --enable-debugger && \
-    make && \
+    make -j$(nproc) && \
     make install-strip && \
     ldconfig && \
     apt-get purge -y $BM_DEPS && \


### PR DESCRIPTION
This pull request replaces the hard-coded number of make jobs (`-j2`) with a number corresponding to the processing units available. This allows `docker build` to complete faster on systems with more than 2 CPU cores. In addition, the verbosity of `apt-get` has been reduced to avoid logging messages such as download progress in Travis CI.