### PR TITLE
base_test: fix typedef-name after 'class' error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,21 @@ jobs:
       run: docker build -t bm-no-pi --build-arg IMAGE_TYPE=test -f Dockerfile.noPI .
     - name: Run tests
       run: docker run --rm -w /behavioral-model bm-no-pi /bin/bash -c "make check -j$(nproc)"
+
+  test-ubuntu22:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: sudo ./install_deps_ubuntu_22.04.sh
+    - name: Build BMv2
+      run: |
+        ./autogen.sh
+        ./configure --with-pdfixed --with-pi --with-stress-tests --enable-debugger --enable-Werror
+        make -j$(nproc)
+    - name: Run tests
+      run: make check -j$(nproc)

--- a/install_deps_ubuntu_22.04.sh
+++ b/install_deps_ubuntu_22.04.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+apt-get update
+apt-get install -y curl gnupg
+echo 'deb http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_22.04/ /' | tee /etc/apt/sources.list.d/home:p4lang.list
+curl -fsSL https://download.opensuse.org/repositories/home:p4lang/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_p4lang.gpg > /dev/null
+
+apt-get update
+
+apt-get install -qq --no-install-recommends \
+    automake \
+    build-essential \
+    cmake \
+    git \
+    g++ \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libgmp-dev \
+    libgrpc++-dev \
+    libgrpc-dev \
+    libopenmpi-dev \
+    libnanomsg-dev \
+    libpcap-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
+    libssl-dev \
+    libthrift-0.16.0 \
+    libthrift-dev \
+    libtool \
+    pkg-config \
+    protobuf-compiler \
+    protobuf-compiler-grpc \
+    python3-all \
+    python3-six \
+    python3-thrift \
+    thrift-compiler \
+    libreadline-dev \
+    p4lang-pi
+
+ldconfig

--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -30,11 +30,15 @@
 
 #include "utils.h"
 
+#ifndef GRPCPP_CHANNEL_IMPL_H
+// A typedef `Channel` has been was introduced in <grpcpp/channel.h>
+// with https://github.com/grpc/grpc/pull/19067
 namespace grpc {
 
 class Channel;
 
 }  // namespace grpc
+#endif  // GRPCPP_CHANNEL_IMPL_H
 
 namespace sswitch_grpc {
 


### PR DESCRIPTION
This pull request fixes the following error, which appears when building BMv2 on Ubuntu 22.04:

```
In file included from base_test.cpp:28:
base_test.h:35:7: error: using typedef-name 'grpc::Channel' after 'class'
   35 | class Channel;
      |       ^~~~~~~
In file included from /usr/include/grpcpp/grpcpp.h:52,
                 from base_test.cpp:21:
/usr/include/grpcpp/channel.h:26:30: note: 'grpc::Channel' has a previous declaration here
   26 | typedef ::grpc_impl::Channel Channel;
      |                              ^~~~~~~
```

This error appears because a typedef [`Channel`](https://github.com/grpc/grpc/commit/40210d3b8a92a285d174322ee9f1e823d619cec3#diff-fb7527f41b6b9035fa3478ad27c113ce9fe63c6dcf4ca62b5e3559cb8eab8d57R26) has been introduced in newer versions of gRPC.
