### PR TITLE
Remove workaround introduced for Thrift 0.9.2 and Ubuntu 18.04

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 set -e
 ubuntu_release=`lsb_release -s -r`
-if [[ "${ubuntu_release}" > "18" ]]
-then
-    # This older package libssl1.0-dev enables compiling Thrift 0.9.2
-    # on Ubuntu 18.04.  Package libssl-dev exists, but Thrift 0.9.2
-    # fails to compile when it is installed.
-    # TBD: whether using this package makes a difference for Ubuntu
-    # 18.04 and Thrift 0.11.0.
-    LIBSSL_DEV="libssl1.0-dev"
-else
-    LIBSSL_DEV="libssl-dev"
-fi
 sudo apt-get install -y \
     automake \
     cmake \
@@ -29,7 +18,7 @@ sudo apt-get install -y \
     bison \
     pkg-config \
     g++ \
-    $LIBSSL_DEV \
+    libssl-dev \
     libffi-dev \
     python3-dev \
     python3-pip \


### PR DESCRIPTION
It is no longer needed for Ubuntu 18.04 or 20.04, with the currently
supported Thrift version 0.11.0.