### PR TITLE
simple_switch: make the prio-queue a command line option

### DIFF
--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -46,6 +46,9 @@ main(int argc, char* argv[]) {
   simple_switch_parser.add_uint_option(
       "drop-port",
       "Choose drop port number (default is 511)");
+  simple_switch_parser.add_uint_option(
+      "priority-queues",
+      "Number of priority queues (default is 1)");
 
   bm::OptionsParser parser;
   parser.parse(argc, argv, &simple_switch_parser);
@@ -65,7 +68,18 @@ main(int argc, char* argv[]) {
       std::exit(1);
   }
 
-  simple_switch = new SimpleSwitch(enable_swap_flag, drop_port);
+  uint32_t priority_queues = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "priority-queues", &priority_queues);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      priority_queues = SimpleSwitch::default_nb_queues_per_port;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
+  simple_switch = new SimpleSwitch(enable_swap_flag, drop_port,
+                                   priority_queues);
 
   int status = simple_switch->init_from_options_parser(parser);
   if (status != 0) std::exit(status);

--- a/targets/simple_switch/sswitch_CLI.py
+++ b/targets/simple_switch/sswitch_CLI.py
@@ -52,11 +52,15 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
 
     @handle_bad_input
     def do_set_queue_depth(self, line):
-        "Set depth of one / all egress queue(s): set_queue_depth <nb_pkts> [<egress_port>]"
+        "Set depth of one / all egress queue(s): set_queue_depth <nb_pkts> [<egress_port> [<priority>]]"
         args = line.split()
         self.at_least_n_args(args, 1)
         depth = self.parse_int(args[0], "nb_pkts")
-        if len(args) > 1:
+        if len(args) > 2:
+            port = self.parse_int(args[1], "egress_port")
+            priority = self.parse_int(args[2], "priority")
+            self.sswitch_client.set_egress_priority_queue_depth(port, priority, depth)
+        elif len(args) == 2:
             port = self.parse_int(args[1], "egress_port")
             self.sswitch_client.set_egress_queue_depth(port, depth)
         else:
@@ -64,11 +68,15 @@ class SimpleSwitchAPI(runtime_CLI.RuntimeAPI):
 
     @handle_bad_input
     def do_set_queue_rate(self, line):
-        "Set rate of one / all egress queue(s): set_queue_rate <rate_pps> [<egress_port>]"
+        "Set rate of one / all egress queue(s): set_queue_rate <rate_pps> [<egress_port> [<priority>]]"
         args = line.split()
         self.at_least_n_args(args, 1)
         rate = self.parse_int(args[0], "rate_pps")
-        if len(args) > 1:
+        if len(args) > 2:
+            port = self.parse_int(args[1], "egress_port")
+            priority = self.parse_int(args[2], "priority")
+            self.sswitch_client.set_egress_priority_queue_rate(port, priority, rate)
+        elif len(args) == 2:
             port = self.parse_int(args[1], "egress_port")
             self.sswitch_client.set_egress_queue_rate(port, rate)
         else:

--- a/targets/simple_switch/thrift/simple_switch.thrift
+++ b/targets/simple_switch/thrift/simple_switch.thrift
@@ -48,8 +48,10 @@ service SimpleSwitch {
   MirroringSessionConfig mirroring_session_get(1:i32 mirror_id)
   throws (1:InvalidMirroringOperation ouch);
 
+  i32 set_egress_priority_queue_depth(1:i32 port_num, 2:i32 priority, 3:i32 depth_pkts);
   i32 set_egress_queue_depth(1:i32 port_num, 2:i32 depth_pkts);
   i32 set_all_egress_queue_depths(1:i32 depth_pkts);
+  i32 set_egress_priority_queue_rate(1:i32 port_num, 2:i32 priority, 3:i64 rate_pps);
   i32 set_egress_queue_rate(1:i32 port_num, 2:i64 rate_pps);
   i32 set_all_egress_queue_rates(1:i64 rate_pps);
 

--- a/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
+++ b/targets/simple_switch/thrift/src/SimpleSwitch_server.cpp
@@ -104,6 +104,14 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     }
   }
 
