### PR TITLE
Reset meter rates when getting default meter spec from PI

### DIFF
--- a/PI/src/direct_res_spec.cpp
+++ b/PI/src/direct_res_spec.cpp
@@ -49,6 +49,16 @@ void convert_to_counter_data(pi_counter_data_t *to,
 std::vector<bm::Meter::rate_config_t> convert_from_meter_spec(
     const pi_meter_spec_t *meter_spec) {
   std::vector<bm::Meter::rate_config_t> rates;
+
+  // default meter config
+  // it may make more sense to change PI to pass a NULL pointer in this case...
+  if (meter_spec->cir == static_cast<uint64_t>(-1) &&
+      meter_spec->cburst == static_cast<uint32_t>(-1) &&
+      meter_spec->pir == static_cast<uint64_t>(-1) &&
+      meter_spec->pburst == static_cast<uint32_t>(-1)) {
+    return rates;  // empty vector
+  }
+
   auto conv_packets = [](uint64_t r, uint32_t b) {
     bm::Meter::rate_config_t new_rate;
     new_rate.info_rate = static_cast<double>(r) / 1000000.;

--- a/PI/src/pi_meter_imp.cpp
+++ b/PI/src/pi_meter_imp.cpp
@@ -83,10 +83,12 @@ pi_status_t _pi_meter_set(pi_session_handle_t session_handle,
   std::string m_name(pi_p4info_meter_name_from_id(p4info, meter_id));
 
   auto rates = pibmv2::convert_from_meter_spec(meter_spec);
-  // We could check if this is a (P4Runtime) "reset" operation (rates are set to
-  // max<uint64_t> and burst sizes are set to max<uint32_t>) and call
-  // reset_rates instead. However, the behavior is pretty much the same.
-  auto error_code = pibmv2::switch_->meter_set_rates(0, m_name, index, rates);
+  bm::Meter::MeterErrorCode error_code;
+  if (rates.empty()) {  // is this a P4Runtime "reset" operation?
+    error_code = pibmv2::switch_->meter_reset_rates(0, m_name, index);
+  } else {
+    error_code = pibmv2::switch_->meter_set_rates(0, m_name, index, rates);
+  }
   if (error_code != bm::Meter::MeterErrorCode::SUCCESS)
     return convert_error_code(error_code);
   return PI_STATUS_SUCCESS;
@@ -136,8 +138,13 @@ pi_status_t _pi_meter_set_direct(pi_session_handle_t session_handle,
   std::string t_name = get_direct_t_name(p4info, meter_id);
 
   auto rates = pibmv2::convert_from_meter_spec(meter_spec);
-  auto error_code = pibmv2::switch_->mt_set_meter_rates(
+  bm::MatchErrorCode error_code;
+  if (rates.empty()) {  // is this a P4Runtime "reset" operation?
+    error_code = pibmv2::switch_->mt_reset_meter_rates(0, t_name, entry_handle);
+  } else {
+    error_code = pibmv2::switch_->mt_set_meter_rates(
       0, t_name, entry_handle, rates);
+  }
   if (error_code != bm::MatchErrorCode::SUCCESS)
     return pibmv2::convert_error_code(error_code);
   return PI_STATUS_SUCCESS;

--- a/PI/src/pi_tables_imp.cpp
+++ b/PI/src/pi_tables_imp.cpp
@@ -696,8 +696,13 @@ void set_direct_resources(const pi_p4info_t *p4info, pi_dev_id_t dev_id,
         {
           auto rates = pibmv2::convert_from_meter_spec(
               reinterpret_cast<pi_meter_spec_t *>(config->config));
-          error_code = pibmv2::switch_->mt_set_meter_rates(
-              0, t_name, entry_handle, rates);
+          if (rates.empty()) {  // is this a P4Runtime "reset" operation?
+            error_code = pibmv2::switch_->mt_reset_meter_rates(
+                0, t_name, entry_handle);
+          } else {
+            error_code = pibmv2::switch_->mt_set_meter_rates(
+                0, t_name, entry_handle, rates);
+          }
         }
         break;
       default:  // TODO(antonin): what to do?

--- a/include/bm/bm_sim/context.h
+++ b/include/bm/bm_sim/context.h
@@ -341,6 +341,9 @@ class Context final {
   mt_get_meter_rates(const std::string &table_name, entry_handle_t handle,
                      std::vector<Meter::rate_config_t> *configs);
 
+  MatchErrorCode
+  mt_reset_meter_rates(const std::string &table_name, entry_handle_t handle);
+
   Counter::CounterErrorCode
   read_counters(const std::string &counter_name,
                 size_t index,
@@ -368,6 +371,9 @@ class Context final {
   MeterErrorCode
   meter_get_rates(const std::string &meter_name, size_t idx,
                   std::vector<Meter::rate_config_t> *configs);
+
+  MeterErrorCode
+  meter_reset_rates(const std::string &meter_name, size_t idx);
 
   RegisterErrorCode
   register_read(const std::string &register_name,

--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -168,11 +168,12 @@ class MatchTableAbstract : public NamedP4Object {
                                 counter_value_t packets);
 
   MatchErrorCode set_meter_rates(
-      entry_handle_t handle,
-      const std::vector<Meter::rate_config_t> &configs) const;
+      entry_handle_t handle, const std::vector<Meter::rate_config_t> &configs);
 
   MatchErrorCode get_meter_rates(
       entry_handle_t handle, std::vector<Meter::rate_config_t> *configs) const;
+
+  MatchErrorCode reset_meter_rates(entry_handle_t handle);
 
   MatchErrorCode set_entry_ttl(entry_handle_t handle, unsigned int ttl_ms);
 

--- a/include/bm/bm_sim/runtime_interface.h
+++ b/include/bm/bm_sim/runtime_interface.h
@@ -245,6 +245,11 @@ class RuntimeInterface {
                      entry_handle_t handle,
                      std::vector<Meter::rate_config_t> *configs) = 0;
 
+  virtual MatchErrorCode
+  mt_reset_meter_rates(cxt_id_t cxt_id,
+                       const std::string &table_name,
+                       entry_handle_t handle) = 0;
+
   virtual MatchTableType
   mt_get_type(cxt_id_t cxt_id, const std::string &table_name) const = 0;
 
@@ -337,6 +342,10 @@ class RuntimeInterface {
   meter_get_rates(cxt_id_t cxt_id,
                   const std::string &meter_name, size_t idx,
                   std::vector<Meter::rate_config_t> *configs) = 0;
+
+  virtual MeterErrorCode
+  meter_reset_rates(cxt_id_t cxt_id,
+                    const std::string &meter_name, size_t idx) = 0;
 
   virtual RegisterErrorCode
   register_read(cxt_id_t cxt_id,

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -690,6 +690,13 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
     return contexts.at(cxt_id).mt_get_meter_rates(table_name, handle, configs);
   }
 
+  MatchErrorCode
+  mt_reset_meter_rates(
+      cxt_id_t cxt_id, const std::string &table_name,
+      entry_handle_t handle) override {
+    return contexts.at(cxt_id).mt_reset_meter_rates(table_name, handle);
+  }
+
   Counter::CounterErrorCode
   read_counters(cxt_id_t cxt_id,
                 const std::string &counter_name,
@@ -735,6 +742,12 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
                   const std::string &meter_name, size_t idx,
                   std::vector<Meter::rate_config_t> *configs) override {
     return contexts.at(cxt_id).meter_get_rates(meter_name, idx, configs);
+  }
+
+  MeterErrorCode
+  meter_reset_rates(cxt_id_t cxt_id,
+                    const std::string &meter_name, size_t idx) override {
+    return contexts.at(cxt_id).meter_reset_rates(meter_name, idx);
   }
 
   RegisterErrorCode

--- a/src/bm_sim/context.cpp
+++ b/src/bm_sim/context.cpp
@@ -413,6 +413,15 @@ Context::mt_get_meter_rates(const std::string &table_name,
   return abstract_table->get_meter_rates(handle, configs);
 }
 
+MatchErrorCode
+Context::mt_reset_meter_rates(const std::string &table_name,
+                              entry_handle_t handle) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  auto abstract_table = p4objects_rt->get_abstract_match_table_rt(table_name);
+  if (!abstract_table) return MatchErrorCode::INVALID_TABLE_NAME;
+  return abstract_table->reset_meter_rates(handle);
+}
+
 MatchTableType
 Context::mt_get_type(const std::string &table_name) const {
   boost::shared_lock<boost::shared_mutex> lock(request_mutex);
@@ -579,6 +588,15 @@ Context::meter_get_rates(
   if (idx >= meter_array->size()) return Meter::INVALID_INDEX;
   *configs = meter_array->get_meter(idx).get_rates();
   return Meter::SUCCESS;
+}
+
+Context::MeterErrorCode
+Context::meter_reset_rates(const std::string &meter_name, size_t idx) {
+  boost::shared_lock<boost::shared_mutex> lock(request_mutex);
+  MeterArray *meter_array = p4objects_rt->get_meter_array_rt(meter_name);
+  if (!meter_array) return Meter::INVALID_METER_NAME;
+  if (idx >= meter_array->size()) return Meter::INVALID_INDEX;
+  return meter_array->get_meter(idx).reset_rates();
 }
 
 Context::RegisterErrorCode

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -265,7 +265,7 @@ MatchTableAbstract::write_counters(entry_handle_t handle,
 MatchErrorCode
 MatchTableAbstract::set_meter_rates(
     entry_handle_t handle,
-    const std::vector<Meter::rate_config_t> &configs) const {
+    const std::vector<Meter::rate_config_t> &configs) {
   if (!with_meters) return MatchErrorCode::METERS_DISABLED;
   auto lock = lock_write();
   if (!is_valid_handle(handle)) return MatchErrorCode::INVALID_HANDLE;
@@ -284,6 +284,17 @@ MatchTableAbstract::get_meter_rates(
   const Meter &meter = match_unit_->get_meter(handle);
   *configs = meter.get_rates();
   return MatchErrorCode::SUCCESS;
+}
+
+MatchErrorCode
+MatchTableAbstract::reset_meter_rates(entry_handle_t handle) {
+  if (!with_meters) return MatchErrorCode::METERS_DISABLED;
+  auto lock = lock_write();
+  if (!is_valid_handle(handle)) return MatchErrorCode::INVALID_HANDLE;
+  Meter &meter = match_unit_->get_meter(handle);
+  Meter::MeterErrorCode rc = meter.reset_rates();
+  return (rc == Meter::MeterErrorCode::SUCCESS) ?
+      MatchErrorCode::SUCCESS : MatchErrorCode::ERROR;
 }
 
 MatchErrorCode

--- a/targets/simple_switch_grpc/tests/test_meter.cpp
+++ b/targets/simple_switch_grpc/tests/test_meter.cpp
@@ -87,7 +87,7 @@ TEST_F(SimpleSwitchGrpcTest_Meter, ReadDefault) {
     EXPECT_TRUE(status.ok());
   }
 
-  {
+  auto read_entry = [this, &table_entry]() -> const p4v1::TableEntry & {
     p4v1::ReadRequest read_request;
     read_request.set_device_id(device_id);
     auto read_entity = read_request.add_entities();
@@ -102,8 +102,34 @@ TEST_F(SimpleSwitchGrpcTest_Meter, ReadDefault) {
     auto status = reader->Finish();
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(read_response.entities_size(), 1);
-    const auto &read_entry = read_response.entities(0).table_entry();
-    ASSERT_FALSE(read_entry.has_meter_config());
+    const auto &rentry = read_response.entities(0).table_entry();
+    return rentry;
+  };
+
+  {
+    const auto &rentry = read_entry();
+    ASSERT_FALSE(rentry.has_meter_config());
+  }
+
+  {
+    // This modify should not change anything since we use a default / empty
+    // meter config.
+    p4v1::WriteRequest write_request;
+    write_request.set_device_id(device_id);
+    auto update = write_request.add_updates();
+    update->set_type(p4v1::Update_Type_MODIFY);
+    auto entity = update->mutable_entity();
+    entity->mutable_direct_meter_entry()->mutable_table_entry()
+        ->CopyFrom(table_entry);
+    p4v1::WriteResponse write_response;
+    ClientContext context;
+    auto status = Write(&context, write_request, &write_response);
+    EXPECT_TRUE(status.ok());
+  }
+
+  {
+    const auto &rentry = read_entry();
+    ASSERT_FALSE(rentry.has_meter_config());
   }
 }
 


### PR DESCRIPTION
The code was incorrect as it was assuming that converting the default
meter spec to bmv2 rates and then back to a PI spec would yield the
default spec again. This is not a valid assumption because we convert
the meter rates from an integer to a float and then back to an integer.

Fixes #1029