### PR TITLE
simple_switch: fix egress_spec initialization

### DIFF
--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -670,7 +670,9 @@ SimpleSwitch::egress_thread(size_t worker_id) {
     phv->get_field("standard_metadata.egress_port").set(port);
 
     Field &f_egress_spec = phv->get_field("standard_metadata.egress_spec");
-    f_egress_spec.set(0);
+    // When egress_spec == drop_port the packet will be dropped, thus
+    // here we initialize egress_spec to a value different from drop_port.
+    f_egress_spec.set(drop_port + 1);
 
     phv->get_field("standard_metadata.packet_length").set(
         packet->get_register(RegisterAccess::PACKET_LENGTH_REG_IDX));


### PR DESCRIPTION
When simple_switch_grpc is used with drop port set to 0, it causes unintended behavior of packets being dropped at the end of egress pipeline. This is because by default egress_spec is initialized to 0 and this value happens to match the specified drop port.

Fixes: #1157