### PR TITLE
simple_switch_grpc: make read PEM reusable

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -96,3 +96,6 @@ bm/bm_sim/header_unions.h
 
 nobase_include_HEADERS += \
 bm/bm_sim/core/primitives.h
+
+nobase_include_HEADERS += \
+bm/bm_grpc/pem.h

--- a/include/bm/bm_grpc/pem.h
+++ b/include/bm/bm_grpc/pem.h
@@ -1,0 +1,59 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BM_BM_GRPC_PEM_H_
+#define BM_BM_GRPC_PEM_H_
+
+#include <exception>
+#include <fstream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+
+namespace bm {
+
+class read_pem_exception : public std::exception {
+ public:
+  read_pem_exception(const std::string &filename, const std::string &error)
+      : filename(filename), error(error) { }
+
+  std::string msg() const {
+    std::stringstream ss;
+    ss << "Error when reading pem file '" << filename << "': " << error << "\n";
+    return ss.str();
+  }
+
+  const char *what() const noexcept override {
+    return error.c_str();
+  }
+
+ private:
+  std::string filename;
+  std::string error;
+};
+
+std::string read_pem_file(const std::string &filename) {
+  std::ifstream fs(filename, std::ios::in);
+  if (!fs) {
+    throw read_pem_exception(filename, "file cannot be opened");
+  }
+  return std::string((std::istreambuf_iterator<char>(fs)),
+                     std::istreambuf_iterator<char>());
+}
+
+}  // namespace bm
+
+#endif  // BM_BM_GRPC_PEM_H_

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -21,6 +21,7 @@
 
 #include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/target_parser.h>
+#include <bm/bm_grpc/pem.h>
 
 #include <exception>
 #include <fstream>
@@ -31,39 +32,6 @@
 #include <string>
 
 #include "switch_runner.h"
-
-namespace {
-
-class read_pem_exception : public std::exception {
- public:
-  read_pem_exception(const std::string &filename, const std::string &error)
-      : filename(filename), error(error) { }
-
-  std::string msg() const {
-    std::stringstream ss;
-    ss << "Error when reading pem file '" << filename << "': " << error << "\n";
-    return ss.str();
-  }
-
-  const char *what() const noexcept override {
-    return error.c_str();
-  }
-
- private:
-  std::string filename;
-  std::string error;
-};
-
-std::string read_pem_file(const std::string &filename) {
-  std::ifstream fs(filename, std::ios::in);
-  if (!fs) {
-    throw read_pem_exception(filename, "file cannot be opened");
-  }
-  return std::string((std::istreambuf_iterator<char>(fs)),
-                     std::istreambuf_iterator<char>());
-}
-
-}  // namespace
 
 int
 main(int argc, char* argv[]) {
@@ -233,17 +201,17 @@ main(int argc, char* argv[]) {
   try {
     if (grpc_server_ssl) {
       if (grpc_server_cacert != "") {
-        ssl_options->pem_root_certs = read_pem_file(grpc_server_cacert);
+        ssl_options->pem_root_certs = bm::read_pem_file(grpc_server_cacert);
       }
       if (grpc_server_cert != "") {
-        ssl_options->pem_cert_chain = read_pem_file(grpc_server_cert);
+        ssl_options->pem_cert_chain = bm::read_pem_file(grpc_server_cert);
       }
       if (grpc_server_key != "") {
-        ssl_options->pem_private_key = read_pem_file(grpc_server_key);
+        ssl_options->pem_private_key = bm::read_pem_file(grpc_server_key);
       }
       ssl_options->with_client_auth = grpc_server_with_client_auth;
     }
-  } catch (const read_pem_exception &e) {
+  } catch (const bm::read_pem_exception &e) {
     std::cerr << e.msg();
     std::exit(1);
   }

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -17,6 +17,7 @@ run_cpplint $ROOT_DIR/src/bm_sim src
 run_cpplint $ROOT_DIR/src/bm_apps src
 run_cpplint $ROOT_DIR/include/bm/bm_sim include
 run_cpplint $ROOT_DIR/include/bm/bm_apps include
+run_cpplint $ROOT_DIR/include/bm/bm_grpc include
 run_cpplint $ROOT_DIR/targets/simple_switch targets
 run_cpplint $ROOT_DIR/targets/l2_switch targets
 run_cpplint $ROOT_DIR/targets/simple_router targets


### PR DESCRIPTION
This pull request moves `read_pem_file()` and `read_pem_exception` under `include/` to enable reusability between targets. In particular, this change would allow to reuse this code with the psa_switch target.