### PR TITLE
Fix IPv6 address parse error

### DIFF
--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -506,7 +506,7 @@ def ipv6Addr_to_bytes(addr):
     except:
         raise UIn_BadIPv6Error()
     try:
-        return [ord(b) for b in ip.packed]
+        return list(ip.packed)
     except:
         raise UIn_BadIPv6Error()
 


### PR DESCRIPTION
In a python3 environment, ipaddr.IPv6Address.packed returns bytes.
So it passes int value to ord() and it causes parse error.
There is no need to use ord() and simply use list() solve this error.