### PR TITLE
Fix range-loop-construct warnings

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -653,7 +653,7 @@ P4Objects::init_header_types(const Json::Value &cfg_root) {
                                              header_type_id);
 
     const Json::Value &cfg_fields = cfg_header_type["fields"];
-    for (const auto cfg_field : cfg_fields) {
+    for (const auto &cfg_field : cfg_fields) {
       const string field_name = cfg_field[0].asString();
       bool is_signed = false;
       if (cfg_field.size() > 2)

--- a/src/bm_sim/simple_pre.cpp
+++ b/src/bm_sim/simple_pre.cpp
@@ -184,7 +184,7 @@ McSimplePre::mc_node_update(const l1_hdl_t l1_hdl,
 void
 McSimplePre::get_entries_common(Json::Value *root) const {
   Json::Value mgrps(Json::arrayValue);
-  for (const auto p : mgid_entries) {
+  for (const auto &p : mgid_entries) {
     Json::Value mgrp(Json::objectValue);
     mgrp["id"] = Json::Value(Json::UInt(p.first));
 
@@ -212,7 +212,7 @@ McSimplePre::get_entries_common(Json::Value *root) const {
   (*root)["l1_handles"] = l1_handles;
 
   Json::Value l2_handles(Json::arrayValue);
-  for (const auto p : l2_entries) {
+  for (const auto &p : l2_entries) {
     Json::Value handle(Json::objectValue);
     handle["handle"] = Json::Value(Json::UInt(p.first));
     const auto &entry = p.second;


### PR DESCRIPTION
This pull request fixes the following warnings reported by g++ (GCC) 11:

```
P4Objects.cpp:656:21: warning: loop variable 'cfg_field' creates a copy from type 'const Json::Value' [-Wrange-loop-construct]
  656 |     for (const auto cfg_field : cfg_fields) {
      |                     ^~~~~~~~~
P4Objects.cpp:656:21: note: use reference type to prevent copying
  656 |     for (const auto cfg_field : cfg_fields) {
      |                     ^~~~~~~~~
      |                     &
```
```
simple_pre.cpp:187:19: warning: loop variable 'p' creates a copy from type 'const std::pair<const long unsigned int, bm::McSimplePre::MgidEntry>' [-Wrange-loop-construct]
  187 |   for (const auto p : mgid_entries) {
      |                   ^
simple_pre.cpp:187:19: note: use reference type to prevent copying
  187 |   for (const auto p : mgid_entries) {
      |                   ^
      |                   &
```

```
simple_pre.cpp:215:19: warning: loop variable 'p' creates a copy from type 'const std::pair<const long unsigned int, bm::McSimplePre::L2Entry>' [-Wrange-loop-construct]
  215 |   for (const auto p : l2_entries) {
      |                   ^
simple_pre.cpp:215:19: note: use reference type to prevent copying
  215 |   for (const auto p : l2_entries) {
      |                   ^
      |                   &
```