### PR TITLE
Replace python invocations with python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ the Mininet integration right away using our *simple_router* target.
 In a first terminal, type the following:
 
     - cd mininet
-    - sudo python 1sw_demo.py --behavioral-exe ../targets/simple_router/simple_router --json ../targets/simple_router/simple_router.json
+    - sudo python3 1sw_demo.py --behavioral-exe ../targets/simple_router/simple_router --json ../targets/simple_router/simple_router.json
 
 Then in a second terminal:
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -63,7 +63,7 @@ installed on your machine. Then run the following commands:
 
 ```bash
 cd mininet
-python stress_test_ipv4.py
+python3 stress_test_ipv4.py
 ```
 
 The Python script creates a Mininet topology with 2 hosts connected by one
@@ -111,7 +111,7 @@ cd bmv2
 ./configure 'CXXFLAGS=-g -O3' 'CFLAGS=-g -O3' --disable-logging-macros --disable-elogger
 make -j8
 cd mininet
-python stress_test_ipv4.py
+python3 stress_test_ipv4.py
 ```
 
 You should get similar results as above: around 1Gbps, or 80,000pps.

--- a/targets/psa_switch/pswitch_CLI
+++ b/targets/psa_switch/pswitch_CLI
@@ -23,4 +23,4 @@ fi
 CLI=$THIS_DIR/pswitch_CLI.py
 TOOLS_DIR=$THIS_DIR/../../tools/
 
-PYTHONPATH=$PYTHONPATH:$TOOLS_DIR python $CLI $json $port
+PYTHONPATH=$PYTHONPATH:$TOOLS_DIR python3 $CLI $json $port

--- a/targets/simple_switch/sswitch_CLI
+++ b/targets/simple_switch/sswitch_CLI
@@ -23,4 +23,4 @@ fi
 CLI=$THIS_DIR/sswitch_CLI.py
 TOOLS_DIR=$THIS_DIR/../../tools/
 
-PYTHONPATH=$PYTHONPATH:$TOOLS_DIR python $CLI $json $port
+PYTHONPATH=$PYTHONPATH:$TOOLS_DIR python3 $CLI $json $port


### PR DESCRIPTION
While python may be an alias for, or a link to, python3 on some systems, it is not always the case.