### PR TITLE
ci: Upload Doxygen documentation only from p4lang

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   upload-doc:
+    if: ${{ github.repository == 'p4lang/behavioral-model' && github.ref == 'refs/heads/main' }}
     name: Upload bmv2.org Doxygen documentation to S3
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Run Doxygen


### PR DESCRIPTION
The GitHub action used to upload the Doxygen documentation should run only in the p4lang/behavioral-model repository.