### PR TITLE
Add lifecycle management for PRs and issues

### DIFF
--- a/.github/workflows/lifecycle_management.yml
+++ b/.github/workflows/lifecycle_management.yml
@@ -1,0 +1,34 @@
+name: "Issues and PRs lifecycle management"
+on:
+  schedule:
+    # every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    if: github.repository == 'p4lang/behavioral-model'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment, or this will be closed in 180 days'
+          stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment, or this will be closed in 180 days'
+          stale-issue-label: 'lifecycle/stale'
+          stale-pr-label: 'lifecycle/stale'
+          days-before-stale: 180
+          days-before-close: 180
+          exempt-issue-labels: 'lifecycle/frozen'
+          exempt-pr-labels: 'lifecycle/frozen'
+          exempt-assignees: 'antoninbas'
+          remove-stale-when-updated: true
+          debug-only: false
+          operations-per-run: 200
+          start-date: '2020-01-01T00:00:00Z'
+  skip:
+    if: github.repository != 'p4lang/behavioral-model'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip
+        run: |
+          echo "Skipping lifecyle management because workflow cannot be run from fork"


### PR DESCRIPTION
PRs and issues will be marked as stale after 6 months, and closed
automatically after another 6 months.

Signed-off-by: Antonin Bas <abas@vmware.com>