### PR TITLE
readme: Update URL links

### DIFF
--- a/Doxymain.md
+++ b/Doxymain.md
@@ -11,11 +11,11 @@ should be starting with the [bmv2 README]
 (https://github.com/p4lang/behavioral-model).
 
 The bmv2 code already comes with 3 example targets: [simple_router]
-(https://github.com/p4lang/behavioral-model/tree/master/targets/simple_router),
+(https://github.com/p4lang/behavioral-model/tree/main/targets/simple_router),
 [l2_switch]
-(https://github.com/p4lang/behavioral-model/tree/master/targets/l2_switch) and
+(https://github.com/p4lang/behavioral-model/tree/main/targets/l2_switch) and
 [simple_switch]
-(https://github.com/p4lang/behavioral-model/tree/master/targets/simple_switch).
+(https://github.com/p4lang/behavioral-model/tree/main/targets/simple_switch).
 simple_router is the smallest and simplest one, and I suggest starting with
 it. l2_switch introduces some additional complexity by including a packet
 replication engine (to support multicast). simple_switch is the standard P4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BEHAVIORAL MODEL (bmv2)
 
-[![Build Status](https://travis-ci.org/p4lang/behavioral-model.svg?branch=master)](https://travis-ci.org/p4lang/behavioral-model)
+[![Build Status](https://travis-ci.org/p4lang/behavioral-model.svg?branch=main)](https://travis-ci.org/p4lang/behavioral-model)
 
 This is the second version of the reference P4 software switch, nicknamed bmv2
 (for behavioral model version 2). The software switch is written in C++11. It
@@ -106,7 +106,7 @@ There are currently 2 P4 compilers available for bmv2 on p4lang:
  * [p4c](https://github.com/p4lang/p4c) includes a bmv2 backend and is the
    recommended compiler to use, as it supports both P4_14 and P4_16
    programs. Refer to the
-   [README](https://github.com/p4lang/p4c/blob/master/README.md) for information
+   [README](https://github.com/p4lang/p4c/blob/main/README.md) for information
    on how to install and use p4c. At the moment, the bmv2 p4c backend supports
    the v1model architecture, with some tentative support for the PSA
    architecture. P4_16 programs written for v1model can be executed with the

--- a/docs/runtime_CLI.md
+++ b/docs/runtime_CLI.md
@@ -41,7 +41,7 @@ The `v1model.p4` standard_metadata field `mcast_grp` specifies one of
 simple_switch can use a larger range of multicast group ids.  The
 range given here is limited by the definition of the `mcast_grp`
 standard_metadata field in [p4c's `v1model.p4` include
-file](https://github.com/p4lang/p4c/blob/master/p4include/v1model.p4),
+file](https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4),
 which has type `bit<16>`.
 
 For packets that should be multicast replicated, the PRE looks up the

--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -79,7 +79,7 @@ Here are the fields:
   none of those, so a normal unicast packet from ingress (`NORMAL`).
   Until such time as similar constants are pre-defined for you, you
   may copy [this
-  list](https://github.com/p4lang/p4c/blob/master/testdata/p4_14_samples/switch_20160512/includes/intrinsic.p4#L62-L68)
+  list](https://github.com/p4lang/p4c/blob/main/testdata/p4_14_samples/switch_20160512/includes/intrinsic.p4#L62-L68)
   of constants into your code.
 - `parser_status` (sm14) or `parser_error` (v1m) - `parser_status` is
   the name in the P4_14 language specification.  It has been renamed
@@ -895,7 +895,7 @@ for array elements for packet processing, the Thrift API (used by
 `simple_switch_CLI`, and perhaps some switch controller software) only
 supports control plane read and write operations for array elements up
 to 64 bits wide (see the type `BmRegisterValue` in file
-[`standard.thrift`](https://github.com/p4lang/behavioral-model/blob/master/thrift_src/standard.thrift),
+[`standard.thrift`](https://github.com/p4lang/behavioral-model/blob/main/thrift_src/standard.thrift),
 which is a 64-bit integer as of October 2019).  The P4Runtime API does
 not have this limitation, but there is no P4Runtime implementation of
 register read and write operations yet for simple_switch:

--- a/targets/README.md
+++ b/targets/README.md
@@ -44,7 +44,7 @@ References:
 
 + [Specification documents](https://p4.org/specs/) for P4_14 and P4_16
   languages.
-+ The include file [`v1model.p4`](https://github.com/p4lang/p4c/blob/master/p4include/v1model.p4)
++ The include file [`v1model.p4`](https://github.com/p4lang/p4c/blob/main/p4include/v1model.p4)
   defining the `v1model` architecture for P4_16 programs, and the
   [`simple_switch` documentation](../docs/simple_switch.md) giving
   more details of this architecture and its implementation in

--- a/targets/simple_switch_grpc/README.md
+++ b/targets/simple_switch_grpc/README.md
@@ -80,7 +80,7 @@ released specification](https://p4.org/specs/).
 We are working on supporting gNMI and OpenConfig YANG models as part of the
 P4Runtime server. We are using [sysrepo](https://github.com/sysrepo/sysrepo) as
 our YANG configuration data store and operational state manager. See [this
-README](https://github.com/p4lang/PI/blob/master/proto/README.md) for more
+README](https://github.com/p4lang/PI/blob/main/proto/README.md) for more
 information on how to try it out. After installing sysrepo, building and
 installing the PI project with sysrepo support enabled, you will need to
 configure simple_switch_grpc with `--with-sysrepo` and build it again.
@@ -182,7 +182,7 @@ by P4Runtime.
 Refer to [Enabling the Thrift server](#enabling-the-thrift-server) above. Use
 `--with-thrift` when configuring bmv2 and simple_switch_grpc.
 
-#### What's the difference between the [PI folder in this repository](https://github.com/p4lang/behavioral-model/tree/master/PI) and the [PI repository](https://github.com/p4lang/PI)? How do they relate to simple_switch and simple_switch_grpc?
+#### What's the difference between the [PI folder in this repository](https://github.com/p4lang/behavioral-model/tree/main/PI) and the [PI repository](https://github.com/p4lang/PI)? How do they relate to simple_switch and simple_switch_grpc?
 
 The PI repository includes all the core code for the PI project: common server
 code, P4Runtime & P4Info Protobuf IDL definitions, implementation of the
@@ -192,7 +192,7 @@ implement P4Runtime using the PI C interface. All these targets have to do is
 implement a "few" C functions, such as `_pi_table_entry_add`.
 
 The PI repository also includes [a reference implementation of the PI interface
-for bmv2](https://github.com/p4lang/PI/tree/master/targets/bmv2). This
+for bmv2](https://github.com/p4lang/PI/tree/main/targets/bmv2). This
 implementation uses the bmv2 Thrift RPC server. In other words, the P4Runtime
 RPC calls are mapped to PI C function calls, which in-turn are mapped to bmv2
 Thrift RPC calls. This implementation enables controlling multiple bmv2
@@ -209,6 +209,6 @@ P4Runtime server and the bmv2 device are run in the same process
 (simple_switch_grpc), you can only have a single bmv2 device for a given
 P4Runtime server. The PI C implementation used by simple_switch_grpc, which
 directly accesses bmv2 internal data structures, is located in the [PI folder in
-this repository](https://github.com/p4lang/behavioral-model/tree/master/PI).
+this repository](https://github.com/p4lang/behavioral-model/tree/main/PI).
 
 We encourage newcomers to use simple_switch_grpc if possible.

--- a/targets/simple_switch_grpc/README.md
+++ b/targets/simple_switch_grpc/README.md
@@ -3,7 +3,7 @@
 This is an alternative version of the simple_switch target, which does not use
 the Thrift runtime server for table programming (unless required, see below).
 Instead it starts a gRPC server which implements
-[p4untime.proto](https://github.com/p4lang/PI/blob/master/proto/p4/p4runtime.proto).
+[p4untime.proto](https://github.com/p4lang/p4runtime/blob/main/proto/p4/v1/p4runtime.proto).
 
 Make sure you read this README and [FAQ](#faq) before asking a question on
 Github or the p4-dev mailing list.


### PR DESCRIPTION
This pull request updates the URL for `p4untime.proto` in `targets/simple_switch_grpc/README.md` and replaces the `master` branch with `main` in links to behavioral-model, p4c and PI.