### PR TITLE
Remove dependency on Judy1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_ARG_WITH([pdfixed],
 AM_CONDITIONAL([COND_PDFIXED], [test "$want_pdfixed" = yes])
 
 AC_ARG_WITH([nanomsg],
-    AS_HELP_STRING([--with-nanomsg], [Build Nanomsg RPC service, if disabled then you must have some other way of controlling the switch]),
+    AS_HELP_STRING([--with-nanomsg], [Support generating Nanomsg events]),
     [want_nanomsg="$withval"], [want_nanomsg=yes])
 
 AM_CONDITIONAL([COND_NANOMSG], [test "$want_nanomsg" = yes])
@@ -255,6 +255,7 @@ AC_CHECK_HEADER([boost/multiprecision/gmp.hpp], [], [AC_MSG_ERROR([Missing boost
 AC_CHECK_HEADER([boost/program_options.hpp], [], [AC_MSG_ERROR([Missing boost program options header])])
 AC_CHECK_HEADER([boost/functional/hash.hpp], [], [AC_MSG_ERROR([Missing boost functional hash header])])
 AC_CHECK_HEADER([boost/filesystem.hpp], [], [AC_MSG_ERROR([Missing boost filesystem header])])
+AC_CHECK_HEADER([boost/container/flat_set.hpp], [], [AC_MSG_ERROR([Boost flat_set header not found])])
 
 AC_SUBST([AM_CPPFLAGS], ["-I\$(top_srcdir)/include \
                           -I\$(top_builddir)/include \

--- a/include/bm/bm_sim/dynamic_bitset.h
+++ b/include/bm/bm_sim/dynamic_bitset.h
@@ -1,0 +1,176 @@
+/* Copyright 2021 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas
+ *
+ */
+
+#ifndef BM_BM_SIM_DYNAMIC_BITSET_H_
+#define BM_BM_SIM_DYNAMIC_BITSET_H_
+
+#include <bitset>
+#include <cassert>
+#include <limits>
+#include <vector>
+
+namespace bm {
+
+template <typename T>
+inline int find_lowest_bit(T v);
+
+template<>
+inline int find_lowest_bit<uint32_t>(uint32_t v) {
+  static const int kMultiplyDeBruijnBitPosition[32] = {
+    0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+    31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+  };
+  return kMultiplyDeBruijnBitPosition[((v & -v) * 0x077CB531U) >> 27];
+}
+
+template<>
+inline int find_lowest_bit<uint64_t>(uint64_t v) {
+  auto sw = static_cast<uint32_t>(v & 0xFFFFFFFF);
+  return (sw == 0) ?
+      32 + find_lowest_bit<uint32_t>(static_cast<uint32_t>(v >> 32)) :
+      find_lowest_bit<uint32_t>(sw);
+}
+
+class DynamicBitset {
+ public:
+  using Block = unsigned long;  // NOLINT(runtime/int)
+  using Backend = std::vector<Block>;
+  using size_type = Backend::size_type;
+
+  static constexpr size_type npos = static_cast<size_type>(-1);
+
+  size_type size() const {
+    return num_bits;
+  }
+
+  size_type count() const {
+    return num_bits_set;
+  }
+
+  bool test(size_type idx) const {
+    assert(idx < num_bits);
+    auto word_idx = static_cast<size_type>(idx / block_width);
+    auto bit_idx = static_cast<int>(idx % block_width);
+    return words[word_idx] & static_cast<Block>(1) << bit_idx;
+  }
+
+  bool set(size_type idx) {
+    assert(idx < num_bits);
+    auto word_idx = static_cast<size_type>(idx / block_width);
+    auto bit_idx = static_cast<int>(idx % block_width);
+    auto mask = static_cast<Block>(1) << bit_idx;
+    auto bit = words[word_idx] & mask;
+    words[word_idx] |= mask;
+    num_bits_set += (bit >> bit_idx) ^ 1;
+    return (bit == 0);
+  }
+
+  bool reset(size_type idx) {
+    assert(idx < num_bits);
+    auto word_idx = static_cast<size_type>(idx / block_width);
+    auto bit_idx = static_cast<int>(idx % block_width);
+    auto mask = static_cast<Block>(1) << bit_idx;
+    auto bit = words[word_idx] & mask;
+    words[word_idx] &= ~mask;
+    num_bits_set -= (bit >> bit_idx);
+    return (bit != 0);
+  }
+
+  void push_back(bool v) {
+    auto bit_idx = static_cast<int>(num_bits % block_width);
+    if (bit_idx == 0) words.push_back(0);
+    num_bits++;
+    if (v) set(num_bits - 1);
+  }
+
+  void clear() {
+    words.clear();
+    num_bits = 0;
+    num_bits_set = 0;
+  }
+
+  size_type find_first() const {
+    return find_from_block(0);
+  }
+
+  size_type find_next(size_type idx) const {
+    idx++;
+    if (idx >= num_bits) return npos;
+    auto word_idx = static_cast<size_type>(idx / block_width);
+    auto bit_idx = static_cast<int>(idx % block_width);
+    auto sw = words[word_idx] & (ones << bit_idx);
+    if (sw == 0) return find_from_block(word_idx + 1);
+    return word_idx * block_width + find_lowest_bit(sw);
+  }
+
+  size_type find_unset_first() const {
+    return find_unset_from_block(0);
+  }
+
+  size_type find_unset_next(size_type idx) const {
+    idx++;
+    if (idx >= num_bits) return npos;
+    auto word_idx = static_cast<size_type>(idx / block_width);
+    auto bit_idx = static_cast<int>(idx % block_width);
+    auto sw = words[word_idx] | ~(ones << bit_idx);
+    if (sw == ones) return find_unset_from_block(word_idx + 1);
+    return word_idx * block_width + find_lowest_bit(~sw);
+  }
+
+  bool operator==(const DynamicBitset &other) const {
+    return (num_bits == other.num_bits) && (words == other.words);
+  }
+
+  bool operator!=(const DynamicBitset &other) const {
+    return !(*this == other);
+  }
+
+  void resize(size_type new_num_bits) {
+    num_bits = new_num_bits;
+    words.resize(num_bits / block_width);
+  }
+
+ private:
+  size_type find_from_block(size_type word_idx) const {
+    for (size_type i = word_idx; i < words.size(); i++) {
+      if (words[i] == 0) continue;
+      return i * block_width + find_lowest_bit(words[i]);
+    }
+    return npos;
+  }
+
+  size_type find_unset_from_block(size_type word_idx) const {
+    for (size_type i = word_idx; i < words.size(); i++) {
+      if (words[i] == ones) continue;
+      return i * block_width + find_lowest_bit(~words[i]);
+    }
+    return npos;
+  }
+
+  static constexpr size_type block_width = std::numeric_limits<Block>::digits;
+  static constexpr Block ones = ~static_cast<Block>(0);
+  Backend words;
+  size_type num_bits{0};
+  size_type num_bits_set{0};
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_DYNAMIC_BITSET_H_

--- a/tests/CPPLINT.cfg
+++ b/tests/CPPLINT.cfg
@@ -3,3 +3,4 @@ filter=-build/namespaces
 filter=-runtime/explicit
 filter=-runtime/references
 filter=-runtime/printf
+filter=-runtime/threadsafe_fn

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,7 +70,8 @@ test_enums \
 test_core_primitives \
 test_control_flow \
 test_assert_assume \
-test_log_msg
+test_log_msg \
+test_ras
 
 check_PROGRAMS = $(TESTS) test_all
 
@@ -112,6 +113,7 @@ test_core_primitives_SOURCES = $(common_source) test_core_primitives.cpp
 test_control_flow_SOURCES    = $(common_source) test_control_flow.cpp
 test_assert_assume_SOURCES   = $(common_source) test_assert_assume.cpp
 test_log_msg_SOURCES         = $(common_source) test_log_msg.cpp
+test_ras_SOURCES             = $(common_source) test_ras.cpp
 
 test_all_SOURCES = $(common_source) \
 test_actions.cpp \
@@ -150,7 +152,8 @@ test_enums.cpp \
 test_core_primitives.cpp \
 test_control_flow.cpp \
 test_assert_assume.cpp \
-test_log_msg.cpp
+test_log_msg.cpp \
+test_ras.cpp
 
 EXTRA_DIST = \
 testdata/en0.pcap \

--- a/tests/test_ras.cpp
+++ b/tests/test_ras.cpp
@@ -1,0 +1,48 @@
+/* Copyright 2021 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Antonin Bas
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_sim/ras.h>
+
+#include <algorithm>
+#include <vector>
+
+using bm::RandAccessUIntSet;
+
+class RandomAccessSetTest : public ::testing::Test { };
+
+TEST_F(RandomAccessSetTest, LargeTestGetNth) {
+  RandAccessUIntSet ras;
+  std::vector<RandAccessUIntSet::mbr_t> mbrs;
+  int size = 128;
+  for (auto i = 0; i < size; i++) {
+    auto mbr = static_cast<RandAccessUIntSet::mbr_t>(rand() % 65536);
+    ras.add(mbr);
+    mbrs.push_back(mbr);
+  }
+  std::sort(mbrs.begin(), mbrs.end());
+  size_t nth = 0;
+  for (auto i = 0; i < 10000; i++) {
+    auto mbr = ras.get_nth(nth);
+    ASSERT_EQ(mbrs[nth], mbr);
+    nth = (nth + 10) % size;
+  }
+}


### PR DESCRIPTION
We have been experiencing issues with some builds of bmv2, with memory
errors in Judy when building it from source (it's possible that it's an
issue with how we build Judy and not with Judy itself...). Judy is very
complex and not actively maintained any more apparently, so it's
probably a good idea to remove the dependency on Judy altogether. In
this commit, we replace usage of Judy1 with alternative implementations:

* HandleMgr now uses a custom implementation, inspired from
  boost::dynamic_bitset.
* RandomAccessUIntSet is now implemented using
  boost::container::flat_set (a sorted vector which exposes a set
  interface). Note that this may introduce a dependency on a new Boost
  library (libboost-container-dev) for some distros.

Originally I was planning on supporting both the Judy-based
implementation and the alternative implementation (with a configure
switch). However I strongly believe that there is no significant
difference in performance, and it doesn't seem necessary to maintain
both versions.

We still need to remove the dependency on JudyL (LPM trie implementation
and BMI) which is likely to be a bit more difficult to do.

See #1001