### PR TITLE
Add a missing #include <type_traits>

### DIFF
--- a/src/bm_sim/debugger.cpp
+++ b/src/bm_sim/debugger.cpp
@@ -20,6 +20,7 @@
 
 #include <bm/config.h>
 #include <bm/bm_sim/debugger.h>
+#include <type_traits>
 
 #ifdef BM_DEBUG_ON
 #include <bm/bm_sim/nn.h>


### PR DESCRIPTION
This is necessary to prevent compilation failures with recent Clang and libc++.