### PR TITLE
Add enable-debugger option in 1sw_demo.py.

### DIFF
--- a/mininet/1sw_demo.py
+++ b/mininet/1sw_demo.py
@@ -36,13 +36,15 @@ parser.add_argument('--json', help='Path to JSON config file',
                     type=str, action="store", required=True)
 parser.add_argument('--pcap-dump', help='Dump packets on interfaces to pcap files',
                     type=str, action="store", required=False, default=False)
+parser.add_argument('--enable-debugger', help='Enable debugger (Please ensure debugger support is enabled in behavioral exe, as it is disabled by default)',
+                    action="store_true", required=False, default=False)
 
 args = parser.parse_args()
 
 
 class SingleSwitchTopo(Topo):
     "Single switch connected to n (< 256) hosts."
-    def __init__(self, sw_path, json_path, thrift_port, pcap_dump, n, **opts):
+    def __init__(self, sw_path, json_path, thrift_port, pcap_dump, enable_debugger, n, **opts):
         # Initialize topology and default options
         Topo.__init__(self, **opts)
 
@@ -50,7 +52,8 @@ class SingleSwitchTopo(Topo):
                                 sw_path = sw_path,
                                 json_path = json_path,
                                 thrift_port = thrift_port,
-                                pcap_dump = pcap_dump)
+                                pcap_dump = pcap_dump,
+                                enable_debugger = enable_debugger)
 
         for h in range(n):
             host = self.addHost('h%d' % (h + 1),
@@ -66,6 +69,7 @@ def main():
                             args.json,
                             args.thrift_port,
                             args.pcap_dump,
+                            args.enable_debugger,
                             num_hosts)
     net = Mininet(topo = topo,
                   host = P4Host,


### PR DESCRIPTION
This change adds a new command line option `--enable-debugger` to enable debugger support in 1sw_demo.py. Once this option is specified, 1sw_demo.py will pass `--debugger` option to the behavioral exe when launching it. And this will allow us to connect the debugger with pydbg.

One thing to notice is - in order to use this option, we need to use the debugger enabled behavioral exe. Feel free to check the behavioral model readme to see how to compile with debugger support enabled.

More discussions can be found with issue #1173.