### PR TITLE
Add Makefile for services

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ if COND_THRIFT
 endif
 
 if COND_PI
-    MAYBE_PI = PI
+    MAYBE_PI = PI services
 endif
 
 # simple_switch depends on libbmpi so PI needs to appear first

--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,45 @@ AC_TYPE_SIZE_T
 AC_TYPE_UINT64_T
 AC_LANG_POP(C++)
 
+AS_IF([test "$want_pi" = yes], [
+	AC_PATH_PROG([PROTOC], [protoc], [])
+	AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found])])
+
+	PKG_CHECK_MODULES([PROTOBUF], [protobuf >= 3.0.0])
+	AC_SUBST([PROTOBUF_CFLAGS])
+	AC_SUBST([PROTOBUF_LIBS])
+
+	PKG_CHECK_MODULES([GRPC], [grpc++ >= 1.3.0 grpc >= 3.0.0])
+	AC_SUBST([GRPC_CFLAGS])
+	AC_SUBST([GRPC_LIBS])
+
+	AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
+	AS_IF([test "x$GRPC_CPP_PLUGIN" = x], [
+		AC_MSG_ERROR([grpc_cpp_plugin not found])
+	])
+
+	AS_IF([test "$PYTHON" != :], [
+		AC_PATH_PROG([GRPC_PY_PLUGIN], [grpc_python_plugin])
+		AS_IF([test "x$GRPC_PY_PLUGIN" = x], [
+			AC_MSG_WARN([grpc_python_plugin not found, Python code won't be generated])
+		])
+	])
+	AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
+
+	AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
+	AS_IF([test "x$GRPC_CPP_PLUGIN" = x], [
+		AC_MSG_ERROR([grpc_cpp_plugin not found])
+	])
+
+	AS_IF([test "$PYTHON" != :], [
+		AC_PATH_PROG([GRPC_PY_PLUGIN], [grpc_python_plugin])
+		AS_IF([test "x$GRPC_PY_PLUGIN" = x], [
+			AC_MSG_WARN([grpc_python_plugin not found, Python code won't be generated])
+		])
+	])
+	AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
+])
+
 # Generate makefiles
 AC_CONFIG_FILES([Makefile
 		thrift_src/Makefile
@@ -281,14 +320,15 @@ AC_CONFIG_FILES([Makefile
 		third_party/gtest/Makefile
 		third_party/jsoncpp/Makefile
 		third_party/spdlog/Makefile
-                include/Makefile
-                src/Makefile
-                src/bf_lpm_trie/Makefile
+		include/Makefile
+		src/Makefile
+		src/bf_lpm_trie/Makefile
 		src/bm_sim/Makefile
 		src/bm_runtime/Makefile
 		src/BMI/Makefile
 		src/bm_apps/Makefile
 		src/bm_apps/examples/Makefile
+		services/Makefile
 		targets/Makefile
 		targets/simple_router/Makefile
 		targets/l2_switch/Makefile
@@ -300,13 +340,13 @@ AC_CONFIG_FILES([Makefile
 		targets/psa_switch/tests/Makefile
 		tests/Makefile
 		tests/stress_tests/Makefile
-                tools/Makefile
-                pdfixed/Makefile
-                pdfixed/include/Makefile
-                PI/Makefile])
+		tools/Makefile
+		pdfixed/Makefile
+		pdfixed/include/Makefile
+		PI/Makefile])
 
 AS_IF([test "$want_pi" = yes], [
-  AC_CONFIG_SUBDIRS([targets/simple_switch_grpc])
+	AC_CONFIG_SUBDIRS([targets/simple_switch_grpc])
 ])
 
 # Generate other files

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -1,0 +1,83 @@
+ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
+
+lib_LTLIBRARIES = libbm_grpc_dataplane.la
+
+EXTRA_DIST = p4/bm/dataplane_interface.proto
+
+proto = $(abs_srcdir)/p4/bm/dataplane_interface.proto
+
+PROTOFLAGS = -I$(abs_srcdir)/
+
+proto_cpp_files = \
+cpp_out/p4/bm/dataplane_interface.pb.cc \
+cpp_out/p4/bm/dataplane_interface.pb.h
+
+proto_grpc_files = \
+grpc_out/p4/bm/dataplane_interface.grpc.pb.cc \
+grpc_out/p4/bm/dataplane_interface.grpc.pb.h
+
+includep4bmdir = $(includedir)/p4/bm/
+nodist_includep4bm_HEADERS = \
+cpp_out/p4/bm/dataplane_interface.pb.h \
+grpc_out/p4/bm/dataplane_interface.grpc.pb.h
+
+BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
+
+if HAVE_GRPC_PY_PLUGIN
+p4bmpydir = $(pythondir)/p4/bm
+nodist_p4bmpy_PYTHON = \
+py_out/p4/bm/dataplane_interface_pb2.py \
+py_out/p4/bm/__init__.py
+
+BUILT_SOURCES += \
+$(nodist_p4bmpy_PYTHON)
+endif
+
+# See http://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
+
+proto_files.ts: $(proto)
+	@rm -f proto_files.tmp
+	@touch proto_files.tmp
+	@mkdir -p $(builddir)/cpp_out
+	@mkdir -p $(builddir)/grpc_out
+	$(PROTOC) $^ --cpp_out $(builddir)/cpp_out $(PROTOFLAGS)
+	$(PROTOC) $^ --grpc_out $(builddir)/grpc_out --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN) $(PROTOFLAGS)
+if HAVE_GRPC_PY_PLUGIN
+	@mkdir -p $(builddir)/py_out
+# With the Python plugin, it seems that I need to use a single command for proto
+# + grpc and that the output directory needs to be the same (because the grpc
+# plugin inserts code into the proto-generated files). But maybe I am just using
+# an old version of the Python plugin.
+	$(PROTOC) $^ --python_out $(builddir)/py_out $(PROTOFLAGS) --grpc_out $(builddir)/py_out --plugin=protoc-gen-grpc=$(GRPC_PY_PLUGIN)
+	@touch $(builddir)/py_out/p4/bm/__init__.py
+endif
+	@mv -f proto_files.tmp $@
+
+$(BUILT_SOURCES): proto_files.ts
+## Recover from the removal of $@
+	@if test -f $@; then :; else \
+		trap 'rm -rf proto_files.lock proto_files.ts' 1 2 13 15; \
+## mkdir is a portable test-and-set
+	if mkdir proto_files.lock 2>/dev/null; then \
+## This code is being executed by the first process.
+		rm -f proto_files.ts; \
+		$(MAKE) $(AM_MAKEFLAGS) proto_files.ts; \
+		result=$$?; rm -rf proto_files.lock; exit $$result; \
+	else \
+## This code is being executed by the follower processes.
+## Wait until the first process is done.
+		while test -d proto_files.lock; do sleep 1; done; \
+## Succeed if and only if the first process succeeded.
+			test -f proto_files.ts; \
+		fi; \
+	fi
+
+AM_CPPFLAGS += -Icpp_out -Igrpc_out \
+-I$(builddir)/cpp_out \
+-I$(builddir)/grpc_out
+
+nodist_libbm_grpc_dataplane_la_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
+# no warnings or Werror for auto-generated sources
+libbm_grpc_dataplane_la_CXXFLAGS =
+
+CLEANFILES = $(BUILT_SOURCES) proto_files.ts

--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -30,7 +30,6 @@ simple_switch_grpc_LDFLAGS = \
 -Wl,--no-as-needed,-lgrpc++_reflection,--as-needed \
 -rdynamic
 
-lib_LTLIBRARIES = libbm_grpc_dataplane.la
 noinst_LTLIBRARIES = libsimple_switch_grpc.la
 
 libsimple_switch_grpc_la_SOURCES = \
@@ -43,7 +42,7 @@ endif
 libsimple_switch_grpc_la_LIBADD = \
 $(builddir)/../simple_switch/libsimpleswitch.la \
 $(builddir)/../../PI/libbmpi.la \
-libbm_grpc_dataplane.la
+$(builddir)/../../services/libbm_grpc_dataplane.la
 
 if WITH_THRIFT
 libsimple_switch_grpc_la_LIBADD += \
@@ -56,83 +55,6 @@ libsimple_switch_grpc_la_LIBADD += \
 -lpifeproto -lpigrpcserver -lpi -lpip4info \
 $(GRPC_LIBS) $(PROTOBUF_LIBS)
 
-# dataplane_interface.proto
-
-EXTRA_DIST = ../../services/p4/bm/dataplane_interface.proto
-
-proto = $(abs_srcdir)/../../services/p4/bm/dataplane_interface.proto
-
-PROTOFLAGS = -I$(abs_srcdir)/../../services
-
-proto_cpp_files = \
-../../services/cpp_out/p4/bm/dataplane_interface.pb.cc \
-../../services/cpp_out/p4/bm/dataplane_interface.pb.h
-
-proto_grpc_files = \
-../../services/grpc_out/p4/bm/dataplane_interface.grpc.pb.cc \
-../../services/grpc_out/p4/bm/dataplane_interface.grpc.pb.h
-
-includep4bmdir = $(includedir)/p4/bm/
-nodist_includep4bm_HEADERS = \
-../../services/cpp_out/p4/bm/dataplane_interface.pb.h \
-../../services/grpc_out/p4/bm/dataplane_interface.grpc.pb.h
-
-BUILT_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
-
-if HAVE_GRPC_PY_PLUGIN
-p4bmpydir = $(pythondir)/p4/bm
-nodist_p4bmpy_PYTHON = \
-../../services/py_out/p4/bm/dataplane_interface_pb2.py \
-../../services/py_out/p4/bm/__init__.py
-
-BUILT_SOURCES += \
-$(nodist_p4bmpy_PYTHON)
-endif
-
-# See http://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html
-
-proto_files.ts: $(proto)
-	@rm -f proto_files.tmp
-	@touch proto_files.tmp
-	@mkdir -p $(builddir)/../../services/cpp_out
-	@mkdir -p $(builddir)/../../services/grpc_out
-	$(PROTOC) $^ --cpp_out $(builddir)/../../services/cpp_out $(PROTOFLAGS)
-	$(PROTOC) $^ --grpc_out $(builddir)/../../services/grpc_out --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN) $(PROTOFLAGS)
-if HAVE_GRPC_PY_PLUGIN
-	@mkdir -p $(builddir)/../../services/py_out
-# With the Python plugin, it seems that I need to use a single command for proto
-# + grpc and that the output directory needs to be the same (because the grpc
-# plugin inserts code into the proto-generated files). But maybe I am just using
-# an old version of the Python plugin.
-	$(PROTOC) $^ --python_out $(builddir)/../../services/py_out $(PROTOFLAGS) --grpc_out $(builddir)/../../services/py_out --plugin=protoc-gen-grpc=$(GRPC_PY_PLUGIN)
-	@touch $(builddir)/../../services/py_out/p4/bm/__init__.py
-endif
-	@mv -f proto_files.tmp $@
-
-$(BUILT_SOURCES): proto_files.ts
-## Recover from the removal of $@
-	@if test -f $@; then :; else \
-	  trap 'rm -rf proto_files.lock proto_files.ts' 1 2 13 15; \
-## mkdir is a portable test-and-set
-	if mkdir proto_files.lock 2>/dev/null; then \
-## This code is being executed by the first process.
-	  rm -f proto_files.ts; \
-	  $(MAKE) $(AM_MAKEFLAGS) proto_files.ts; \
-	  result=$$?; rm -rf proto_files.lock; exit $$result; \
-	else \
-## This code is being executed by the follower processes.
-## Wait until the first process is done.
-	  while test -d proto_files.lock; do sleep 1; done; \
-## Succeed if and only if the first process succeeded.
-	    test -f proto_files.ts; \
-	  fi; \
-	fi
-
-AM_CPPFLAGS += -Icpp_out -Igrpc_out \
--I$(builddir)/../../services/cpp_out -I$(builddir)/../../services/grpc_out
-
-nodist_libbm_grpc_dataplane_la_SOURCES = $(proto_cpp_files) $(proto_grpc_files)
-# no warnings or Werror for auto-generated sources
-libbm_grpc_dataplane_la_CXXFLAGS =
-
-CLEANFILES = $(BUILT_SOURCES) proto_files.ts
+AM_CPPFLAGS += \
+ -I$(builddir)/../../services/cpp_out \
+ -I$(builddir)/../../services/grpc_out

--- a/targets/simple_switch_grpc/configure.ac
+++ b/targets/simple_switch_grpc/configure.ac
@@ -51,21 +51,6 @@ AC_SUBST([GRPC_LIBS])
 AC_CHECK_HEADER([boost/optional.hpp], [],
                 [AC_MSG_ERROR([Boost optional header not found])])
 
-AC_PATH_PROG([PROTOC], [protoc], [])
-AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found])])
-
-AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
-AS_IF([test "x$GRPC_CPP_PLUGIN" = x], [
-    AC_MSG_ERROR([grpc_cpp_plugin not found])
-])
-AS_IF([test "$PYTHON" != :], [
-    AC_PATH_PROG([GRPC_PY_PLUGIN], [grpc_python_plugin])
-    AS_IF([test "x$GRPC_PY_PLUGIN" = x], [
-        AC_MSG_WARN([grpc_python_plugin not found, Python code won't be generated])
-    ])
-])
-AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
-
 AC_ARG_WITH([sysrepo],
     AS_HELP_STRING([--with-sysrepo],
                    [Use sysrepo gNMI service implementation @<:@default=no@:>@]),


### PR DESCRIPTION
This pull request moves the automake definitions used to build `dataplane_interface.proto` from `simple_switch_grpc` into `services`.

This change allows to compile the proto files in a target independent and to reuse the dataplane_interface in other targets.