### PR TITLE
Fix simple_switch.md: mark_to_drop overrides multicast.

### DIFF
--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -159,7 +159,8 @@ starts egress processing. The clock is the same as for
 pipeline, but should not be written to.
 - `mcast_grp`: needed for the multicast feature. This field needs to be written
 in the ingress pipeline when you wish the packet to be multicast. A value of 0
-means no multicast. This value must be one of a valid multicast group configured
+means no multicast, and alling `mark_to_drop` will set the value to 0.
+A nonzero value should be that of a valid multicast group configured
 through bmv2 runtime interfaces. See the "after-ingress pseudocode" for
 relative priority of this vs. other possible packet operations at
 end of ingress.
@@ -227,7 +228,8 @@ if (digest to generate) {   // because your code called generate_digest
 }
 if (resubmit was called) {
     start ingress processing over again for the original packet
-} else if (mcast_grp != 0) {  // because your code assigned a value to mcast_grp
+} else if (mcast_grp != 0) {  // because your code assigned a value to mcast_grp and 
+                              // did not call mark_to_drop afterwards
     multicast the packet to the output port(s) configured for group mcast_grp
 } else if (egress_spec == DROP_PORT) {  // e.g. because your code called drop/mark_to_drop
     Drop packet.
@@ -300,22 +302,23 @@ if (resubmit was called) {
     determined by the field list given as an argument to the last
     resubmit operation called.  The resubmitted packet will have
     instance_type equal to PKT_INSTANCE_TYPE_RESUBMIT.
-} else if (egress_spec == DROP_PORT) {
-    // This condition will be true if your code called the
-    // mark_to_drop (P4_16) or drop (P4_14) primitive action during
-    // ingress processing.
-    Drop packet.
-} else if (mcast_grp != 0) {
+}  else if (mcast_grp != 0) {
     // This condition will be true if your code made an assignment to
-    // standard_metadata.mcast_grp during ingress processing.  There
-    // are no special primitive actions built in to simple_switch for
-    // you to call to do this -- use a normal P4_16 assignment
-    // statement, or P4_14 modify_field() primitive action.
+    // `standard_metadata.mcast_grp`` during ingress processing AND did
+    // did not call `mark_to_drop` afterwards. 
+    // There are no special primitive actions built in to simple_switch 
+    // for you to call to do this -- use a normal P4_16 assignment
+    // statement, or P4_14 `modify_field()`` primitive action.
     Make 0 or more copies of the packet based upon the list of
     (egress_port, egress_rid) values configured by the control plane
     for the mcast_grp value.  Enqueue each one in the appropriate
     packet buffer queue.  The instance_type of each will be
     PKT_INSTANCE_TYPE_REPLICATION.
+} else if (egress_spec == DROP_PORT) {
+    // This condition will be true if your code called the
+    // mark_to_drop (P4_16) or drop (P4_14) primitive action during
+    // ingress processing.
+    Drop packet.
 } else {
     Enqueue one copy of the packet destined for egress_port equal to
     egress_spec.

--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -159,7 +159,7 @@ starts egress processing. The clock is the same as for
 pipeline, but should not be written to.
 - `mcast_grp`: needed for the multicast feature. This field needs to be written
 in the ingress pipeline when you wish the packet to be multicast. A value of 0
-means no multicast, and alling `mark_to_drop` will set the value to 0.
+means no multicast, and calling `mark_to_drop` will set the value to 0.
 A nonzero value should be that of a valid multicast group configured
 through bmv2 runtime interfaces. See the "after-ingress pseudocode" for
 relative priority of this vs. other possible packet operations at

--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -302,13 +302,13 @@ if (resubmit was called) {
     determined by the field list given as an argument to the last
     resubmit operation called.  The resubmitted packet will have
     instance_type equal to PKT_INSTANCE_TYPE_RESUBMIT.
-}  else if (mcast_grp != 0) {
+} else if (mcast_grp != 0) {
     // This condition will be true if your code made an assignment to
-    // `standard_metadata.mcast_grp`` during ingress processing AND did
+    // `standard_metadata.mcast_grp` during ingress processing AND did
     // did not call `mark_to_drop` afterwards. 
     // There are no special primitive actions built in to simple_switch 
     // for you to call to do this -- use a normal P4_16 assignment
-    // statement, or P4_14 `modify_field()`` primitive action.
+    // statement, or P4_14 `modify_field()` primitive action.
     Make 0 or more copies of the packet based upon the list of
     (egress_port, egress_rid) values configured by the control plane
     for the mcast_grp value.  Enqueue each one in the appropriate

--- a/docs/simple_switch.md
+++ b/docs/simple_switch.md
@@ -300,6 +300,11 @@ if (resubmit was called) {
     determined by the field list given as an argument to the last
     resubmit operation called.  The resubmitted packet will have
     instance_type equal to PKT_INSTANCE_TYPE_RESUBMIT.
+} else if (egress_spec == DROP_PORT) {
+    // This condition will be true if your code called the
+    // mark_to_drop (P4_16) or drop (P4_14) primitive action during
+    // ingress processing.
+    Drop packet.
 } else if (mcast_grp != 0) {
     // This condition will be true if your code made an assignment to
     // standard_metadata.mcast_grp during ingress processing.  There
@@ -311,11 +316,6 @@ if (resubmit was called) {
     for the mcast_grp value.  Enqueue each one in the appropriate
     packet buffer queue.  The instance_type of each will be
     PKT_INSTANCE_TYPE_REPLICATION.
-} else if (egress_spec == DROP_PORT) {
-    // This condition will be true if your code called the
-    // mark_to_drop (P4_16) or drop (P4_14) primitive action during
-    // ingress processing.
-    Drop packet.
 } else {
     Enqueue one copy of the packet destined for egress_port equal to
     egress_spec.


### PR DESCRIPTION
I empirically observed that mark_to_drop overrides multicast on BMv2.

@jafingerhut @antoninbas @verios-google