### PR TITLE
Stop using libJudy in trie implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,9 +184,8 @@ AS_IF([test "$want_nanomsg" = yes], [
     AC_DEFINE([NANOMSG_ON], [], [Enable Nanomsg support])
 ])
 
-# Check for pthread, libjudy, libgmp, libpcap
+# Check for pthread, libgmp, libpcap
 AX_PTHREAD([], [AC_MSG_ERROR([Missing pthread library])])
-AC_CHECK_LIB([Judy], [Judy1Next], [], [AC_MSG_ERROR([Missing libJudy])])
 AC_CHECK_LIB([gmp], [__gmpz_init], [], [AC_MSG_ERROR([Missing libgmp])])
 AC_CHECK_LIB([pcap], [pcap_create], [], [AC_MSG_ERROR([Missing libpcap])])
 AC_CHECK_LIB([pcap], [pcap_set_immediate_mode], [pcap_fix=yes], [pcap_fix=no])

--- a/src/bf_lpm_trie/bf_lpm_trie/bf_lpm_trie.h
+++ b/src/bf_lpm_trie/bf_lpm_trie/bf_lpm_trie.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-present Barefoot Networks, Inc.
+ * Copyright 2021 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
@@ -30,7 +31,7 @@ extern "C"{
   
 typedef struct bf_lpm_trie_s bf_lpm_trie_t;
 
-typedef unsigned long value_t;
+typedef uintptr_t value_t;
 
 bf_lpm_trie_t *bf_lpm_trie_create(size_t key_width_bytes, bool auto_shrink);
 


### PR DESCRIPTION
We use sorted vectors instead.
This was the last part of bmv2 that still depended on libJudy. See
https://github.com/p4lang/behavioral-model/issues/1001 for why we are
removing this dependency.

There doesn't seem to be a noticeable performance difference between the
old and the new implementation, when running the test_LPM_match_1 stress
test.