### PR TITLE
Enable P4Runtime support for psa_switch

### DIFF
--- a/PI/Makefile.am
+++ b/PI/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 if COND_TARGETS
-AM_CPPFLAGS += -I$(top_srcdir)/targets/simple_switch -DWITH_SIMPLE_SWITCH
+AM_CPPFLAGS += -DWITH_BASE_SWITCH
 endif
 
 libbmpi_la_SOURCES = \

--- a/PI/src/pi_clone_imp.cpp
+++ b/PI/src/pi_clone_imp.cpp
@@ -26,8 +26,8 @@
 
 // TODO(antonin): it would probably make more sense to move this code to
 // targets/simple_switch, but for now it will have to do.
-#if WITH_SIMPLE_SWITCH
-#include "simple_switch.h"
+#if WITH_BASE_SWITCH
+#include "bm/bm_sim/switch.h"
 
 #include "common.h"
 
@@ -40,9 +40,9 @@ pi_status_t _pi_clone_session_set(
     const pi_clone_session_config_t *clone_session_config) {
   _BM_UNUSED(session_handle);
   _BM_UNUSED(dev_tgt);
-  auto *sswitch = dynamic_cast<SimpleSwitch *>(pibmv2::switch_);
+  auto *sswitch = dynamic_cast<bm::BaseSwitch *>(pibmv2::switch_);
   if (sswitch == nullptr) return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
-  SimpleSwitch::MirroringSessionConfig config = {};
+  bm::BaseSwitch::MirroringSessionConfig config = {};
   if (clone_session_config->direction != PI_CLONE_DIRECTION_BOTH)
     return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
   config.egress_port = clone_session_config->eg_port;
@@ -63,7 +63,7 @@ pi_status_t _pi_clone_session_reset(
     pi_clone_session_id_t clone_session_id) {
   _BM_UNUSED(session_handle);
   _BM_UNUSED(dev_tgt);
-  auto *sswitch = dynamic_cast<SimpleSwitch *>(pibmv2::switch_);
+  auto *sswitch = dynamic_cast<bm::BaseSwitch *>(pibmv2::switch_);
   if (sswitch == nullptr) return PI_STATUS_NOT_IMPLEMENTED_BY_TARGET;
   auto success = sswitch->mirroring_delete_session(clone_session_id);
   return success ? PI_STATUS_SUCCESS : PI_STATUS_TARGET_ERROR;
@@ -71,7 +71,7 @@ pi_status_t _pi_clone_session_reset(
 
 }
 
-#else  // WITH_SIMPLE_SWITCH
+#else  // WITH_BASE_SWITCH
 
 extern "C" {
 
@@ -99,4 +99,4 @@ pi_status_t _pi_clone_session_reset(
 
 }
 
-#endif  // WITH_SIMPLE_SWITCH
+#endif  // WITH_BASE_SWITCH

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -98,4 +98,5 @@ nobase_include_HEADERS += \
 bm/bm_sim/core/primitives.h
 
 nobase_include_HEADERS += \
-bm/bm_grpc/pem.h
+bm/bm_grpc/pem.h \
+bm/grpc/ssl_options.h

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -98,6 +98,7 @@ class CopyIdGenerator {
 class Packet final {
   friend class SwitchWContexts;
   friend class Switch;
+  friend class BaseSwitch;
 
  public:
   using clock = std::chrono::system_clock;

--- a/include/bm/bm_sim/switch.h
+++ b/include/bm/bm_sim/switch.h
@@ -971,6 +971,8 @@ class SwitchWContexts : public DevMgr, public RuntimeInterface {
 //! Context. This is the base class for the standard simple switch target
 //! implementation.
 class Switch : public SwitchWContexts {
+  friend class BaseSwitch;
+
  public:
   //! See SwitchWContexts::SwitchWContexts()
   explicit Switch(bool enable_swap = false);
@@ -1086,6 +1088,37 @@ class Switch : public SwitchWContexts {
   std::shared_ptr<T> get_component() {
     return get_cxt_component<T>(0);
   }
+};
+
+//! This is the base class for the Simple Switch and PSA Switch
+//! target implementations.
+class BaseSwitch : public Switch {
+ public:
+  using TransmitFn = std::function<void(port_t, packet_id_t,
+                                        const char *, int)>;
+
+  void set_transmit_fn(TransmitFn fn) {
+    my_transmit_fn = std::move(fn);
+  }
+
+  // returns the packet id of most recently received packet. Not thread-safe.
+  static packet_id_t get_packet_id() {
+    return packet_id - 1;
+  }
+
+  struct MirroringSessionConfig {
+    port_t egress_port;
+    bool egress_port_valid;
+    unsigned int mgid;
+    bool mgid_valid;
+  };
+
+  BaseSwitch(bool enable_swap = false) : Switch(enable_swap)
+    { }
+
+ protected:
+    TransmitFn my_transmit_fn;
+    static packet_id_t packet_id;
 };
 
 }  // namespace bm

--- a/include/bm/grpc/ssl_options.h
+++ b/include/bm/grpc/ssl_options.h
@@ -1,0 +1,28 @@
+/* Copyright 2022 University of Oxford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BM_GRPC__SSL_OPTIONS_H_
+#define BM_GRPC__SSL_OPTIONS_H_
+
+#include <string>
+
+struct SSLOptions {
+  std::string pem_root_certs;
+  std::string pem_private_key;
+  std::string pem_cert_chain;
+  bool with_client_auth;
+};
+
+#endif // BM_GRPC__SSL_OPTIONS_H_

--- a/services/Makefile.am
+++ b/services/Makefile.am
@@ -2,7 +2,10 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 lib_LTLIBRARIES = libbm_grpc_dataplane.la
 
-EXTRA_DIST = p4/bm/dataplane_interface.proto
+EXTRA_DIST = \
+p4/bm/dataplane_interface.proto \
+switch_runner/switch_runner.cpp \
+switch_runner/switch_runner.h
 
 proto = $(abs_srcdir)/p4/bm/dataplane_interface.proto
 

--- a/services/switch_runner/switch_runner.cpp
+++ b/services/switch_runner/switch_runner.cpp
@@ -23,6 +23,7 @@
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/transport.h>
+#include <bm/bm_sim/packet.h>
 
 #include <bm/PI/pi.h>
 
@@ -46,28 +47,15 @@
 #include <unordered_map>
 #include <utility>
 
-#include "simple_switch.h"
-
 #include "switch_runner.h"
 
-#ifdef WITH_SYSREPO
-#include "switch_sysrepo.h"
-#endif  // WITH_SYSREPO
-
-#ifdef WITH_THRIFT
-#include <bm/SimpleSwitch.h>
-#include <bm/bm_runtime/bm_runtime.h>
-
-namespace sswitch_runtime {
-    shared_ptr<SimpleSwitchIf> get_handler(SimpleSwitch *sw);
-}  // namespace sswitch_runtime
-#endif  // WITH_THRIFT
-
-namespace sswitch_grpc {
+namespace switch_runner {
 
 using grpc::ServerContext;
 using grpc::Status;
 using grpc::StatusCode;
+
+using bm::packet_id_t;
 
 using ServerReaderWriter = grpc::ServerReaderWriter<
   p4::bm::PacketStreamResponse, p4::bm::PacketStreamRequest>;
@@ -139,7 +127,7 @@ class DataplaneInterfaceServiceImpl
         if (request.id() != 0) {
           // grpc service has a single thread. get_packet_id() will return the
           // packet id of the newly received packet.
-          packet_id_translation[SimpleSwitch::get_packet_id()] = request.id();
+          packet_id_translation[bm::BaseSwitch::get_packet_id()] = request.id();
         }
         // PortStats is a POD struct; it will be value-initialized to 0s if the
         // port key is not found in the map.
@@ -148,7 +136,7 @@ class DataplaneInterfaceServiceImpl
         stats.in_octets += packet.size();
       }
     }
-    auto &runner = sswitch_grpc::SimpleSwitchGrpcRunner::get_instance();
+    auto &runner = switch_runner::SwitchGrpcRunner::get_instance();
     runner.block_until_all_packets_processed();
     Lock lock(mutex);
     active = false;
@@ -493,28 +481,31 @@ class NotificationsCapture : public bm::TransportIface {
   bm::SwitchWContexts *sw;
 };
 
-
-SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(
-    bool enable_swap,
+SwitchGrpcRunner::SwitchGrpcRunner(
+    std::shared_ptr<bm::BaseSwitch> switch_target,
     std::string grpc_server_addr,
     bm::DevMgrIface::port_t cpu_port,
     std::string dp_grpc_server_addr,
-    bm::DevMgrIface::port_t drop_port,
     std::shared_ptr<SSLOptions> ssl_options,
     size_t nb_queues_per_port)
-    : simple_switch(new SimpleSwitch(enable_swap, drop_port,
-                                     nb_queues_per_port)),
-      grpc_server_addr(grpc_server_addr), cpu_port(cpu_port),
+    : switch_target(switch_target),
+      grpc_server_addr(grpc_server_addr),
+      cpu_port(cpu_port),
       dp_grpc_server_addr(dp_grpc_server_addr),
       dp_service(nullptr),
       dp_grpc_server(nullptr),
-      ssl_options(ssl_options) {
+      ssl_options(ssl_options),
+      nb_queues_per_port(nb_queues_per_port)
+{
   PIGrpcServerInit();
 }
 
 int
-SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
+SwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
   std::unique_ptr<bm::DevMgrIface> my_dev_mgr = nullptr;
+  if (nb_queues_per_port <= 0) {
+    nb_queues_per_port = default_nb_queues_per_port;
+  }
   if (!dp_grpc_server_addr.empty()) {
     dp_service = new DataplaneInterfaceServiceImpl(parser.device_id);
     grpc::ServerBuilder builder;
@@ -531,11 +522,6 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
     dp_grpc_server = builder.BuildAndStart();
     my_dev_mgr.reset(dp_service);
   }
-
-#ifdef WITH_SYSREPO
-      sysrepo_driver = std::unique_ptr<SysrepoDriver>(new SysrepoDriver(
-          parser.device_id, simple_switch.get()));
-#endif  // WITH_SYSREPO
 
   // Even when using gNMI to manage ports, it is convenient to be able to use
   // the --interface / -i command-line option. However we have to "intercept"
@@ -557,8 +543,8 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
 #endif  // WITH_SYSREPO
 
   auto my_transport = std::make_shared<NotificationsCapture>(
-      simple_switch.get());
-  int status = simple_switch->init_from_options_parser(
+      switch_target.get());
+  int status = switch_target->init_from_options_parser(
       *parser_ptr, std::move(my_transport), std::move(my_dev_mgr));
   if (status != 0) return status;
 
@@ -571,10 +557,10 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
   // PortMonitor saves the CB by reference so we cannot use this code; it seems
   // that at this stage we do not need the CB any way.
   // using PortStatus = bm::DevMgrIface::PortStatus;
-  // auto port_cb = std::bind(&SimpleSwitchGrpcRunner::port_status_cb, this,
+  // auto port_cb = std::bind(&SwitchGrpcRunner::port_status_cb, this,
   //                          std::placeholders::_1, std::placeholders::_2);
-  // simple_switch->register_status_cb(PortStatus::PORT_ADDED, port_cb);
-  // simple_switch->register_status_cb(PortStatus::PORT_REMOVED, port_cb);
+  // switch_target->register_status_cb(PortStatus::PORT_ADDED, port_cb);
+  // switch_target->register_status_cb(PortStatus::PORT_REMOVED, port_cb);
 
   // check if CPU port number is also used by --interface
   // TODO(antonin): ports added dynamically?
@@ -589,7 +575,7 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
                             packet_id_t pkt_id, const char *buf, int len) {
     if (cpu_port > 0 && port_num == cpu_port) {
       BMLOG_DEBUG("Transmitting packet-in");
-      auto status = pi_packetin_receive(simple_switch->get_device_id(),
+      auto status = pi_packetin_receive(switch_target->get_device_id(),
                                         buf, static_cast<size_t>(len));
       if (status != PI_STATUS_SUCCESS)
         bm::Logger::get()->error("Error when transmitting packet-in");
@@ -598,12 +584,12 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
       // directly
       dp_service->my_transmit_fn(port_num, pkt_id, buf, len);
     } else {
-      simple_switch->transmit_fn(port_num, buf, len);
+      switch_target->transmit_fn(port_num, buf, len);
     }
   };
-  simple_switch->set_transmit_fn(transmit_fn);
+  switch_target->set_transmit_fn(transmit_fn);
 
-  bm::pi::register_switch(simple_switch.get(), cpu_port);
+  bm::pi::register_switch(switch_target.get(), cpu_port);
 
   {
     using pi::fe::proto::LogWriterIface;
@@ -645,66 +631,44 @@ SimpleSwitchGrpcRunner::init_and_start(const bm::OptionsParser &parser) {
                     nullptr,
                     (ssl_options != nullptr) ? &pi_ssl_options : nullptr);
 
-#ifdef WITH_SYSREPO
-  if (!sysrepo_driver->start()) return 1;
-  for (const auto &p : saved_interfaces)
-    sysrepo_driver->add_iface(p.first, p.second);
-#endif  // WITH_SYSREPO
-
-#ifdef WITH_THRIFT
-  int thrift_port = simple_switch->get_runtime_port();
-  bm_runtime::start_server(simple_switch.get(), thrift_port);
-  using ::sswitch_runtime::SimpleSwitchIf;
-  using ::sswitch_runtime::SimpleSwitchProcessor;
-  bm_runtime::add_service<SimpleSwitchIf, SimpleSwitchProcessor>(
-          "simple_switch", sswitch_runtime::get_handler(simple_switch.get()));
-#else
-  if (parser.option_was_provided("thrift-port")) {
-    bm::Logger::get()->warn(
-        "You used the '--thrift-port' command-line option, but this target was "
-        "compiled without Thrift support. You can enable Thrift support (not "
-        "recommended) by providing '--with-thrift' to configure.");
-  }
-#endif  // WITH_THRIFT
-
-  simple_switch->start_and_return();
+  switch_target->start_and_return();
 
   return 0;
 }
 
 void
-SimpleSwitchGrpcRunner::wait() {
+SwitchGrpcRunner::wait() {
   PIGrpcServerWait();
 }
 
 void
-SimpleSwitchGrpcRunner::shutdown() {
+SwitchGrpcRunner::shutdown() {
   if (!dp_grpc_server_addr.empty()) dp_grpc_server->Shutdown();
   PIGrpcServerShutdown();
 }
 
 void
-SimpleSwitchGrpcRunner::block_until_all_packets_processed() {
-  simple_switch->block_until_no_more_packets();
+SwitchGrpcRunner::block_until_all_packets_processed() {
+  switch_target->block_until_no_more_packets();
 }
 
 bool
-SimpleSwitchGrpcRunner::is_dp_service_active() {
+SwitchGrpcRunner::is_dp_service_active() {
   if (dp_service != nullptr) {
     return dp_service->get_packet_stream_status();
   }
   return false;
 }
 
-SimpleSwitchGrpcRunner::~SimpleSwitchGrpcRunner() {
+SwitchGrpcRunner::~SwitchGrpcRunner() {
   PIGrpcServerCleanup();
 }
 
 void
-SimpleSwitchGrpcRunner::port_status_cb(bm::DevMgrIface::port_t port,
+SwitchGrpcRunner::port_status_cb(bm::DevMgrIface::port_t port,
     const bm::DevMgrIface::PortStatus port_status) {
   _BM_UNUSED(port);
   _BM_UNUSED(port_status);
 }
 
-}  // namespace sswitch_grpc
+} // namespace switch_runner

--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -2,6 +2,15 @@ if COND_NANOMSG
 MAYBE_TESTS = tests
 endif
 
+if COND_PI
+AM_CPPFLAGS += \
+-DWITH_PI \
+-I$(top_srcdir)/PI
+PI_LIB = $(top_builddir)/PI/libbmpi.la
+else
+PI_LIB =
+endif  # COND_PI
+
 SUBDIRS = . $(MAYBE_TESTS)
 
 THRIFT_IDL = $(srcdir)/thrift/psa_switch.thrift
@@ -23,6 +32,28 @@ $(top_builddir)/src/bf_lpm_trie/libbflpmtrie.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
 -lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+
+if COND_PI
+
+AM_CPPFLAGS += \
+-I$(builddir)/../../services/cpp_out \
+-I$(builddir)/../../services/grpc_out \
+-I$(builddir)/../../services/switch_runner
+
+libpsaswitch_la_SOURCES += \
+../../services/switch_runner/switch_runner.cpp \
+../../services/switch_runner/switch_runner.h
+
+libpsaswitch_la_LIBADD += \
+$(builddir)/../../PI/libbmpi.la \
+$(builddir)/../../services/libbm_grpc_dataplane.la
+
+libpsaswitch_la_LIBADD += \
+-lpifeproto -lpigrpcserver -lpi -lpip4info \
+$(GRPC_LIBS) $(PROTOBUF_LIBS)
+
+endif  # COND_PI
+
 
 if COND_THRIFT
 

--- a/targets/psa_switch/main.cpp
+++ b/targets/psa_switch/main.cpp
@@ -25,19 +25,16 @@
 
 #include <bm/PsaSwitch.h>
 #include <bm/bm_runtime/bm_runtime.h>
+#include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/target_parser.h>
+
+#include "psa_switch.h"
 
 #ifdef WITH_PI
 #include <bm/bm_grpc/pem.h>
 #include <bm/grpc/ssl_options.h>
+#include "switch_runner.h"
 #endif
-
-#include "psa_switch.h"
-
-namespace {
-bm::psa::PsaSwitch *psa_switch;
-bm::TargetParserBasic *psa_switch_parser;
-}  // namespace
 
 namespace pswitch_runtime {
 shared_ptr<PsaSwitchIf> get_handler(bm::psa::PsaSwitch *sw);
@@ -46,19 +43,19 @@ shared_ptr<PsaSwitchIf> get_handler(bm::psa::PsaSwitch *sw);
 int
 main(int argc, char* argv[]) {
   using bm::psa::PsaSwitch;
-  psa_switch = new PsaSwitch();
-  psa_switch_parser = new bm::TargetParserBasic();
-  psa_switch_parser->add_flag_option(
-    "enable-swap",
-    "enable JSON swapping at runtime"
-  );
-  psa_switch_parser->add_uint_option(
+
+  bm::TargetParserBasicWithDynModules psa_switch_parser;
+  psa_switch_parser.add_flag_option(
+    "disable-swap",
+    "enable JSON swapping at runtime");
+  psa_switch_parser.add_uint_option(
     "drop-port",
     "Choose a numerical value for the drop port (default is 511). "
     "You will need to use this command-line option when you wish to use port "
-    "511 as a valid dataplane port or as the CPU port."
-  );
-  psa_switch_parser->add_uint_option(
+    "511 as a valid dataplane port or as the CPU port.");
+
+#ifdef WITH_PI
+  psa_switch_parser.add_uint_option(
     "cpu-port",
     "Choose a numerical value for the CPU port, it will be used for "
     "packet-in / packet-out. Do not add an interface with this port number, "
@@ -68,81 +65,44 @@ main(int argc, char* argv[]) {
     "be able to receive / send packets using the P4Runtime StreamChannel "
     "bi-directional stream."
   );
-
-#ifdef WITH_PI
-  psa_switch_parser->add_string_option(
+  psa_switch_parser.add_string_option(
     "grpc-server-addr",
     "Bind gRPC server to given address [default is 0.0.0.0:9559]"
   );
-  psa_switch_parser->add_flag_option(
+  psa_switch_parser.add_flag_option(
     "grpc-server-ssl",
     "Enable SSL/TLS for gRPC server"
   );
-  psa_switch_parser->add_string_option(
+  psa_switch_parser.add_string_option(
     "grpc-server-cacert",
     "Path to pem file holding CA certificate to verify peer against"
   );
-  psa_switch_parser->add_string_option(
+  psa_switch_parser.add_string_option(
     "grpc-server-cert",
     "Path to pem file holding server certificate"
   );
-  psa_switch_parser->add_string_option(
+  psa_switch_parser.add_string_option(
     "grpc-server-key",
     "Path to pem file holding server key"
   );
-  psa_switch_parser->add_flag_option(
+  psa_switch_parser.add_flag_option(
     "grpc-server-with-client-auth",
     "Require client to have a valid certificate for mutual authentication"
   );
-  psa_switch_parser->add_flag_option(
+  psa_switch_parser.add_flag_option(
     "dp-grpc-server-addr",
     "Use a gRPC channel to inject and receive dataplane packets; "
       "bind this gRPC server to given address, e.g. 0.0.0.0:50052"
   );
-#endif  // WITH_PI
+#endif // WITH_PI
 
-  int status = psa_switch->init_from_command_line_options(
-      argc, argv, psa_switch_parser);
-  if (status != 0) {
-    std::cerr << "Failed to initialize switch from command-line options\n";
-    std::exit(status);
-  }
-
-  bool enable_swap_flag = false;
-  if (psa_switch_parser->get_flag_option("enable-swap", &enable_swap_flag)
-      != bm::TargetParserBasic::ReturnCode::SUCCESS) {
-    std::cerr << "Failed to get enable-swap value\n";
-    std::exit(1);
-  }
-  if (enable_swap_flag) psa_switch->enable_config_swap();
-
-  uint32_t drop_port = 0xffffffff;
-  {
-    auto rc = psa_switch_parser->get_uint_option("drop-port", &drop_port);
-    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
-      drop_port = PsaSwitch::default_drop_port;
-    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
-      std::cerr << "Failed to get drop-port value\n";
-      std::exit(1);
-    }
-    psa_switch->set_drop_port(drop_port);
-  }
-
-  uint32_t cpu_port = 0xffffffff;
-  {
-    auto rc = psa_switch_parser->get_uint_option("cpu-port", &cpu_port);
-    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
-      cpu_port = 0;
-    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port == 0) {
-      std::cerr << "Failed to get cpu-port value\n";
-      std::exit(1);
-    }
-  }
+  bm::OptionsParser parser;
+  parser.parse(argc, argv, &psa_switch_parser);
 
 #ifdef WITH_PI
   std::string dp_grpc_server_addr;
   {
-    auto rc = psa_switch_parser->get_string_option(
+    auto rc = psa_switch_parser.get_string_option(
         "dp-grpc-server-addr", &dp_grpc_server_addr);
     if (rc != bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED &&
         rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
@@ -153,7 +113,7 @@ main(int argc, char* argv[]) {
 
   std::string grpc_server_addr;
   {
-    auto rc = psa_switch_parser->get_string_option(
+    auto rc = psa_switch_parser.get_string_option(
         "grpc-server-addr", &grpc_server_addr);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       grpc_server_addr = "0.0.0.0:9559";
@@ -165,7 +125,7 @@ main(int argc, char* argv[]) {
 
   bool grpc_server_ssl = false;
   {
-    auto rc = psa_switch_parser->get_flag_option(
+    auto rc = psa_switch_parser.get_flag_option(
         "grpc-server-ssl", &grpc_server_ssl);
     if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
       std::cerr << "Failed to get grpc-server-ssl value\n";
@@ -175,7 +135,7 @@ main(int argc, char* argv[]) {
 
   std::string grpc_server_cacert;
   {
-    auto rc = psa_switch_parser->get_string_option(
+    auto rc = psa_switch_parser.get_string_option(
         "grpc-server-cacert", &grpc_server_cacert);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       grpc_server_cacert = "";
@@ -187,7 +147,7 @@ main(int argc, char* argv[]) {
 
   std::string grpc_server_cert;
   {
-    auto rc = psa_switch_parser->get_string_option(
+    auto rc = psa_switch_parser.get_string_option(
         "grpc-server-cert", &grpc_server_cert);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       grpc_server_cert = "";
@@ -199,7 +159,7 @@ main(int argc, char* argv[]) {
 
   std::string grpc_server_key;
   {
-    auto rc = psa_switch_parser->get_string_option(
+    auto rc = psa_switch_parser.get_string_option(
         "grpc-server-key", &grpc_server_key);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       grpc_server_key = "";
@@ -211,7 +171,7 @@ main(int argc, char* argv[]) {
 
   bool grpc_server_with_client_auth = false;
   {
-    auto rc = psa_switch_parser->get_flag_option(
+    auto rc = psa_switch_parser.get_flag_option(
         "grpc-server-with-client-auth", &grpc_server_with_client_auth);
     if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
       std::cerr << "Failed to get grpc-server-with-client-auth value\n";
@@ -261,17 +221,71 @@ main(int argc, char* argv[]) {
     std::cerr << e.msg();
     std::exit(1);
   }
-#endif  // WITH_PI
 
-  int thrift_port = psa_switch->get_runtime_port();
-  bm_runtime::start_server(psa_switch, thrift_port);
+  uint32_t cpu_port = 0xffffffff;
+  {
+    auto rc = psa_switch_parser.get_uint_option("cpu-port", &cpu_port);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED) {
+      cpu_port = 0;
+    } else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port == 0) {
+      std::cerr << "Failed to parse --cpu-port\n";
+      std::exit(1);
+    }
+  }
+
+#endif // WITH_PI
+
+  std::shared_ptr<PsaSwitch> psa_switch = std::make_shared<PsaSwitch>();
+
+  bool disable_swap_flag = false;
+  {
+    auto rc = psa_switch_parser.get_flag_option("disable-swap", &disable_swap_flag);
+    if (rc  != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to parse --disable-swap\n";
+      std::exit(1);
+    }
+  }
+  if (!disable_swap_flag) psa_switch->enable_config_swap();
+
+  uint32_t drop_port = 0xffffffff;
+  {
+    auto rc = psa_switch_parser.get_uint_option("drop-port", &drop_port);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED) {
+      drop_port = PsaSwitch::default_drop_port;
+    } else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to parse --drop-port\n";
+      std::exit(1);
+    }
+    psa_switch->set_drop_port(drop_port);
+  }
+
+  // Start Thrift server
+  bm_runtime::start_server(psa_switch.get(), parser.thrift_port);
   using ::pswitch_runtime::PsaSwitchIf;
   using ::pswitch_runtime::PsaSwitchProcessor;
   bm_runtime::add_service<PsaSwitchIf, PsaSwitchProcessor>(
-      "psa_switch", pswitch_runtime::get_handler(psa_switch));
-  psa_switch->start_and_return();
+      "psa_switch", pswitch_runtime::get_handler(psa_switch.get()));
 
-  while (true) std::this_thread::sleep_for(std::chrono::seconds(100));
+#ifdef WITH_PI
+  auto &runner = switch_runner::SwitchGrpcRunner::get_instance(
+      psa_switch,
+      grpc_server_addr,
+      cpu_port,
+      dp_grpc_server_addr,
+      grpc_server_ssl ? ssl_options : nullptr);
+
+  int status = runner.init_and_start(parser);
+  if (status != 0) std::exit(status);
+
+  runner.wait();
+
+#else // WITH_PI
+
+  psa_switch->start_and_return();
+  while (true)
+    std::this_thread::sleep_for(std::chrono::seconds(100));
+
+#endif // WITH_PI
 
   return 0;
 }

--- a/targets/psa_switch/main.cpp
+++ b/targets/psa_switch/main.cpp
@@ -50,6 +50,16 @@ main(int argc, char* argv[]) {
     "You will need to use this command-line option when you wish to use port "
     "511 as a valid dataplane port or as the CPU port."
   );
+  psa_switch_parser->add_uint_option(
+    "cpu-port",
+    "Choose a numerical value for the CPU port, it will be used for "
+    "packet-in / packet-out. Do not add an interface with this port number, "
+    "and 0 is not a valid value. "
+    "If you do not use this command-line option, "
+    "P4Runtime packet IO functionality will not be available: you will not "
+    "be able to receive / send packets using the P4Runtime StreamChannel "
+    "bi-directional stream."
+  );
 
   int status = psa_switch->init_from_command_line_options(
       argc, argv, psa_switch_parser);
@@ -69,6 +79,15 @@ main(int argc, char* argv[]) {
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
     psa_switch->set_drop_port(drop_port);
+  }
+
+  uint32_t cpu_port = 0xffffffff;
+  {
+    auto rc = psa_switch_parser->get_uint_option("cpu-port", &cpu_port);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      cpu_port = 0;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port == 0)
+      std::exit(1);
   }
 
   int thrift_port = psa_switch->get_runtime_port();

--- a/targets/psa_switch/main.cpp
+++ b/targets/psa_switch/main.cpp
@@ -18,11 +18,19 @@
  *
  */
 
+
 /* Switch instance */
+
+#include <iostream>
 
 #include <bm/PsaSwitch.h>
 #include <bm/bm_runtime/bm_runtime.h>
 #include <bm/bm_sim/target_parser.h>
+
+#ifdef WITH_PI
+#include <bm/bm_grpc/pem.h>
+#include <bm/grpc/ssl_options.h>
+#endif
 
 #include "psa_switch.h"
 
@@ -61,14 +69,51 @@ main(int argc, char* argv[]) {
     "bi-directional stream."
   );
 
+#ifdef WITH_PI
+  psa_switch_parser->add_string_option(
+    "grpc-server-addr",
+    "Bind gRPC server to given address [default is 0.0.0.0:9559]"
+  );
+  psa_switch_parser->add_flag_option(
+    "grpc-server-ssl",
+    "Enable SSL/TLS for gRPC server"
+  );
+  psa_switch_parser->add_string_option(
+    "grpc-server-cacert",
+    "Path to pem file holding CA certificate to verify peer against"
+  );
+  psa_switch_parser->add_string_option(
+    "grpc-server-cert",
+    "Path to pem file holding server certificate"
+  );
+  psa_switch_parser->add_string_option(
+    "grpc-server-key",
+    "Path to pem file holding server key"
+  );
+  psa_switch_parser->add_flag_option(
+    "grpc-server-with-client-auth",
+    "Require client to have a valid certificate for mutual authentication"
+  );
+  psa_switch_parser->add_flag_option(
+    "dp-grpc-server-addr",
+    "Use a gRPC channel to inject and receive dataplane packets; "
+      "bind this gRPC server to given address, e.g. 0.0.0.0:50052"
+  );
+#endif  // WITH_PI
+
   int status = psa_switch->init_from_command_line_options(
       argc, argv, psa_switch_parser);
-  if (status != 0) std::exit(status);
+  if (status != 0) {
+    std::cerr << "Failed to initialize switch from command-line options\n";
+    std::exit(status);
+  }
 
   bool enable_swap_flag = false;
   if (psa_switch_parser->get_flag_option("enable-swap", &enable_swap_flag)
-      != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+    std::cerr << "Failed to get enable-swap value\n";
     std::exit(1);
+  }
   if (enable_swap_flag) psa_switch->enable_config_swap();
 
   uint32_t drop_port = 0xffffffff;
@@ -76,8 +121,10 @@ main(int argc, char* argv[]) {
     auto rc = psa_switch_parser->get_uint_option("drop-port", &drop_port);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       drop_port = PsaSwitch::default_drop_port;
-    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get drop-port value\n";
       std::exit(1);
+    }
     psa_switch->set_drop_port(drop_port);
   }
 
@@ -86,9 +133,135 @@ main(int argc, char* argv[]) {
     auto rc = psa_switch_parser->get_uint_option("cpu-port", &cpu_port);
     if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
       cpu_port = 0;
-    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port == 0)
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS || cpu_port == 0) {
+      std::cerr << "Failed to get cpu-port value\n";
       std::exit(1);
+    }
   }
+
+#ifdef WITH_PI
+  std::string dp_grpc_server_addr;
+  {
+    auto rc = psa_switch_parser->get_string_option(
+        "dp-grpc-server-addr", &dp_grpc_server_addr);
+    if (rc != bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED &&
+        rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get dp-grpc-server-addr value\n";
+      std::exit(1);
+    }
+  }
+
+  std::string grpc_server_addr;
+  {
+    auto rc = psa_switch_parser->get_string_option(
+        "grpc-server-addr", &grpc_server_addr);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      grpc_server_addr = "0.0.0.0:9559";
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get grpc-server-addr value\n";
+      std::exit(1);
+    }
+  }
+
+  bool grpc_server_ssl = false;
+  {
+    auto rc = psa_switch_parser->get_flag_option(
+        "grpc-server-ssl", &grpc_server_ssl);
+    if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get grpc-server-ssl value\n";
+      std::exit(1);
+    }
+  }
+
+  std::string grpc_server_cacert;
+  {
+    auto rc = psa_switch_parser->get_string_option(
+        "grpc-server-cacert", &grpc_server_cacert);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      grpc_server_cacert = "";
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get grpc-server-cacert value\n";
+      std::exit(1);
+    }
+  }
+
+  std::string grpc_server_cert;
+  {
+    auto rc = psa_switch_parser->get_string_option(
+        "grpc-server-cert", &grpc_server_cert);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      grpc_server_cert = "";
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get grpc-server-cert value\n";
+      std::exit(1);
+    }
+  }
+
+  std::string grpc_server_key;
+  {
+    auto rc = psa_switch_parser->get_string_option(
+        "grpc-server-key", &grpc_server_key);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      grpc_server_key = "";
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get grpc-server-key value\n";
+      std::exit(1);
+    }
+  }
+
+  bool grpc_server_with_client_auth = false;
+  {
+    auto rc = psa_switch_parser->get_flag_option(
+        "grpc-server-with-client-auth", &grpc_server_with_client_auth);
+    if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS) {
+      std::cerr << "Failed to get grpc-server-with-client-auth value\n";
+      std::exit(1);
+    }
+  }
+
+  if (!grpc_server_ssl &&
+      (grpc_server_cacert != "" ||
+       grpc_server_cert != "" ||
+       grpc_server_key != "")) {
+    std::cerr << "SSL/TLS is disabled for gRPC server, "
+              << "so provided .pem files will be ignored\n";
+  }
+
+  if (!grpc_server_ssl && grpc_server_with_client_auth) {
+    std::cerr << "SSL/TLS is disabled for gRPC server, "
+              << "so cannot request client auth\n";
+  }
+
+  if (grpc_server_ssl && grpc_server_cert == "") {
+    std::cerr << "When enabling SSL/TLS for gRPC server, "
+              << "--grpc-server-cert is required\n";
+    std::exit(1);
+  }
+  if (grpc_server_ssl && grpc_server_key == "") {
+    std::cerr << "When enabling SSL/TLS for gRPC server, "
+              << "--grpc-server-key is required\n";
+    std::exit(1);
+  }
+
+  auto ssl_options = std::make_shared<SSLOptions>();
+  try {
+    if (grpc_server_ssl) {
+      if (grpc_server_cacert != "") {
+        ssl_options->pem_root_certs = bm::read_pem_file(grpc_server_cacert);
+      }
+      if (grpc_server_cert != "") {
+        ssl_options->pem_cert_chain = bm::read_pem_file(grpc_server_cert);
+      }
+      if (grpc_server_key != "") {
+        ssl_options->pem_private_key = bm::read_pem_file(grpc_server_key);
+      }
+      ssl_options->with_client_auth = grpc_server_with_client_auth;
+    }
+  } catch (const bm::read_pem_exception &e) {
+    std::cerr << e.msg();
+    std::exit(1);
+  }
+#endif  // WITH_PI
 
   int thrift_port = psa_switch->get_runtime_port();
   bm_runtime::start_server(psa_switch, thrift_port);

