### PR TITLE
[simple_switch_grpc] Support SSL options for P4Runtime server

### DIFF
--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -42,6 +42,12 @@ class SysrepoDriver;
 
 class DataplaneInterfaceServiceImpl;
 
+struct SSLOptions {
+  std::string pem_root_certs;
+  std::string pem_private_key;
+  std::string pem_cert_chain;
+};
+
 class SimpleSwitchGrpcRunner {
  public:
   static constexpr bm::DevMgrIface::port_t default_drop_port = 511;
@@ -53,10 +59,11 @@ class SimpleSwitchGrpcRunner {
       std::string grpc_server_addr = "0.0.0.0:9559",
       bm::DevMgrIface::port_t cpu_port = 0,
       std::string dp_grpc_server_addr = "",
-      bm::DevMgrIface::port_t drop_port = default_drop_port) {
+      bm::DevMgrIface::port_t drop_port = default_drop_port,
+      std::shared_ptr<SSLOptions> ssl_options = nullptr) {
     static SimpleSwitchGrpcRunner instance(
         enable_swap, grpc_server_addr, cpu_port, dp_grpc_server_addr,
-        drop_port);
+        drop_port, ssl_options);
     return instance;
   }
 
@@ -74,7 +81,8 @@ class SimpleSwitchGrpcRunner {
                          std::string grpc_server_addr = "0.0.0.0:9559",
                          bm::DevMgrIface::port_t cpu_port = 0,
                          std::string dp_grpc_server_addr = "",
-                         bm::DevMgrIface::port_t drop_port = default_drop_port);
+                         bm::DevMgrIface::port_t drop_port = default_drop_port,
+                         std::shared_ptr<SSLOptions> ssl_options = nullptr);
   ~SimpleSwitchGrpcRunner();
 
   void port_status_cb(bm::DevMgrIface::port_t port,
@@ -90,6 +98,7 @@ class SimpleSwitchGrpcRunner {
 #ifdef WITH_SYSREPO
   std::unique_ptr<SysrepoDriver> sysrepo_driver;
 #endif  // WITH_SYSREPO
+  std::shared_ptr<SSLOptions> ssl_options;
 };
 
 }  // namespace sswitch_grpc


### PR DESCRIPTION
The reference P4Runtime server in p4lang/PI now support configuring a
secure SSL/TLS gRPC server. We add the corresponding command-line
options to simple_switch_grpc to initialize the secure server.

Tested with self-signed certificate and development version of
p4runtime-shell.