### PR TITLE
Fix HandleMgr implementation

### DIFF
--- a/include/bm/bm_sim/dynamic_bitset.h
+++ b/include/bm/bm_sim/dynamic_bitset.h
@@ -144,7 +144,7 @@ class DynamicBitset {
 
   void resize(size_type new_num_bits) {
     num_bits = new_num_bits;
-    words.resize(num_bits / block_width);
+    words.resize((num_bits + block_width - 1) / block_width);
   }
 
  private:

--- a/include/bm/bm_sim/handle_mgr.h
+++ b/include/bm/bm_sim/handle_mgr.h
@@ -152,6 +152,7 @@ class HandleMgr {
     if (pos < s) {
       handles.set(pos);
       first_unset = handles.find_unset_next(first_unset);
+      first_unset = (first_unset == DynamicBitset::npos) ? s : first_unset;
     } else {
       assert(pos == s);
       first_unset++;
@@ -173,9 +174,12 @@ class HandleMgr {
     auto s = handles.size();
     if (pos >= s)
       handles.resize(pos + 1);
-    else if (!handles.set(pos))
+    if (!handles.set(pos))
       return -1;
-    if (first_unset == pos) first_unset = handles.find_unset_next(pos);
+    if (first_unset == pos) {
+      first_unset = handles.find_unset_next(pos);
+      first_unset = (first_unset == DynamicBitset::npos) ? s : first_unset;
+    }
     return 0;
   }
 

--- a/tests/test_handle_mgr.cpp
+++ b/tests/test_handle_mgr.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <bm/bm_sim/dynamic_bitset.h>
 #include <bm/bm_sim/handle_mgr.h>
 
 using bm::HandleMgr;
@@ -110,4 +111,31 @@ TEST_F(HandleMgrTest, LargeTest) {
     i++;
   }
   ASSERT_EQ(num_active_handles, i);
+}
+
+TEST_F(HandleMgrTest, FirstUnsetUpdateGetHandle) {
+  HandleMgr handle_mgr;
+  handle_t handle;
+  ASSERT_EQ(0, handle_mgr.get_handle(&handle));
+  ASSERT_EQ(0, handle_mgr.release_handle(handle));
+  ASSERT_EQ(0, handle_mgr.get_handle(&handle));
+  ASSERT_EQ(0, handle_mgr.get_handle(&handle));
+}
+
+TEST_F(HandleMgrTest, FirstUnsetUpdateSetHandle) {
+  const int block_width = std::numeric_limits<bm::DynamicBitset::Block>::digits;
+  HandleMgr handle_mgr;
+  for (int i = 0; i < block_width; i++) {
+    ASSERT_EQ(0, handle_mgr.set_handle(i));
+  }
+  handle_t handle;
+  ASSERT_EQ(0, handle_mgr.get_handle(&handle));
+}
+
+TEST_F(HandleMgrTest, SetHandle) {
+  HandleMgr handle_mgr;
+  ASSERT_EQ(0, handle_mgr.set_handle(0));
+  ASSERT_EQ(0, handle_mgr.release_handle(0));
+  ASSERT_EQ(0, handle_mgr.set_handle(0));
+  ASSERT_EQ(0, handle_mgr.set_handle(1));
 }


### PR DESCRIPTION
There were a few edge cases that were not handled correctly (when
updating the first_unset member variable). The implementation of
DynamicBitset::resize was also plain wrong.

Fixes #1024