### PR TITLE
[v1model] Doc bit width mismatch: enq_qdepth and deq_qdepth

### DIFF
--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -166,9 +166,9 @@ recommend that you use the following P4_14 code:
 header_type queueing_metadata_t {
     fields {
         enq_timestamp : 48;
-        enq_qdepth : 16;
+        enq_qdepth : 19;
         deq_timedelta : 32;
-        deq_qdepth : 16;
+        deq_qdepth : 19;
         qid : 8;
     }
 }


### PR DESCRIPTION
In simple_switch.md: `enq_qdepth` and `deq_qdepth` are documented as `16` bits.
In [p4c/p4include/v1model.p4](https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4#L97): `enq_qdepth` and `deq_qdepth` are `bit<19>`. 

Thanks for reviewing.