### PR TITLE
Update Dockerfile.noPI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: antrea-io/has-changes@v1
@@ -24,7 +24,7 @@ jobs:
   test:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -51,3 +51,16 @@ jobs:
     - name: Check style
       run: |
         ./tools/check_style.sh
+
+  test-no-pi:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Build Dockerfile.noPI image
+      run: docker build -t bm-no-pi --build-arg IMAGE_TYPE=test -f Dockerfile.noPI .
+    - name: Run tests
+      run: docker run --rm -w /behavioral-model bm-no-pi /bin/bash -c "make check -j$(nproc)"

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -3,6 +3,12 @@ LABEL maintainer="P4 Developers <p4-dev@lists.p4.org>"
 LABEL description="This Docker image does not have any dependency on PI or P4 \
 Runtime, it only builds bmv2 simple_switch."
 
+# Select the type of image we're building. Use `build` for a normal build, which
+# is optimized for image size. Use `test` if this image will be used for
+# testing; in this case, the source code and build-only dependencies will not be
+# removed from the image.
+ARG IMAGE_TYPE=build
+
 ENV BM_DEPS automake \
             build-essential \
             pkg-config \
@@ -34,7 +40,10 @@ RUN apt-get update -qq && \
     make -j$(nproc) && \
     make install-strip && \
     ldconfig && \
-    apt-get purge -qq $BM_DEPS && \
-    apt-get autoremove --purge -qq && \
-    rm -rf /behavioral-model /var/cache/apt/* /var/lib/apt/lists/* && \
-    echo 'Build image ready'
+    (test "$IMAGE_TYPE" = "build" && \
+        apt-get purge -qq $BM_DEPS && \
+        apt-get autoremove --purge -qq && \
+        rm -rf /behavioral-model /var/cache/apt/* /var/lib/apt/lists/* && \
+        echo 'Build image ready') || \
+    (test "$IMAGE_TYPE" = "test" && \
+      echo 'Test image ready')

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -5,6 +5,7 @@ Runtime, it only builds bmv2 simple_switch."
 
 ENV BM_DEPS automake \
             build-essential \
+            pkg-config \
             curl \
             git \
             libgmp-dev \

--- a/configure.ac
+++ b/configure.ac
@@ -297,21 +297,9 @@ AS_IF([test "$want_pi" = yes], [
 			AC_MSG_WARN([grpc_python_plugin not found, Python code won't be generated])
 		])
 	])
-	AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
-
-	AC_PATH_PROG([GRPC_CPP_PLUGIN], [grpc_cpp_plugin])
-	AS_IF([test "x$GRPC_CPP_PLUGIN" = x], [
-		AC_MSG_ERROR([grpc_cpp_plugin not found])
-	])
-
-	AS_IF([test "$PYTHON" != :], [
-		AC_PATH_PROG([GRPC_PY_PLUGIN], [grpc_python_plugin])
-		AS_IF([test "x$GRPC_PY_PLUGIN" = x], [
-			AC_MSG_WARN([grpc_python_plugin not found, Python code won't be generated])
-		])
-	])
-	AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
 ])
+
+AM_CONDITIONAL([HAVE_GRPC_PY_PLUGIN], [test "x$GRPC_PY_PLUGIN" != x])
 
 # Generate makefiles
 AC_CONFIG_FILES([Makefile


### PR DESCRIPTION
This pull request removes a few redundant lines in `configure.ac` and moves the declaration for the `HAVE_GRPC_PY_PLUGIN` conditional outside the test for `--with-pi` to ensure that it is always defined. In addition, the `pkg-config` package has been added as dependency in Dockerfile.noPI to enable support for the `PKG_CHECK_MODULES` macro. This fixes the following error:

```
./configure: line 14028: syntax error near unexpected token `PROTOBUF,'
./configure: line 14028: `	PKG_CHECK_MODULES(PROTOBUF, protobuf >= 3.0.0)'
```