### PR TITLE
bf_lpm_trie: fix gcc warning

### DIFF
--- a/src/bf_lpm_trie/bf_lpm_trie.c
+++ b/src/bf_lpm_trie/bf_lpm_trie.c
@@ -149,7 +149,7 @@ static inline int delete_branch(node_t *current_node, byte_t byte) {
   branches_vec_t *branches = &current_node->branches;
   int a = 0;
   int b = branches->size;
-  int idx;
+  int idx = 0;
   while (a < b) {
     idx = a + (b - a) / 2;
     byte_t v = branches->branches[idx].v;


### PR DESCRIPTION
This pull request fixes the following compiler warning:
```
../src/bf_lpm_trie/bf_lpm_trie.c:167:56: warning: 'idx' may be used uninitialized in this function [-Wmaybe-uninitialized]
  167 |   memmove(&branches->branches[idx], &branches->branches[idx + 1], size);
      |                                                        ^
../src/bf_lpm_trie/bf_lpm_trie.c:152:7: note: 'idx' was declared here
  152 |   int idx;
      |       ^
../src/bf_lpm_trie/bf_lpm_trie.c:267:56: warning: 'idx' may be used uninitialized in this function [-Wmaybe-uninitialized]
  267 |   memmove(&prefixes->prefixes[idx], &prefixes->prefixes[idx + 1], size);
      |                                                        ^
../src/bf_lpm_trie/bf_lpm_trie.c:251:7: note: 'idx' was declared here
```