### PR TITLE
bmi_port: Fix memory leak and incorrect return type

### DIFF
--- a/src/BMI/bmi_port.c
+++ b/src/BMI/bmi_port.c
@@ -186,9 +186,11 @@ int bmi_start_mgr(bmi_port_mgr_t* port_mgr) {
 }
 
 int bmi_port_create_mgr(bmi_port_mgr_t **port_mgr, int max_port_count) {
-  bmi_port_mgr_t *port_mgr_ = malloc(sizeof(bmi_port_mgr_t));
   int exitCode;
+
   if (!port_mgr) return -1;
+
+  bmi_port_mgr_t *port_mgr_ = malloc(sizeof(bmi_port_mgr_t));
 
   memset(port_mgr_, 0, sizeof(bmi_port_mgr_t));
 
@@ -197,6 +199,8 @@ int bmi_port_create_mgr(bmi_port_mgr_t **port_mgr, int max_port_count) {
 
   if (socketpair(PF_LOCAL, SOCK_STREAM, 0, port_mgr_->socketpairfd)) {
     perror("socketpair");
+    free(port_mgr_->ports);
+    free(port_mgr_);
     return -1;
   }
 

--- a/src/BMI/bmi_port.c
+++ b/src/BMI/bmi_port.c
@@ -99,7 +99,7 @@ static inline bmi_port_t *insert_port(bmi_port_mgr_t *port_mgr, int port_num) {
   return &port_mgr->ports[a];
 }
 
-static inline void *delete_port(bmi_port_mgr_t *port_mgr, bmi_port_t *port) {
+static inline void delete_port(bmi_port_mgr_t *port_mgr, bmi_port_t *port) {
   int idx = port - port_mgr->ports;
   size_t size = (port_mgr->port_count - idx - 1) * sizeof(*port_mgr->ports);
   memmove(port, port + 1, size);


### PR DESCRIPTION
This pull request fixes a memory leak and incorrect return type in `src/BMI/bmi_port.c` reported by `cppcheck`.