### PR TITLE
make: Add missing "dynamic_bitset.h"

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -43,6 +43,7 @@ bm/bm_sim/debugger.h \
 bm/bm_sim/deparser.h \
 bm/bm_sim/dev_mgr.h \
 bm/bm_sim/device_id.h \
+bm/bm_sim/dynamic_bitset.h \
 bm/bm_sim/entries.h \
 bm/bm_sim/enums.h \
 bm/bm_sim/event_logger.h \


### PR DESCRIPTION
After commit da96f81 the build fails with:

```bash
In file included from ../../include/bm/bm_sim/match_units.h:37,
                 from ../../include/bm/bm_sim/match_tables.h:34,
                 from ../../include/bm/bm_sim/tables.h:29,
                 from ../../include/bm/bm_sim/P4Objects.h:33,
                 from actions.cpp:25:
../../include/bm/bm_sim/handle_mgr.h:31:10: fatal error: dynamic_bitset.h: No such file or directory
   31 | #include "dynamic_bitset.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
make[4]: *** [Makefile:580: actions.lo] Error 1
In file included from ../../include/bm/bm_sim/action_profile.h:35,
                 from action_profile.cpp:22:
../../include/bm/bm_sim/handle_mgr.h:31:10: fatal error: dynamic_bitset.h: No such file or directory
   31 | #include "dynamic_bitset.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```