### PR TITLE
Document Thrift 0.13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You also need to install the following from source. Feel free to use the
 install scripts under travis/.
 
 - [thrift 0.11.0](https://github.com/apache/thrift/releases/tag/0.11.0) or later
-  (tested up to 0.12.1)
+  (tested up to 0.13)
 - [nanomsg 1.0.0](https://github.com/nanomsg/nanomsg/releases/tag/1.0.0) or
   later
 

--- a/travis/install-thrift.sh
+++ b/travis/install-thrift.sh
@@ -3,14 +3,14 @@
 THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $THIS_DIR/common.sh
 
-check_lib libthrift libthrift-0.11.0
+check_lib libthrift libthrift-0.13.0
 
 set -e
 # Make it possible to get thrift in China
-# wget http://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz
-# tar -xzvf thrift-0.11.0.tar.gz
-git clone -b 0.11.0 https://github.com/apache/thrift.git thrift-0.11.0
-cd thrift-0.11.0
+# wget http://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz
+# tar -xzvf thrift-0.13.0.tar.gz
+git clone -b 0.13.0 https://github.com/apache/thrift.git thrift-0.13.0
+cd thrift-0.13.0
 ./bootstrap.sh
 ./configure --with-cpp=yes --with-c_glib=no --with-java=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no
 make -j2 && sudo make install


### PR DESCRIPTION
CI builds use Thrift 0.13
We update install-thrift.sh to install Thrift 0.13 instead of 0.11, and
we document that Thrift 0.13 is supported in the README.