--- a/targets/psa_switch/primitives.cpp
+++ b/targets/psa_switch/primitives.cpp
@@ -27,8 +27,14 @@
 #include <bm/bm_sim/phv.h>
 #include <bm/bm_sim/logger.h>
 
+#include "psa_switch.h"
+
 #include <random>
 #include <thread>
+
+namespace {
+  bm::psa::PsaSwitch *psa_switch;
+} // namespace
 
 namespace bm {
 
@@ -134,7 +140,8 @@ REGISTER_PRIMITIVE(shift_right);
 
 class drop : public ActionPrimitive<> {
   void operator ()() {
-    get_field("standard_metadata.egress_spec").set(511);
+    get_field("standard_metadata.egress_spec").set(
+      psa_switch->get_drop_port());
     if (get_phv().has_field("intrinsic_metadata.mcast_grp")) {
       get_field("intrinsic_metadata.mcast_grp").set(0);
     }
@@ -391,6 +398,7 @@ REGISTER_PRIMITIVE_W_NAME("truncate", truncate_);
 // the previous alternative was to have all the primitives in a header file (the
 // primitives could also be placed in psa_switch.cpp directly), but I need
 // this dummy function if I want to keep the primitives in their own file
-int import_primitives() {
+int import_primitives(bm::psa::PsaSwitch *_psa_switch) {
+  psa_switch = _psa_switch;
   return 0;
 }

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -62,7 +62,7 @@ struct bmv2_hash {
 REGISTER_HASH(hash_ex);
 REGISTER_HASH(bmv2_hash);
 
-extern int import_primitives();
+extern int import_primitives(bm::psa::PsaSwitch*);
 extern int import_counters();
 extern int import_meters();
 extern int import_random();
@@ -117,8 +117,9 @@ class PsaSwitch::MirroringSessions {
   std::unordered_map<mirror_id_t, MirroringSessionConfig> sessions_map;
 };
 
-PsaSwitch::PsaSwitch(bool enable_swap)
+PsaSwitch::PsaSwitch(bool enable_swap, port_t drop_port)
   : Switch(enable_swap),
+    drop_port(drop_port),
     input_buffer(1024),
 #ifdef SSWITCH_PRIORITY_QUEUEING_ON
     egress_buffers(nb_egress_threads,
@@ -181,7 +182,7 @@ PsaSwitch::PsaSwitch(bool enable_swap)
   force_arith_header("psa_egress_output_metadata");
   force_arith_header("psa_egress_deparser_input_metadata");
 
-  import_primitives();
+  import_primitives(this);
   import_counters();
   import_meters();
   import_random();

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -75,12 +75,15 @@ class PsaSwitch : public Switch {
     bool mgid_valid;
   };
 
+  static constexpr port_t default_drop_port = 511;
+
  private:
   using clock = std::chrono::high_resolution_clock;
 
  public:
   // by default, swapping is off
-  explicit PsaSwitch(bool enable_swap = false);
+  explicit PsaSwitch(bool enable_swap = false,
+                     port_t drop_port = default_drop_port);
 
   ~PsaSwitch();
 
@@ -125,6 +128,14 @@ class PsaSwitch : public Switch {
   }
 
   void set_transmit_fn(TransmitFn fn);
+
+  port_t get_drop_port() const {
+    return drop_port;
+  }
+
+  void set_drop_port(port_t _drop_port) {
+    drop_port = _drop_port;
+  }
 
   // overriden interfaces
   Counter::CounterErrorCode
@@ -218,6 +229,7 @@ class PsaSwitch : public Switch {
   static constexpr size_t nb_egress_threads = 4u;
   static constexpr port_t PSA_PORT_RECIRCULATE = 0xfffffffa;
   static packet_id_t packet_id;
+  port_t drop_port;
 
   class MirroringSessions;
 

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -61,19 +61,12 @@ namespace bm {
 
 namespace psa {
 
-class PsaSwitch : public Switch {
+class PsaSwitch : public BaseSwitch {
  public:
   using mirror_id_t = int;
 
   using TransmitFn = std::function<void(port_t, packet_id_t,
                                         const char *, int)>;
-
-  struct MirroringSessionConfig {
-    port_t egress_port;
-    bool egress_port_valid;
-    unsigned int mgid;
-    bool mgid_valid;
-  };
 
   static constexpr port_t default_drop_port = 511;
 
@@ -121,13 +114,6 @@ class PsaSwitch : public Switch {
 
   // returns the number of microseconds elasped since the clock's epoch
   uint64_t get_time_since_epoch_us() const;
-
-  // returns the packet id of most recently received packet. Not thread-safe.
-  static packet_id_t get_packet_id() {
-    return (packet_id-1);
-  }
-
-  void set_transmit_fn(TransmitFn fn);
 
   port_t get_drop_port() const {
     return drop_port;
@@ -228,7 +214,6 @@ class PsaSwitch : public Switch {
  private:
   static constexpr size_t nb_egress_threads = 4u;
   static constexpr port_t PSA_PORT_RECIRCULATE = 0xfffffffa;
-  static packet_id_t packet_id;
   port_t drop_port;
 
   class MirroringSessions;
@@ -287,7 +272,6 @@ class PsaSwitch : public Switch {
 #endif
   egress_buffers;
   Queue<std::unique_ptr<Packet> > output_buffer;
-  TransmitFn my_transmit_fn;
   std::shared_ptr<McSimplePreLAG> pre;
   clock::time_point start;
   std::unordered_map<mirror_id_t, port_t> mirroring_map;

--- a/targets/psa_switch/psa_switch.h
+++ b/targets/psa_switch/psa_switch.h
@@ -86,12 +86,6 @@ class PsaSwitch : public BaseSwitch {
 
   void reset_target_state_() override;
 
-  bool mirroring_add_session(mirror_id_t mirror_id,
-                             const MirroringSessionConfig &config);
-  bool mirroring_delete_session(mirror_id_t mirror_id);
-  bool mirroring_get_session(mirror_id_t mirror_id,
-                             MirroringSessionConfig *config) const;
-
   int mirroring_mapping_add(mirror_id_t mirror_id, port_t egress_port) {
     mirroring_map[mirror_id] = egress_port;
     return 0;
@@ -216,8 +210,6 @@ class PsaSwitch : public BaseSwitch {
   static constexpr port_t PSA_PORT_RECIRCULATE = 0xfffffffa;
   port_t drop_port;
 
-  class MirroringSessions;
-
   enum PktInstanceType {
     PACKET_PATH_NORMAL,
     PACKET_PATH_NORMAL_UNICAST,
@@ -275,7 +267,6 @@ class PsaSwitch : public BaseSwitch {
   std::shared_ptr<McSimplePreLAG> pre;
   clock::time_point start;
   std::unordered_map<mirror_id_t, port_t> mirroring_map;
-  std::unique_ptr<MirroringSessions> mirroring_sessions;
   bool with_queueing_metadata{false};
 };
 

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -72,7 +72,7 @@ REGISTER_HASH(bmv2_hash);
 
 extern int import_primitives(SimpleSwitch *simple_switch);
 
-packet_id_t SimpleSwitch::packet_id = 0;
+packet_id_t bm::BaseSwitch::packet_id = 0;
 
 class SimpleSwitch::MirroringSessions {
  public:
@@ -200,7 +200,7 @@ class SimpleSwitch::InputBuffer {
 
 SimpleSwitch::SimpleSwitch(bool enable_swap, port_t drop_port,
                            size_t nb_queues_per_port)
-  : Switch(enable_swap),
+  : BaseSwitch(enable_swap),
     drop_port(drop_port),
     input_buffer(new InputBuffer(
         1024 /* normal capacity */, 1024 /* resubmit/recirc capacity */)),
@@ -209,16 +209,18 @@ SimpleSwitch::SimpleSwitch(bool enable_swap, port_t drop_port,
                    64, EgressThreadMapper(nb_egress_threads),
                    nb_queues_per_port),
     output_buffer(128),
-    // cannot use std::bind because of a clang bug
-    // https://stackoverflow.com/questions/32030141/is-this-incorrect-use-of-stdbind-or-a-compiler-bug
-    my_transmit_fn([this](port_t port_num, packet_id_t pkt_id,
-                          const char *buffer, int len) {
-        _BM_UNUSED(pkt_id);
-        this->transmit_fn(port_num, buffer, len);
-    }),
     pre(new McSimplePreLAG()),
     start(clock::now()),
     mirroring_sessions(new MirroringSessions()) {
+
+  // cannot use std::bind because of a clang bug
+  // https://stackoverflow.com/questions/32030141/is-this-incorrect-use-of-stdbind-or-a-compiler-bug
+  set_transmit_fn([this](port_t port_num, packet_id_t pkt_id,
+                        const char *buffer, int len) {
+      _BM_UNUSED(pkt_id);
+      this->transmit_fn(port_num, buffer, len);
+  });
+
   add_component<McSimplePreLAG>(pre);
 
   add_required_field("standard_metadata", "ingress_port");
@@ -374,11 +376,6 @@ uint64_t
 SimpleSwitch::get_time_since_epoch_us() const {
   auto tp = clock::now();
   return duration_cast<ts_res>(tp.time_since_epoch()).count();
-}
-
-void
-SimpleSwitch::set_transmit_fn(TransmitFn fn) {
-  my_transmit_fn = std::move(fn);
 }
 
 void

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -46,7 +46,7 @@ using ts_res = std::chrono::microseconds;
 using std::chrono::duration_cast;
 using ticks = std::chrono::nanoseconds;
 
-using bm::Switch;
+using bm::BaseSwitch;
 using bm::Queue;
 using bm::Packet;
 using bm::PHV;
@@ -59,19 +59,9 @@ using bm::FieldList;
 using bm::packet_id_t;
 using bm::p4object_id_t;
 
-class SimpleSwitch : public Switch {
+class SimpleSwitch : public BaseSwitch {
  public:
   using mirror_id_t = int;
-
-  using TransmitFn = std::function<void(port_t, packet_id_t,
-                                        const char *, int)>;
-
-  struct MirroringSessionConfig {
-    port_t egress_port;
-    bool egress_port_valid;
-    unsigned int mgid;
-    bool mgid_valid;
-  };
 
   static constexpr port_t default_drop_port = 511;
   static constexpr size_t default_nb_queues_per_port = 1;
@@ -119,13 +109,6 @@ class SimpleSwitch : public Switch {
   // returns the number of microseconds elasped since the clock's epoch
   uint64_t get_time_since_epoch_us() const;
 
-  // returns the packet id of most recently received packet. Not thread-safe.
-  static packet_id_t get_packet_id() {
-    return packet_id - 1;
-  }
-
-  void set_transmit_fn(TransmitFn fn);
-
   port_t get_drop_port() const {
     return drop_port;
   }
@@ -137,7 +120,6 @@ class SimpleSwitch : public Switch {
 
  private:
   static constexpr size_t nb_egress_threads = 4u;
-  static packet_id_t packet_id;
 
   class MirroringSessions;
 
@@ -193,7 +175,6 @@ class SimpleSwitch : public Switch {
   bm::QueueingLogicPriRL<std::unique_ptr<Packet>, EgressThreadMapper>
   egress_buffers;
   Queue<std::unique_ptr<Packet> > output_buffer;
-  TransmitFn my_transmit_fn;
   std::shared_ptr<McSimplePreLAG> pre;
   clock::time_point start;
   bool with_queueing_metadata{false};

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -85,14 +85,6 @@ class SimpleSwitch : public BaseSwitch {
 
   void swap_notify_() override;
 
-  bool mirroring_add_session(mirror_id_t mirror_id,
-                             const MirroringSessionConfig &config);
-
-  bool mirroring_delete_session(mirror_id_t mirror_id);
-
-  bool mirroring_get_session(mirror_id_t mirror_id,
-                             MirroringSessionConfig *config) const;
-
   int set_egress_priority_queue_depth(size_t port, size_t priority,
                                       const size_t depth_pkts);
   int set_egress_queue_depth(size_t port, const size_t depth_pkts);
@@ -120,8 +112,6 @@ class SimpleSwitch : public BaseSwitch {
 
  private:
   static constexpr size_t nb_egress_threads = 4u;
-
-  class MirroringSessions;
 
   class InputBuffer;
 
@@ -178,7 +168,6 @@ class SimpleSwitch : public BaseSwitch {
   std::shared_ptr<McSimplePreLAG> pre;
   clock::time_point start;
   bool with_queueing_metadata{false};
-  std::unique_ptr<MirroringSessions> mirroring_sessions;
 };
 
 #endif  // SIMPLE_SWITCH_SIMPLE_SWITCH_H_

--- a/targets/simple_switch_grpc/Makefile.am
+++ b/targets/simple_switch_grpc/Makefile.am
@@ -33,7 +33,8 @@ simple_switch_grpc_LDFLAGS = \
 noinst_LTLIBRARIES = libsimple_switch_grpc.la
 
 libsimple_switch_grpc_la_SOURCES = \
-switch_runner.cpp switch_runner.h
+../../services/switch_runner/switch_runner.cpp \
+../../services/switch_runner/switch_runner.h
 if WITH_SYSREPO
 libsimple_switch_grpc_la_SOURCES += \
 switch_sysrepo.h switch_sysrepo.cpp
@@ -57,4 +58,5 @@ $(GRPC_LIBS) $(PROTOBUF_LIBS)
 
 AM_CPPFLAGS += \
  -I$(builddir)/../../services/cpp_out \
- -I$(builddir)/../../services/grpc_out
+ -I$(builddir)/../../services/grpc_out \
+ -I$(builddir)/../../services/switch_runner

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -197,7 +197,7 @@ main(int argc, char* argv[]) {
       std::exit(1);
   }
 
-  auto ssl_options = std::make_shared<sswitch_grpc::SSLOptions>();
+  auto ssl_options = std::make_shared<SSLOptions>();
   try {
     if (grpc_server_ssl) {
       if (grpc_server_cacert != "") {

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -22,6 +22,7 @@
 #define SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_
 
 #include <bm/bm_sim/dev_mgr.h>
+#include <bm/grpc/ssl_options.h>
 
 #include <grpcpp/server.h>
 
@@ -41,13 +42,6 @@ namespace sswitch_grpc {
 class SysrepoDriver;
 
 class DataplaneInterfaceServiceImpl;
-
-struct SSLOptions {
-  std::string pem_root_certs;
-  std::string pem_private_key;
-  std::string pem_cert_chain;
-  bool with_client_auth;
-};
 
 class SimpleSwitchGrpcRunner {
  public:

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -10,6 +10,8 @@ AM_CPPFLAGS += \
 -isystem $(top_srcdir)/../../third_party/gtest/include \
 -I$(top_srcdir) \
 -I$(top_srcdir)/../../include \
+-I$(top_srcdir)/../simple_switch \
+-I$(top_srcdir)/../../services/switch_runner \
 -isystem$(top_srcdir)/../../third_party/spdlog \
 -I$(top_builddir)/../../services/cpp_out -I$(top_builddir)/../../services/grpc_out \
 -DTESTDATADIR=\"$(abs_srcdir)/testdata\"

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "base_test.h"
+#include "simple_switch.h"
 #include "switch_runner.h"
 
 namespace sswitch_grpc {
@@ -42,8 +43,13 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
   // TODO(antonin): the issue with this is that tests may affect each other; in
   // particular tests which modify port operational status.
   void SetUp() override {
-    auto &runner = SimpleSwitchGrpcRunner::get_instance(
-        true, SimpleSwitchGrpcBaseTest::grpc_server_addr,
+    std::shared_ptr<SimpleSwitch> simple_switch = std::make_shared<SimpleSwitch>(
+        true, // enable_swap
+        switch_runner::SwitchGrpcRunner::default_drop_port
+      );
+
+    auto &runner = switch_runner::SwitchGrpcRunner::get_instance(
+        simple_switch, SimpleSwitchGrpcBaseTest::grpc_server_addr,
         SimpleSwitchGrpcBaseTest::cpu_port,
         SimpleSwitchGrpcBaseTest::dp_grpc_server_addr);
     bm::OptionsParser parser;
@@ -61,7 +67,7 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
   }
 
   void TearDown() override {
-    SimpleSwitchGrpcRunner::get_instance().shutdown();
+    switch_runner::SwitchGrpcRunner::get_instance().shutdown();
   }
 };
 


### PR DESCRIPTION
This pull request enables initial P4Runtime support for the psa_switch target. It updates the psa_switch target to provide the same command-line interface as simple_switch_grpc, and reuses most of the code by introducing `bm::BaseSwitch` (a base class extended by Simple Switch and PSA Switch targets) and making `switch_runner` component reusable between targets.

A couple of examples from the tutorials repository have been converted from v1model to PSA to test compatibility between simple_switch_grpc and psa_switch: https://github.com/rst0git/tutorials/tree/psa-p4runtime/psa-exercises