### PR TITLE
travis: update branch name in deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 stages:
   - test
   - name: deploy
-    if: repo = p4lang/behavioral-model AND branch = master
+    if: repo = p4lang/behavioral-model AND branch = main
 
 matrix:
   include:
@@ -34,7 +34,7 @@ matrix:
         skip_cleanup: true
         on:
           repo: p4lang/behavioral-model
-          branch: master
+          branch: main
 
 addons:
   apt:


### PR DESCRIPTION
The deploy stage in travis should update the content of http://bmv2.org, however it looks like it doesn't work currently because the `master` branch has been renamed to `main`.