### PR TITLE
[psa_switch] supporting InternetChecksum extern

### DIFF
--- a/include/bm/bm_sim/actions.h
+++ b/include/bm/bm_sim/actions.h
@@ -791,7 +791,6 @@ class ActionFn :  public NamedP4Object {
   std::vector<ActionPrimitiveCall> primitives{};
   ParameterList params{};
   ParameterList sub_params{};
-  ParameterList field_params{};
   RegisterSync register_sync{};
   std::vector<Data> const_values{};
   // should I store the objects in the vector, instead of pointers?

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -303,6 +303,13 @@ class Data {
   }
 
   //! NC
+  void bit_and(const Data &src1, uint64_t src2) {
+    assert(src1.arith);
+    value = src1.value & src2;
+    export_bytes();
+  }
+
+  //! NC
   void bit_or(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
     value = src1.value | src2.value;

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -303,13 +303,6 @@ class Data {
   }
 
   //! NC
-  void bit_and(const Data &src1, uint64_t src2) {
-    assert(src1.arith);
-    value = src1.value & src2;
-    export_bytes();
-  }
-
-  //! NC
   void bit_or(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
     value = src1.value | src2.value;

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -388,8 +388,24 @@ class Data {
   }
 
   //! NC
+  template<typename T,
+           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  friend bool operator==(const Data &lhs, const T &rhs) {
+    assert(lhs.arith);
+    return lhs.value.convert_to<T>() == rhs;
+  }
+
+  //! NC
   friend bool operator!=(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
+    return !(lhs == rhs);
+  }
+
+  //! NC
+  template<typename T,
+           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  friend bool operator!=(const Data &lhs, const T &rhs) {
+    assert(lhs.arith);
     return !(lhs == rhs);
   }
 

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -388,24 +388,8 @@ class Data {
   }
 
   //! NC
-  template<typename T,
-           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-  friend bool operator==(const Data &lhs, const T &rhs) {
-    assert(lhs.arith);
-    return lhs.value.convert_to<T>() == rhs;
-  }
-
-  //! NC
   friend bool operator!=(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
-    return !(lhs == rhs);
-  }
-
-  //! NC
-  template<typename T,
-           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-  friend bool operator!=(const Data &lhs, const T &rhs) {
-    assert(lhs.arith);
     return !(lhs == rhs);
   }
 

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -340,11 +340,17 @@ P4Objects::process_single_param(ActionFn* action_fn,
     }
     action_fn->parameter_end_vector();
   } else if (type == "field_list") {
-    action_fn->start_field_list();
+    action_fn->parameter_start_field_list();
     for (const auto &cfg_parameter_value : cfg_parameter["value"]) {
+      const auto type = cfg_parameter_value["type"].asString();
+      if (type != "field") {
+        throw json_exception(
+        EFormat() << "Invalid type '" << type << "', expected 'field'",
+        cfg_parameter_value);
+      }
       process_single_param(action_fn, cfg_parameter_value, primitive_name);
     }
-    action_fn->end_field_list();
+    action_fn->parameter_end_field_list();
   } else if (type == "runtime_data") {
     auto action_data_offset = cfg_parameter["value"].asUInt();
     auto runtime_data_size = action_fn->get_num_params();

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -339,6 +339,12 @@ P4Objects::process_single_param(ActionFn* action_fn,
       process_single_param(action_fn, cfg_parameter_value, primitive_name);
     }
     action_fn->parameter_end_vector();
+  } else if (type == "field_list") {
+    action_fn->start_field_list();
+    for (const auto &cfg_parameter_value : cfg_parameter["value"]) {
+      process_single_param(action_fn, cfg_parameter_value, primitive_name);
+    }
+    action_fn->end_field_list();
   } else if (type == "runtime_data") {
     auto action_data_offset = cfg_parameter["value"].asUInt();
     auto runtime_data_size = action_fn->get_num_params();

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -283,6 +283,25 @@ ActionFn::parameter_end_vector() {
 }
 
 void
+ActionFn::start_field_list() {
+  ActionParam param;
+  param.tag = ActionParam::PARAMS_FIELDS;
+  auto start = static_cast<unsigned int>(sub_params.size());
+  param.params_vector = {start, start /* end */};
+  params.push_back(param);
+  params.swap(sub_params);
+}
+
+void
+ActionFn::end_field_list() {
+  params.swap(sub_params);
+  assert(params.back().tag == ActionParam::PARAMS_FIELDS &&
+         "no vector was started");
+  auto end = static_cast<unsigned int>(sub_params.size());
+  params.back().params_vector.end = end;
+}
+
+void
 ActionFn::push_back_primitive(ActionPrimitive_ *primitive,
                               std::unique_ptr<SourceInfo> source_info) {
   size_t param_offset = 0;

--- a/src/bm_sim/actions.cpp
+++ b/src/bm_sim/actions.cpp
@@ -287,18 +287,18 @@ void
 ActionFn::parameter_start_field_list() {
   ActionParam param;
   param.tag = ActionParam::FIELD_LIST;
-  auto start = static_cast<unsigned int>(field_params.size());
+  auto start = static_cast<unsigned int>(sub_params.size());
   param.field_list = {start, start /* end */};
   params.push_back(param);
-  params.swap(field_params);
+  params.swap(sub_params);
 }
 
 void
 ActionFn::parameter_end_field_list() {
-  params.swap(field_params);
+  params.swap(sub_params);
   assert(params.back().tag == ActionParam::FIELD_LIST &&
          "no field list was started");
-  auto end = static_cast<unsigned int>(field_params.size());
+  auto end = static_cast<unsigned int>(sub_params.size());
   params.back().field_list.end = end;
 }
 
@@ -395,7 +395,7 @@ ActionFnEntry::push_back_action_data(const char *bytes, int nbytes) {
 void
 ActionFnEntry::execute(Packet *pkt) const {
   ActionEngineState state(pkt, action_data, action_fn->const_values,
-                          action_fn->sub_params, action_fn->field_params);
+                          action_fn->sub_params, action_fn->sub_params);
 
   auto &primitives = action_fn->primitives;
   size_t param_offset = 0;

--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -13,7 +13,8 @@ psa_switch.cpp psa_switch.h \
 primitives.cpp \
 externs/psa_counter.h externs/psa_counter.cpp \
 externs/psa_meter.h externs/psa_meter.cpp \
-externs/psa_random.h externs/psa_random.cpp
+externs/psa_random.h externs/psa_random.cpp \
+externs/psa_internet_checksum.h externs/psa_internet_checksum.cpp
 
 libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/targets/psa_switch/externs/psa_internet_checksum.cpp
+++ b/targets/psa_switch/externs/psa_internet_checksum.cpp
@@ -1,0 +1,134 @@
+/* Copyright 2021 SYRMIA LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Dusan Krdzic (dusan.krdzic@syrmia.com)
+ *
+ */
+
+
+#include "psa_internet_checksum.h"
+#include <bm/bm_sim/_assert.h>
+
+
+namespace {
+
+uint16_t 
+ones_complement_sum(uint16_t x, uint16_t y) {
+    uint32_t ret = (uint32_t) x + (uint32_t) y; 
+    if (ret >= 0x10000) 
+        ret++;
+
+    return ret;
+}
+
+}  // namespace
+
+namespace bm {
+
+namespace psa {
+
+void
+PSA_InternetChecksum::init() {
+    clear();
+}
+
+void
+PSA_InternetChecksum::get(Field &dst) const {
+    dst.set(static_cast<uint16_t>(~sum));
+}
+
+void
+PSA_InternetChecksum::get_state(Field &dst) const {
+    dst.set(sum);
+}
+
+void
+PSA_InternetChecksum::get_verify(Field &dst, Field &equOp) const {
+    dst.set(equOp.get<uint16_t>() == static_cast<uint16_t>(~sum));
+}
+
+void
+PSA_InternetChecksum::set_state(const Data &src) {
+    sum = src.get<uint16_t>();
+}
+
+void
+PSA_InternetChecksum::clear() {
+    sum = 0;
+}
+
+void
+PSA_InternetChecksum::add(const std::vector<Field> fields) {
+    bm::Data input(0);
+    uint16_t current_bits_offset = 0;
+    const uint8_t base = 16;
+
+    // Concatenate fields in one single data
+    for(int i = fields.size() - 1 ; i >= 0 ; i--) {
+        bm::Data shift_value;
+        shift_value.shift_left(bm::Data(fields.at(i).get<uint64_t>()), current_bits_offset);
+        input.add(input, shift_value);
+        current_bits_offset += fields.at(i).get_nbits();
+    }
+
+    _BM_ASSERT(current_bits_offset % 16 == 0);
+
+    while(input != 0) {
+        uint16_t d = input.get<uint16_t>();
+        sum = ones_complement_sum(sum, d);
+        input.shift_right(input, base);
+    }
+}
+
+void
+PSA_InternetChecksum::subtract(const std::vector<Field> fields) {
+    bm::Data input(0);
+    uint16_t current_bits_offset = 0;
+    const uint8_t base = 16;
+
+    // Concatenate fields in one single data
+    for(int i = fields.size() - 1 ; i >= 0 ; i--) {
+        bm::Data shift_value;
+        shift_value.shift_left(bm::Data(fields.at(i).get<uint64_t>()), current_bits_offset);
+        input.add(input, shift_value);
+        current_bits_offset += fields.at(i).get_nbits();
+    }
+
+    _BM_ASSERT(current_bits_offset % 16 == 0);
+
+    while(input != 0) {
+        uint16_t d = input.get<uint16_t>();
+        sum = ones_complement_sum(sum, ~d);
+        input.shift_right(input, base);
+    }
+}
+
+
+BM_REGISTER_EXTERN_W_NAME(InternetChecksum, PSA_InternetChecksum);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, add, const std::vector<Field>);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, subtract, const std::vector<Field>);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get_state, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, set_state,const Data &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get_verify, Field &, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, clear);
+
+}  // namespace bm::psa
+
+}  // namespace bm
+
+int import_internet_checksum() {
+    return 0;
+}

--- a/targets/psa_switch/externs/psa_internet_checksum.cpp
+++ b/targets/psa_switch/externs/psa_internet_checksum.cpp
@@ -39,10 +39,10 @@ concatenate_fields(const std::vector<bm::Field> &fields, bm::Data &input) {
     _BM_ASSERT(n_bits % 16 == 0);
 }
 
-uint16_t 
+uint16_t
 ones_complement_sum(uint16_t x, uint16_t y) {
-    uint32_t ret = (uint32_t) x + (uint32_t) y; 
-    if (ret >= 0x10000) 
+    uint32_t ret = (uint32_t) x + (uint32_t) y;
+    if (ret >= 0x10000)
         ret++;
 
     return ret;

--- a/targets/psa_switch/externs/psa_internet_checksum.cpp
+++ b/targets/psa_switch/externs/psa_internet_checksum.cpp
@@ -87,11 +87,13 @@ PSA_InternetChecksum::clear() {
 void
 PSA_InternetChecksum::add(const std::vector<Field> &fields) {
     bm::Data input(0);
+    bm::Data chunk;
 
     concatenate_fields(fields, input);
 
     while (!input.test_eq(0)) {
-        uint16_t d = input.get<uint16_t>();
+        chunk.bit_and(input, 0xFFFF);
+        uint16_t d = chunk.get<uint16_t>();
         sum = ones_complement_sum(sum, d);
         input.shift_right(input, 16);
     }
@@ -100,11 +102,13 @@ PSA_InternetChecksum::add(const std::vector<Field> &fields) {
 void
 PSA_InternetChecksum::subtract(const std::vector<Field> &fields) {
     bm::Data input(0);
+    bm::Data chunk;
 
     concatenate_fields(fields, input);
 
     while (!input.test_eq(0)) {
-        uint16_t d = input.get<uint16_t>();
+        chunk.bit_and(input, 0xFFFF);
+        uint16_t d = chunk.get<uint16_t>();
         sum = ones_complement_sum(sum, ~d);
         input.shift_right(input, 16);
     }

--- a/targets/psa_switch/externs/psa_internet_checksum.cpp
+++ b/targets/psa_switch/externs/psa_internet_checksum.cpp
@@ -86,13 +86,14 @@ PSA_InternetChecksum::clear() {
 
 void
 PSA_InternetChecksum::add(const std::vector<Field> &fields) {
-    bm::Data input(0);
-    bm::Data chunk;
+    Data input(0);
+    Data chunk;
+    static const Data mask(0xffff);
 
     concatenate_fields(fields, input);
 
     while (!input.test_eq(0)) {
-        chunk.bit_and(input, 0xFFFF);
+        chunk.bit_and(input, mask);
         uint16_t d = chunk.get<uint16_t>();
         sum = ones_complement_sum(sum, d);
         input.shift_right(input, 16);
@@ -101,13 +102,14 @@ PSA_InternetChecksum::add(const std::vector<Field> &fields) {
 
 void
 PSA_InternetChecksum::subtract(const std::vector<Field> &fields) {
-    bm::Data input(0);
-    bm::Data chunk;
+    Data input(0);
+    Data chunk;
+    static const Data mask(0xffff);
 
     concatenate_fields(fields, input);
 
     while (!input.test_eq(0)) {
-        chunk.bit_and(input, 0xFFFF);
+        chunk.bit_and(input, mask);
         uint16_t d = chunk.get<uint16_t>();
         sum = ones_complement_sum(sum, ~d);
         input.shift_right(input, 16);

--- a/targets/psa_switch/externs/psa_internet_checksum.cpp
+++ b/targets/psa_switch/externs/psa_internet_checksum.cpp
@@ -77,7 +77,7 @@ PSA_InternetChecksum::add(const std::vector<Field> fields) {
     bm::Data field_shl;
 
     // Concatenate fields in one single data
-    for (int i = fields.size() - 1 ; i >= 0 ; i--) {
+    for (int i = fields.size() - 1; i >= 0; i--) {
         field_shl.shift_left(fields.at(i), n_bits);
         input.add(input, field_shl);
         n_bits += fields.at(i).get_nbits();
@@ -100,7 +100,7 @@ PSA_InternetChecksum::subtract(const std::vector<Field> fields) {
     bm::Data field_shl;
 
     // Concatenate fields in one single data
-    for (int i = fields.size() - 1 ; i >= 0 ; i--) {
+    for (int i = fields.size() - 1; i >= 0; i--) {
         field_shl.shift_left(fields.at(i), n_bits);
         input.add(input, field_shl);
         n_bits += fields.at(i).get_nbits();

--- a/targets/psa_switch/externs/psa_internet_checksum.cpp
+++ b/targets/psa_switch/externs/psa_internet_checksum.cpp
@@ -72,20 +72,20 @@ PSA_InternetChecksum::clear() {
 void
 PSA_InternetChecksum::add(const std::vector<Field> fields) {
     bm::Data input(0);
-    uint16_t current_bits_offset = 0;
+    uint16_t n_bits = 0;
     const uint8_t base = 16;
+    bm::Data field_shl;
 
     // Concatenate fields in one single data
-    for(int i = fields.size() - 1 ; i >= 0 ; i--) {
-        bm::Data shift_value;
-        shift_value.shift_left(bm::Data(fields.at(i).get<uint64_t>()), current_bits_offset);
-        input.add(input, shift_value);
-        current_bits_offset += fields.at(i).get_nbits();
+    for (int i = fields.size() - 1 ; i >= 0 ; i--) {
+        field_shl.shift_left(fields.at(i), n_bits);
+        input.add(input, field_shl);
+        n_bits += fields.at(i).get_nbits();
     }
 
-    _BM_ASSERT(current_bits_offset % 16 == 0);
+    _BM_ASSERT(n_bits % 16 == 0);
 
-    while(input != 0) {
+    while (input.get<uint64_t>() != 0) {
         uint16_t d = input.get<uint16_t>();
         sum = ones_complement_sum(sum, d);
         input.shift_right(input, base);
@@ -95,20 +95,20 @@ PSA_InternetChecksum::add(const std::vector<Field> fields) {
 void
 PSA_InternetChecksum::subtract(const std::vector<Field> fields) {
     bm::Data input(0);
-    uint16_t current_bits_offset = 0;
+    uint16_t n_bits = 0;
     const uint8_t base = 16;
+    bm::Data field_shl;
 
     // Concatenate fields in one single data
-    for(int i = fields.size() - 1 ; i >= 0 ; i--) {
-        bm::Data shift_value;
-        shift_value.shift_left(bm::Data(fields.at(i).get<uint64_t>()), current_bits_offset);
-        input.add(input, shift_value);
-        current_bits_offset += fields.at(i).get_nbits();
+    for (int i = fields.size() - 1 ; i >= 0 ; i--) {
+        field_shl.shift_left(fields.at(i), n_bits);
+        input.add(input, field_shl);
+        n_bits += fields.at(i).get_nbits();
     }
 
-    _BM_ASSERT(current_bits_offset % 16 == 0);
+    _BM_ASSERT(n_bits % 16 == 0);
 
-    while(input != 0) {
+    while (input.get<uint64_t>() != 0) {
         uint16_t d = input.get<uint16_t>();
         sum = ones_complement_sum(sum, ~d);
         input.shift_right(input, base);

--- a/targets/psa_switch/externs/psa_internet_checksum.h
+++ b/targets/psa_switch/externs/psa_internet_checksum.h
@@ -41,9 +41,9 @@ class PSA_InternetChecksum : public bm::ExternType {
 
     void clear();
 
-    void add(const std::vector<Field> fields);
+    void add(const std::vector<Field> &fields);
 
-    void subtract(const std::vector<Field> fields);
+    void subtract(const std::vector<Field> &fields);
 
     void get_state(Field &dst) const;
 

--- a/targets/psa_switch/externs/psa_internet_checksum.h
+++ b/targets/psa_switch/externs/psa_internet_checksum.h
@@ -1,0 +1,60 @@
+/* Copyright 2021 SYRMIA LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Dusan Krdzic (dusan.krdzic@syrmia.com)
+ *
+ */
+
+
+#ifndef PSA_SWITCH_PSA_INTERNETCHECKSUM_H_
+#define PSA_SWITCH_PSA_INTERNETCHECKSUM_H_
+
+#include <bm/bm_sim/extern.h>
+
+namespace bm {
+
+namespace psa {
+
+class PSA_InternetChecksum : public bm::ExternType {
+ public:
+
+    BM_EXTERN_ATTRIBUTES {
+}
+
+    void init() override;
+
+    void get(Field &dst) const;
+
+    void get_verify(Field &dst, Field &equOp) const;
+
+    void clear();
+
+    void add(const std::vector<Field> fields);
+
+    void subtract(const std::vector<Field> fields);
+
+    void get_state(Field &dst) const;
+
+    void set_state(const Data &src);
+
+ private:
+    uint16_t sum;
+
+};
+
+}  // namespace bm::psa
+
+}  // namespace bm
+#endif

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -66,6 +66,7 @@ extern int import_primitives();
 extern int import_counters();
 extern int import_meters();
 extern int import_random();
+extern int import_internet_checksum();
 
 namespace bm {
 
@@ -183,6 +184,7 @@ PsaSwitch::PsaSwitch(bool enable_swap)
   import_counters();
   import_meters();
   import_random();
+  import_internet_checksum();
 }
 
 #define PACKET_LENGTH_REG_IDX 0

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -37,6 +37,7 @@
 #include "externs/psa_counter.h"
 #include "externs/psa_meter.h"
 #include "externs/psa_random.h"
+#include "externs/psa_internet_checksum.h"
 
 // TODO(antonin)
 // experimental support for priority queueing

--- a/targets/psa_switch/tests/Makefile.am
+++ b/targets/psa_switch/tests/Makefile.am
@@ -1,8 +1,6 @@
 SUBDIRS = .
 
 AM_CPPFLAGS += \
--I$(top_srcdir)/src/bm_sim \
--I$(top_srcdir)/src/BMI \
 -I$(top_srcdir)/targets/psa_switch/externs \
 -isystem $(top_srcdir)/third_party/gtest/include \
 -I$(srcdir)/.. \

--- a/targets/psa_switch/tests/Makefile.am
+++ b/targets/psa_switch/tests/Makefile.am
@@ -20,7 +20,7 @@ TESTS = test_internet_checksum
 check_PROGRAMS = $(TESTS) test_all
 
 # Sources for tests
-test_internet_checksum_SOURCES             = $(common_source) test_internet_checksum.cpp
+test_internet_checksum_SOURCES = $(common_source) test_internet_checksum.cpp
 
 test_all_SOURCES = $(common_source) \
 test_internet_checksum.cpp

--- a/targets/psa_switch/tests/Makefile.am
+++ b/targets/psa_switch/tests/Makefile.am
@@ -1,7 +1,6 @@
 SUBDIRS = .
 
 AM_CPPFLAGS += \
--I$(top_srcdir)/targets/psa_switch/externs \
 -isystem $(top_srcdir)/third_party/gtest/include \
 -I$(srcdir)/.. \
 -I$(srcdir)/ \

--- a/targets/psa_switch/tests/Makefile.am
+++ b/targets/psa_switch/tests/Makefile.am
@@ -1,6 +1,9 @@
 SUBDIRS = .
 
 AM_CPPFLAGS += \
+-I$(top_srcdir)/src/bm_sim \
+-I$(top_srcdir)/src/BMI \
+-I$(top_srcdir)/targets/psa_switch/externs \
 -isystem $(top_srcdir)/third_party/gtest/include \
 -I$(srcdir)/.. \
 -I$(srcdir)/ \
@@ -12,10 +15,12 @@ $(top_builddir)/src/bm_apps/libbmapps.la \
 
 # Define unit tests
 common_source = main.cpp
+TESTS = test_internet_checksum
 
 check_PROGRAMS = $(TESTS) test_all
 
 # Sources for tests
+test_internet_checksum_SOURCES             = $(common_source) test_internet_checksum.cpp
 
-test_all_SOURCES = $(common_source)
-
+test_all_SOURCES = $(common_source) \
+test_internet_checksum.cpp

--- a/targets/psa_switch/tests/test_internet_checksum.cpp
+++ b/targets/psa_switch/tests/test_internet_checksum.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <gtest/gtest.h>
 
 #include <bm/bm_sim/packet.h>
 #include <bm/bm_sim/parser.h>
@@ -25,11 +26,7 @@
 #include <bm/bm_sim/actions.h>
 #include <bm/bm_sim/extern.h>
 
-#include<psa_internet_checksum.h>
-#include <gtest/gtest.h>
-
 using namespace bm;
-using namespace bm::psa;
 
 extern int import_internet_checksum();
 

--- a/targets/psa_switch/tests/test_internet_checksum.cpp
+++ b/targets/psa_switch/tests/test_internet_checksum.cpp
@@ -31,6 +31,7 @@
 using namespace bm;
 using namespace bm::psa;
 
+extern int import_internet_checksum();
 
 /* Frame (34 bytes) */
 static const unsigned char raw_pkt[34] = {
@@ -122,13 +123,20 @@ class PSA_InternetChecksumTest : public ::testing::Test {
                                         PacketBuffer(34, (const char *) raw_pkt, 
                                         sizeof(raw_pkt)), phv_source.get())));
         parser.parse(packet.get());
+
+        import_internet_checksum();
     }
 
     // virtual void TearDown() { }
 };
 
+static std::unique_ptr<ActionPrimitive_> get_extern_primitive(
+    const std::string &extern_name, const std::string &method_name) {
+    return ActionOpcodesMap::get_instance()->get_primitive(
+        "_" + extern_name + "_" + method_name);
+}
+
 TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
-    
     uint16_t cksum;
     uint16_t sum;
     auto phv = packet.get()->get_phv();
@@ -136,8 +144,7 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     // ACTION ADD
     ActionFn actionFn_add("_InternetChecksum_add", 0, 0);
     ActionFnEntry actionFnEntry_add(&actionFn_add);
-    auto primitive_add =  ActionOpcodesMap::get_instance()->
-                            get_primitive("_InternetChecksum_add");
+    auto primitive_add = get_extern_primitive("InternetChecksum", "add");
     ASSERT_NE(nullptr, primitive_add);
     actionFn_add.push_back_primitive(primitive_add.get());
     actionFn_add.parameter_push_back_extern_instance(instance.get());
@@ -158,8 +165,7 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     // ACTION GET
     ActionFn actionFn_get("_InternetChecksum_get", 0, 0);
     ActionFnEntry actionFnEntry_get(&actionFn_get);
-    auto primitive_get =  ActionOpcodesMap::get_instance()->
-                            get_primitive("_InternetChecksum_get");
+    auto primitive_get = get_extern_primitive("InternetChecksum", "get");
     ASSERT_NE(nullptr, primitive_get);
     actionFn_get.push_back_primitive(primitive_get.get());
     actionFn_get.parameter_push_back_extern_instance(instance.get());
@@ -168,8 +174,7 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     // ACTION SUBTRACT 
     ActionFn actionFn_sub("_InternetChecksum_subtract", 0, 0);
     ActionFnEntry actionFnEntry_sub(&actionFn_sub);
-    auto primitive_sub =  ActionOpcodesMap::get_instance()->
-                            get_primitive("_InternetChecksum_subtract");
+    auto primitive_sub = get_extern_primitive("InternetChecksum", "subtract");
     ASSERT_NE(nullptr, primitive_sub);
     actionFn_sub.push_back_primitive(primitive_sub.get());
     actionFn_sub.parameter_push_back_extern_instance(instance.get());
@@ -181,8 +186,7 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     // ACTION GET_STATE
     ActionFn actionFn_get_state("_InternetChecksum_get_state", 0, 0);
     ActionFnEntry actionFnEntry_get_state(&actionFn_get_state);
-    auto primitive_get_state =  ActionOpcodesMap::get_instance()->
-                            get_primitive("_InternetChecksum_get_state");
+    auto primitive_get_state = get_extern_primitive("InternetChecksum", "get_state");
     ASSERT_NE(nullptr, primitive_get_state);
     actionFn_get_state.push_back_primitive(primitive_get_state.get());
     actionFn_get_state.parameter_push_back_extern_instance(instance.get());
@@ -191,8 +195,7 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     // ACTION SET_STATE
     ActionFn actionFn_set_state("_InternetChecksum_set_state", 0, 0);
     ActionFnEntry actionFnEntry_set_state(&actionFn_set_state);
-    auto primitive_set_state =  ActionOpcodesMap::get_instance()->
-                            get_primitive("_InternetChecksum_set_state");
+    auto primitive_set_state = get_extern_primitive("InternetChecksum", "set_state");
     ASSERT_NE(nullptr, primitive_set_state);
     actionFn_set_state.push_back_primitive(primitive_set_state.get());
     actionFn_set_state.parameter_push_back_extern_instance(instance.get());
@@ -222,10 +225,3 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     actionFnEntry_get_state(packet.get());
     ASSERT_EQ(sum, phv->get_field("meta.tmp").get<uint16_t>());
 }
-
-BM_REGISTER_EXTERN_W_NAME(InternetChecksum, PSA_InternetChecksum);
-BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, add, const std::vector<Field>);
-BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, subtract, const std::vector<Field>);
-BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get, Field &);
-BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get_state, Field &);
-BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, set_state,const Data &);

--- a/targets/psa_switch/tests/test_internet_checksum.cpp
+++ b/targets/psa_switch/tests/test_internet_checksum.cpp
@@ -1,0 +1,231 @@
+/* Copyright 2021 SYRMIA LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Dusan Krdzic (dusan.krdzic@syrmia.com)
+ *
+ */
+
+
+#include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/parser.h>
+#include <bm/bm_sim/phv_source.h>
+#include <bm/bm_sim/phv.h>
+#include <bm/bm_sim/actions.h>
+#include <bm/bm_sim/extern.h>
+
+#include<psa_internet_checksum.h>
+#include <gtest/gtest.h>
+
+using namespace bm;
+using namespace bm::psa;
+
+
+/* Frame (34 bytes) */
+static const unsigned char raw_pkt[34] = {
+    0x52, 0x54, 0x00, 0x12, 0x35, 0x02, 0x08, 0x00, 
+    0x27, 0x01, 0x8b, 0xbc, 0x08, 0x00, 0x00, 0xFE, 
+    0xC5, 0x23, 0xFD, 0xA1, 0xD6, 0x8A, 0xAF, 0x02, 
+    0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 
+    0x00, 0x02                              
+};
+
+class PSA_InternetChecksumTest : public ::testing::Test {
+ protected:
+    HeaderType ethernetHeaderType, ipv4HeaderType;
+    HeaderType metaHeaderType;
+    ParseState ethernetParseState, ipv4ParseState;
+    header_id_t ethernetHeader{0}, ipv4Header{1};
+    header_id_t metaHeader{2};
+
+    ErrorCodeMap error_codes;
+    Parser parser;
+
+    std::unique_ptr<PHVSourceIface> phv_source{nullptr};
+
+    std::unique_ptr<bm::ExternType> instance{nullptr};
+
+    PHVFactory phv_factory;
+
+    std::unique_ptr<Packet> packet{nullptr};
+
+    PSA_InternetChecksumTest()
+        :   ethernetHeaderType("ethernet_t", 0), ipv4HeaderType("ipv4_t", 1),
+            metaHeaderType("meta_t", 2),
+            ethernetParseState("parse_ethernet", 0),
+            ipv4ParseState("parse_ipv4", 1),
+            error_codes(ErrorCodeMap::make_with_core()),
+            parser("test_parser", 0, &error_codes),
+            phv_source(PHVSourceIface::make_phv_source()),
+            instance(ExternFactoryMap::get_instance()->
+                    get_extern_instance("InternetChecksum")) {
+        ethernetHeaderType.push_back_field("dstAddr", 48);
+        ethernetHeaderType.push_back_field("srcAddr", 48);
+        ethernetHeaderType.push_back_field("ethertype", 16);
+
+        ipv4HeaderType.push_back_field("version", 4);
+        ipv4HeaderType.push_back_field("ihl", 4);
+        ipv4HeaderType.push_back_field("diffserv", 8);
+        ipv4HeaderType.push_back_field("len", 16);
+        ipv4HeaderType.push_back_field("id", 16);
+        ipv4HeaderType.push_back_field("flags", 3);
+        ipv4HeaderType.push_back_field("flagOffset", 13);
+        ipv4HeaderType.push_back_field("ttl", 8);
+        ipv4HeaderType.push_back_field("protocol", 8);
+        ipv4HeaderType.push_back_field("checksum", 16);
+        ipv4HeaderType.push_back_field("srcAddr", 32);
+        ipv4HeaderType.push_back_field("dstAddr", 32);
+
+        metaHeaderType.push_back_field("tmp", 16);
+
+        phv_factory.push_back_header("ethernet", ethernetHeader,
+                                    ethernetHeaderType);
+        phv_factory.push_back_header("ipv4", ipv4Header, ipv4HeaderType);
+        phv_factory.push_back_header("meta", metaHeader, metaHeaderType, true);
+    }
+
+    virtual void SetUp() {
+        phv_source->set_phv_factory(0, &phv_factory);
+    
+        ParseSwitchKeyBuilder ethernetKeyBuilder;
+        ethernetKeyBuilder.push_back_field(ethernetHeader, 2, 16);  // ethertype
+        ethernetParseState.set_key_builder(ethernetKeyBuilder);
+
+        ParseSwitchKeyBuilder ipv4KeyBuilder;
+        ipv4KeyBuilder.push_back_field(ipv4Header, 8, 8);  // protocol
+        ipv4ParseState.set_key_builder(ipv4KeyBuilder);
+
+        ethernetParseState.add_extract(ethernetHeader);
+        ipv4ParseState.add_extract(ipv4Header);
+
+        char ethernet_ipv4_key[2];
+        ethernet_ipv4_key[0] = 0x08;
+        ethernet_ipv4_key[1] = 0x00;
+        ethernetParseState.add_switch_case(sizeof(ethernet_ipv4_key),
+                                        ethernet_ipv4_key, &ipv4ParseState);
+    
+        parser.set_init_state(&ethernetParseState);
+
+        packet = std::unique_ptr<Packet>(new Packet(Packet::make_new(
+                                        sizeof(raw_pkt),
+                                        PacketBuffer(34, (const char *) raw_pkt, 
+                                        sizeof(raw_pkt)), phv_source.get())));
+        parser.parse(packet.get());
+    }
+
+    // virtual void TearDown() { }
+};
+
+TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
+    
+    uint16_t cksum;
+    uint16_t sum;
+    auto phv = packet.get()->get_phv();
+
+    // ACTION ADD
+    ActionFn actionFn_add("_InternetChecksum_add", 0, 0);
+    ActionFnEntry actionFnEntry_add(&actionFn_add);
+    auto primitive_add =  ActionOpcodesMap::get_instance()->
+                            get_primitive("_InternetChecksum_add");
+    ASSERT_NE(nullptr, primitive_add);
+    actionFn_add.push_back_primitive(primitive_add.get());
+    actionFn_add.parameter_push_back_extern_instance(instance.get());
+    actionFn_add.parameter_start_field_list();
+    actionFn_add.parameter_push_back_field(ipv4Header, 0);
+    actionFn_add.parameter_push_back_field(ipv4Header, 1);
+    actionFn_add.parameter_push_back_field(ipv4Header, 2);
+    actionFn_add.parameter_push_back_field(ipv4Header, 3);
+    actionFn_add.parameter_push_back_field(ipv4Header, 4);
+    actionFn_add.parameter_push_back_field(ipv4Header, 5);
+    actionFn_add.parameter_push_back_field(ipv4Header, 6);
+    actionFn_add.parameter_push_back_field(ipv4Header, 7);
+    actionFn_add.parameter_push_back_field(ipv4Header, 8);
+    actionFn_add.parameter_push_back_field(ipv4Header, 10);
+    actionFn_add.parameter_push_back_field(ipv4Header, 11);
+    actionFn_add.parameter_end_field_list();
+
+    // ACTION GET
+    ActionFn actionFn_get("_InternetChecksum_get", 0, 0);
+    ActionFnEntry actionFnEntry_get(&actionFn_get);
+    auto primitive_get =  ActionOpcodesMap::get_instance()->
+                            get_primitive("_InternetChecksum_get");
+    ASSERT_NE(nullptr, primitive_get);
+    actionFn_get.push_back_primitive(primitive_get.get());
+    actionFn_get.parameter_push_back_extern_instance(instance.get());
+    actionFn_get.parameter_push_back_field(ipv4Header, 9);
+
+    // ACTION SUBTRACT 
+    ActionFn actionFn_sub("_InternetChecksum_subtract", 0, 0);
+    ActionFnEntry actionFnEntry_sub(&actionFn_sub);
+    auto primitive_sub =  ActionOpcodesMap::get_instance()->
+                            get_primitive("_InternetChecksum_subtract");
+    ASSERT_NE(nullptr, primitive_sub);
+    actionFn_sub.push_back_primitive(primitive_sub.get());
+    actionFn_sub.parameter_push_back_extern_instance(instance.get());
+    actionFn_sub.parameter_start_field_list();
+    actionFn_sub.parameter_push_back_field(ipv4Header, 10);
+    actionFn_sub.parameter_push_back_field(ipv4Header, 11);
+    actionFn_sub.parameter_end_field_list();
+
+    // ACTION GET_STATE
+    ActionFn actionFn_get_state("_InternetChecksum_get_state", 0, 0);
+    ActionFnEntry actionFnEntry_get_state(&actionFn_get_state);
+    auto primitive_get_state =  ActionOpcodesMap::get_instance()->
+                            get_primitive("_InternetChecksum_get_state");
+    ASSERT_NE(nullptr, primitive_get_state);
+    actionFn_get_state.push_back_primitive(primitive_get_state.get());
+    actionFn_get_state.parameter_push_back_extern_instance(instance.get());
+    actionFn_get_state.parameter_push_back_field(metaHeader, 0);
+
+    // ACTION SET_STATE
+    ActionFn actionFn_set_state("_InternetChecksum_set_state", 0, 0);
+    ActionFnEntry actionFnEntry_set_state(&actionFn_set_state);
+    auto primitive_set_state =  ActionOpcodesMap::get_instance()->
+                            get_primitive("_InternetChecksum_set_state");
+    ASSERT_NE(nullptr, primitive_set_state);
+    actionFn_set_state.push_back_primitive(primitive_set_state.get());
+    actionFn_set_state.parameter_push_back_extern_instance(instance.get());
+    actionFn_set_state.parameter_push_back_const(Data("0x01"));
+
+    cksum = 0xb6ab;
+    sum = 0x4954;
+
+    actionFnEntry_add(packet.get());
+    actionFnEntry_get(packet.get());
+    actionFnEntry_get_state(packet.get());
+    ASSERT_EQ(sum, phv->get_field("meta.tmp").get<uint16_t>());
+    ASSERT_EQ(cksum, phv->get_field("ipv4.checksum").get<uint16_t>());
+
+    cksum = 0xb6ae;
+    sum =  0x4951;
+
+    actionFnEntry_sub(packet.get());
+    actionFnEntry_get(packet.get());
+    actionFnEntry_get_state(packet.get());
+    ASSERT_EQ(sum, phv->get_field("meta.tmp").get<uint16_t>());
+    ASSERT_EQ(cksum, phv->get_field("ipv4.checksum").get<uint16_t>());
+
+    sum = 0x01;
+
+    actionFnEntry_set_state(packet.get());
+    actionFnEntry_get_state(packet.get());
+    ASSERT_EQ(sum, phv->get_field("meta.tmp").get<uint16_t>());
+}
+
+BM_REGISTER_EXTERN_W_NAME(InternetChecksum, PSA_InternetChecksum);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, add, const std::vector<Field>);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, subtract, const std::vector<Field>);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, get_state, Field &);
+BM_REGISTER_EXTERN_W_NAME_METHOD(InternetChecksum, PSA_InternetChecksum, set_state,const Data &);

--- a/targets/psa_switch/tests/test_internet_checksum.cpp
+++ b/targets/psa_switch/tests/test_internet_checksum.cpp
@@ -35,11 +35,11 @@ extern int import_internet_checksum();
 
 /* Frame (34 bytes) */
 static const unsigned char raw_pkt[34] = {
-    0x52, 0x54, 0x00, 0x12, 0x35, 0x02, 0x08, 0x00, 
-    0x27, 0x01, 0x8b, 0xbc, 0x08, 0x00, 0x00, 0xFE, 
-    0xC5, 0x23, 0xFD, 0xA1, 0xD6, 0x8A, 0xAF, 0x02, 
-    0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 
-    0x00, 0x02                              
+    0x52, 0x54, 0x00, 0x12, 0x35, 0x02, 0x08, 0x00,
+    0x27, 0x01, 0x8b, 0xbc, 0x08, 0x00, 0x00, 0xFE,
+    0xC5, 0x23, 0xFD, 0xA1, 0xD6, 0x8A, 0xAF, 0x02,
+    0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+    0x00, 0x02
 };
 
 class PSA_InternetChecksumTest : public ::testing::Test {
@@ -98,7 +98,7 @@ class PSA_InternetChecksumTest : public ::testing::Test {
 
     virtual void SetUp() {
         phv_source->set_phv_factory(0, &phv_factory);
-    
+
         ParseSwitchKeyBuilder ethernetKeyBuilder;
         ethernetKeyBuilder.push_back_field(ethernetHeader, 2, 16);  // ethertype
         ethernetParseState.set_key_builder(ethernetKeyBuilder);
@@ -115,19 +115,19 @@ class PSA_InternetChecksumTest : public ::testing::Test {
         ethernet_ipv4_key[1] = 0x00;
         ethernetParseState.add_switch_case(sizeof(ethernet_ipv4_key),
                                         ethernet_ipv4_key, &ipv4ParseState);
-    
+
         parser.set_init_state(&ethernetParseState);
 
         packet = std::unique_ptr<Packet>(new Packet(Packet::make_new(
                                         sizeof(raw_pkt),
-                                        PacketBuffer(34, (const char *) raw_pkt, 
+                                        PacketBuffer(34, (const char *) raw_pkt,
                                         sizeof(raw_pkt)), phv_source.get())));
         parser.parse(packet.get());
 
         import_internet_checksum();
     }
 
-    // virtual void TearDown() { }
+    virtual void TearDown() { }
 };
 
 static std::unique_ptr<ActionPrimitive_> get_extern_primitive(
@@ -171,7 +171,7 @@ TEST_F(PSA_InternetChecksumTest, PSA_InternetChecksumMethods) {
     actionFn_get.parameter_push_back_extern_instance(instance.get());
     actionFn_get.parameter_push_back_field(ipv4Header, 9);
 
-    // ACTION SUBTRACT 
+    // ACTION SUBTRACT
     ActionFn actionFn_sub("_InternetChecksum_subtract", 0, 0);
     ActionFnEntry actionFnEntry_sub(&actionFn_sub);
     auto primitive_sub = get_extern_primitive("InternetChecksum", "subtract");


### PR DESCRIPTION
*[psa_switch] supporting InternetChecksum extern and its methods

*Implementation based on PSA spec lines 2783-2850:
https://github.com/p4lang/p4-spec/blob/main/p4-16/psa/PSA.mdk

`InternetChecksum` implementation requires some parts of code from current `basic Checksum` implementation, so
some parts are the same as in the pr for `basic Checksum`: https://github.com/p4lang/behavioral-model/pull/1007

p4c implementation: https://github.com/p4lang/p4c/pull/2850