### PR TITLE
Remove redundant moves in return statements

### DIFF
--- a/include/bm/bm_sim/queueing.h
+++ b/include/bm/bm_sim/queueing.h
@@ -777,7 +777,7 @@ class QueueingLogicPriRL {
   Function for_each_q(size_t queue_id, Function fn) {
     auto &q_info = get_queue(queue_id);
     for (auto &q_info_pri : q_info) fn(q_info_pri);
-    return std::move(fn);
+    return fn;
   }
 
   template <typename Function>
@@ -785,7 +785,7 @@ class QueueingLogicPriRL {
     auto &q_info = get_queue(queue_id);
     auto &q_info_pri = q_info.at(priority);
     fn(q_info_pri);
-    return std::move(fn);
+    return fn;
   }
 
   struct SetCapacityFn {


### PR DESCRIPTION
With recent g++ versions:

../include/bm/bm_sim/queueing.h:780:24: error: redundant move in return statement [-Werror=redundant-move]
  780 |     return std::move(fn);
      |                        ^
../include/bm/bm_sim/queueing.h:780:24: note: remove 'std::move' call
cc1plus: all warnings being treated as error

While copy elision is not possible when retruning a function parameter,
if the other conditions for NVO are met, a move operation should be
used. The std::move doesn't cause the compiler to perform worse (unlike
for RVO), but it is redundant.