### PR TITLE
Fix build with recent versions of Thrift.

### DIFF
--- a/pdfixed/Makefile.am
+++ b/pdfixed/Makefile.am
@@ -95,6 +95,7 @@ pdfixed_thrift_files.ts: $(pd_conn_mgr_IDL) $(pd_mc_IDL) $(pd_sswitch_IDL) $(pd_
 	$(THRIFT) -o $(builddir)/pd_thrift_gen/ --gen py -r $(pd_conn_mgr_IDL)
 	$(THRIFT) -o $(builddir)/pd_thrift_gen/ --gen py -r $(pd_mc_IDL)
 	$(THRIFT) -o $(builddir)/pd_thrift_gen/ --gen py -r $(pd_sswitch_IDL)
+	touch $(pdfixed_thrift_files_cxx)
 	@mv -f pdfixed_thrift_files.tmp $@
 $(BUILT_SOURCES): pdfixed_thrift_files.ts
 ## Recover from the removal of $@

--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -100,6 +100,7 @@ thrift_files.ts: $(THRIFT_IDL)
 	@mkdir -p $(builddir)/gen-cpp/bm
 	$(THRIFT) -out $(builddir)/gen-cpp/bm --gen cpp -r $(THRIFT_IDL)
 	$(THRIFT) -o $(builddir) --gen py -r $(THRIFT_IDL)
+	touch $(psa_switch_thrift_files)
 	if mkdir $(srcdir)/pswitch_runtime.test 2>/dev/null; then \
 	  rm -rf $(srcdir)/pswitch_runtime/; \
 	  cp -r $(builddir)/gen-py/pswitch_runtime/ $(srcdir)/; \

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -121,6 +121,7 @@ thrift_files.ts: $(THRIFT_IDL)
 	@mkdir -p $(builddir)/gen-cpp/bm
 	$(THRIFT) -out $(builddir)/gen-cpp/bm --gen cpp -r $(THRIFT_IDL)
 	$(THRIFT) -o $(builddir) --gen py -r $(THRIFT_IDL)
+	touch $(simple_switch_thrift_files)
 	if mkdir $(srcdir)/sswitch_runtime.test 2>/dev/null; then \
 	  rm -rf $(srcdir)/sswitch_runtime/; \
 	  cp -r $(builddir)/gen-py/sswitch_runtime/ $(srcdir)/; \

--- a/thrift_src/Makefile.am
+++ b/thrift_src/Makefile.am
@@ -94,6 +94,7 @@ thrift_files.ts: $(srcdir)/standard.thrift $(srcdir)/simple_pre.thrift $(srcdir)
 	$(THRIFT) -o $(builddir) --gen py -r $(srcdir)/simple_pre.thrift
 	$(THRIFT) -out $(builddir)/gen-cpp/bm --gen cpp -r $(srcdir)/simple_pre_lag.thrift
 	$(THRIFT) -o $(builddir) --gen py -r $(srcdir)/simple_pre_lag.thrift
+	touch $(thrift_cxx_files)
 	if mkdir $(top_srcdir)/tools/bm_runtime.test 2>/dev/null; then \
 	  rm -rf $(top_srcdir)/tools/bm_runtime/; \
 	  cp -r $(builddir)/gen-py/bm_runtime/ $(top_srcdir)/tools/; \


### PR DESCRIPTION
Recent versions of Thrift (such as the one that comes with recent Fedora
distros) don't generate "_constants" files for C++, so the build fails.
Empty files work fine, so this commit fixes the problem by creating them.

Fixes bug #917.