+  int32_t set_egress_priority_queue_depth(const int32_t port_num,
+                                          const int32_t priority,
+                                          const int32_t depth_pkts) {
+    bm::Logger::get()->trace("set_egress_priority_queue_depth");
+    return switch_->set_egress_priority_queue_depth(
+        port_num, priority, static_cast<uint32_t>(depth_pkts));
+  }
+
   int32_t set_egress_queue_depth(const int32_t port_num,
                                  const int32_t depth_pkts) {
     bm::Logger::get()->trace("set_egress_queue_depth");
@@ -115,6 +123,14 @@ class SimpleSwitchHandler : virtual public SimpleSwitchIf {
     bm::Logger::get()->trace("set_all_egress_queue_depths");
     return switch_->set_all_egress_queue_depths(
         static_cast<uint32_t>(depth_pkts));
+  }
+
+  int32_t set_egress_priority_queue_rate(const int32_t port_num,
+                                         const int32_t priority,
+                                         const int64_t rate_pps) {
+    bm::Logger::get()->trace("set_egress_priority_queue_rate");
+    return switch_->set_egress_priority_queue_rate(
+        port_num, priority, static_cast<uint64_t>(rate_pps));
   }
 
   int32_t set_egress_queue_rate(const int32_t port_num,

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -250,9 +250,11 @@ main(int argc, char* argv[]) {
 
   uint32_t priority_queues = 0xffffffff;
   {
-    auto rc = simple_switch_parser.get_uint_option("priority-queues", &priority_queues);
+    auto rc = simple_switch_parser.get_uint_option("priority-queues",
+                                                   &priority_queues);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
-      priority_queues = sswitch_grpc::SimpleSwitchGrpcRunner::default_nb_queues_per_port;
+      priority_queues =
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_nb_queues_per_port;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
   }

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -500,8 +500,10 @@ SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(
     bm::DevMgrIface::port_t cpu_port,
     std::string dp_grpc_server_addr,
     bm::DevMgrIface::port_t drop_port,
-    std::shared_ptr<SSLOptions> ssl_options)
-    : simple_switch(new SimpleSwitch(enable_swap, drop_port)),
+    std::shared_ptr<SSLOptions> ssl_options,
+    size_t nb_queues_per_port)
+    : simple_switch(new SimpleSwitch(enable_swap, drop_port,
+                                     nb_queues_per_port)),
       grpc_server_addr(grpc_server_addr), cpu_port(cpu_port),
       dp_grpc_server_addr(dp_grpc_server_addr),
       dp_service(nullptr),

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -86,7 +86,8 @@ class SimpleSwitchGrpcRunner {
                          std::string dp_grpc_server_addr = "",
                          bm::DevMgrIface::port_t drop_port = default_drop_port,
                          std::shared_ptr<SSLOptions> ssl_options = nullptr,
-                         size_t nb_queues_per_port = default_nb_queues_per_port);
+                         size_t nb_queues_per_port =
+                             default_nb_queues_per_port);
   ~SimpleSwitchGrpcRunner();
 
   void port_status_cb(bm::DevMgrIface::port_t port,

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -52,6 +52,7 @@ struct SSLOptions {
 class SimpleSwitchGrpcRunner {
  public:
   static constexpr bm::DevMgrIface::port_t default_drop_port = 511;
+  static constexpr size_t default_nb_queues_per_port = 1;
 
   // there is no real need for a singleton here, except for the fact that we use
   // PIGrpcServerRunAddr, ... which uses static state
@@ -61,10 +62,11 @@ class SimpleSwitchGrpcRunner {
       bm::DevMgrIface::port_t cpu_port = 0,
       std::string dp_grpc_server_addr = "",
       bm::DevMgrIface::port_t drop_port = default_drop_port,
-      std::shared_ptr<SSLOptions> ssl_options = nullptr) {
+      std::shared_ptr<SSLOptions> ssl_options = nullptr,
+      size_t nb_queues_per_port = default_nb_queues_per_port) {
     static SimpleSwitchGrpcRunner instance(
         enable_swap, grpc_server_addr, cpu_port, dp_grpc_server_addr,
-        drop_port, ssl_options);
+        drop_port, ssl_options, nb_queues_per_port);
     return instance;
   }
 
@@ -83,7 +85,8 @@ class SimpleSwitchGrpcRunner {
                          bm::DevMgrIface::port_t cpu_port = 0,
                          std::string dp_grpc_server_addr = "",
                          bm::DevMgrIface::port_t drop_port = default_drop_port,
-                         std::shared_ptr<SSLOptions> ssl_options = nullptr);
+                         std::shared_ptr<SSLOptions> ssl_options = nullptr,
+                         size_t nb_queues_per_port = default_nb_queues_per_port);
   ~SimpleSwitchGrpcRunner();
 
   void port_status_cb(bm::DevMgrIface::port_t port,


### PR DESCRIPTION
## Introduction

This PR solves issue #1065 

- Use `QueueingLogicPriRL` instead of `QueueingLogicRL` to make the priority queue a command-line option of simple_switch(_grpc)
- Add optional argument to `set_queue_depth` and `set_queue_rate` to set the depth/rate of a queue with a specific priority