### PR TITLE
Fix `ipaddr` import in `runtime_CLI.py`

### DIFF
--- a/tools/macos/bootstrap_mac.sh
+++ b/tools/macos/bootstrap_mac.sh
@@ -46,7 +46,6 @@ brews_dir=`realpath $tools_dir`/brews
 brew install --HEAD ${brews_dir}/thrift.rb --with-python --with-libevent
 
 brew install python
-/usr/local/bin/pip install ipaddr
 /usr/local/bin/pip install pcapy
 
 # nanomsg

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -498,7 +498,7 @@ def macAddr_to_bytes(addr):
 
 
 def ipv6Addr_to_bytes(addr):
-    from ipaddr import IPv6Address
+    from ipaddress import IPv6Address
     if not ':' in addr:
         raise CLI_FormatExploreError()
     try:


### PR DESCRIPTION
The function `ipv6Addr_to_bytes` in `tools/runtime_CLI.py` tries to import the `IPv6Address` class from the `ipaddr` module, that probably refers to the [`ipaddr`](https://pypi.org/project/ipaddr/) package that have been superseded by standard Python 3  [`ipaddress`](https://docs.python.org/3/library/ipaddress.html) library and its Python 2.7 [backport](https://pypi.org/project/py2-ipaddress/).

The installation of `ipaddr` is still present in [`tools/macos/bootstrap_mac.sh`](https://github.com/p4lang/behavioral-model/blob/2dd81c1b83eb76058588cd1394dd9d80ca00e884/tools/macos/bootstrap_mac.sh#L49) (it can also be deleted or replaced with the installation of the backport if Python2.7 is installed).

This PR fixes the statement, without requiring the old `ipaddr` package.