### PR TITLE
[psa_switch] supporting checksum extern

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -2168,11 +2168,11 @@ P4Objects::init_objects(std::istream *is,
 
     init_errors(cfg_root);  // parser errors
 
+    init_calculations(cfg_root);
+
     init_parsers(cfg_root, &init_state);
 
     init_deparsers(cfg_root);
-
-    init_calculations(cfg_root);
 
     init_counter_arrays(cfg_root);
 

--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -8,7 +8,7 @@ THRIFT_IDL = $(srcdir)/thrift/psa_switch.thrift
 
 noinst_LTLIBRARIES = libpsaswitch.la
 
-libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp
+libpsaswitch_la_SOURCES = psa_switch.cpp psa_switch.h primitives.cpp externs/psa_counter.h externs/psa_counter.cpp externs/psa_meter.h externs/psa_meter.cpp externs/psa_checksum.h externs/psa_checksum.cpp
 
 libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/targets/psa_switch/externs/psa_checksum.cpp
+++ b/targets/psa_switch/externs/psa_checksum.cpp
@@ -1,0 +1,48 @@
+
+
+#include "psa_checksum.h"
+#include <iostream>
+
+namespace bm {
+
+namespace psa {
+
+void
+PSA_Checksum::init() {
+  this->clear();
+}
+
+void PSA_Checksum:: get(Field& dst) {
+  dst.set(internal.get<uint64_t>());
+}
+
+void PSA_Checksum::get_verify(Field& dst, Field& equOp) {
+  if (equOp.get<uint64_t>()!=internal.get<uint64_t>()) {
+    dst.set(false);
+  } else {
+    dst.set(true);
+  }
+}
+
+void PSA_Checksum::clear() {
+  internal.set(0);
+}
+
+void PSA_Checksum::update(const NamedCalculation& calculation) {
+  const uint64_t cksum = calculation.output(get_packet());
+  this->internal.set(cksum);
+}
+
+BM_REGISTER_EXTERN_W_NAME(Checksum,PSA_Checksum);
+BM_REGISTER_EXTERN_W_NAME_METHOD(Checksum, PSA_Checksum,update, const NamedCalculation&);
+BM_REGISTER_EXTERN_W_NAME_METHOD(Checksum, PSA_Checksum,get, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(Checksum, PSA_Checksum,get_verify, Field &, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(Checksum, PSA_Checksum,clear);
+
+}  // namespace bm::psa
+
+}  // namespace bm
+
+int import_checksums() {
+  return 0;
+}

--- a/targets/psa_switch/externs/psa_checksum.h
+++ b/targets/psa_switch/externs/psa_checksum.h
@@ -1,0 +1,41 @@
+
+
+#ifndef PSA_SWITCH_PSA_CHECKSUM_H_
+#define PSA_SWITCH_PSA_CHECKSUM_H_
+
+#include <bm/bm_sim/extern.h>
+#include <bm/bm_sim/calculations.h>
+
+
+namespace bm {
+
+namespace psa {
+
+class PSA_Checksum : public bm::ExternType {
+ public:
+  static constexpr p4object_id_t spec_id = 0xfffffffd;
+
+  BM_EXTERN_ATTRIBUTES {
+    BM_EXTERN_ATTRIBUTE_ADD(hash);
+  }
+
+  void init() override;
+
+  void get(Field& dst);
+
+  void get_verify(Field& dst, Field& equOp);
+  
+  void clear();
+
+  void update(const NamedCalculation& calculation);
+
+ private:
+  std::string hash;
+  Data internal;
+
+};
+
+}  // namespace bm::psa
+
+}  // namespace bm
+#endif

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -65,6 +65,7 @@ REGISTER_HASH(bmv2_hash);
 extern int import_primitives();
 extern int import_counters();
 extern int import_meters();
+extern int import_checksums();
 
 namespace bm {
 
@@ -181,6 +182,7 @@ PsaSwitch::PsaSwitch(bool enable_swap)
   import_primitives();
   import_counters();
   import_meters();
+  import_checksums();
 }
 
 #define PACKET_LENGTH_REG_IDX 0

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -36,6 +36,7 @@
 
 #include "externs/psa_counter.h"
 #include "externs/psa_meter.h"
+#include "externs/psa_checksum.h"
 
 // TODO(antonin)
 // experimental support for priority queueing


### PR DESCRIPTION
Fixes #974 in behavioral-model.

*[psa_switch] supporting checksum extern and it's methods

link to p4c pull request: https://github.com/p4lang/p4c/pull/2794