### PR TITLE
Stop using std::iterator

### DIFF
--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -14,14 +14,16 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
 #ifndef BM_BM_SIM_MATCH_TABLES_H_
 #define BM_BM_SIM_MATCH_TABLES_H_
 
+#include <cstddef>  // for ptrdiff_t
 #include <iosfwd>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -61,9 +63,14 @@ class MatchTableAbstract : public NamedP4Object {
     int priority;
   };
 
-  class handle_iterator
-      : public std::iterator<std::forward_iterator_tag, handle_t> {
+  class handle_iterator {
    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = handle_t;
+    using difference_type = std::ptrdiff_t;  // default for std::iterator
+    using pointer = handle_t*;
+    using reference = handle_t&;
+
     handle_iterator(const MatchTableAbstract *mt,
                     const MatchUnitAbstract_::handle_iterator &it)
         : mt(mt), it(it) { }

--- a/include/bm/bm_sim/match_units.h
+++ b/include/bm/bm_sim/match_units.h
@@ -14,20 +14,22 @@
  */
 
 /*
- * Antonin Bas (antonin@barefootnetworks.com)
+ * Antonin Bas
  *
  */
 
 #ifndef BM_BM_SIM_MATCH_UNITS_H_
 #define BM_BM_SIM_MATCH_UNITS_H_
 
+#include <atomic>
+#include <cstddef>  // for ptrdiff_t
+#include <iosfwd>
+#include <iterator>
+#include <memory>
 #include <string>
 #include <unordered_map>
-#include <vector>
-#include <atomic>
 #include <utility>  // for pair<>
-#include <memory>
-#include <iosfwd>
+#include <vector>
 
 #include "match_key_types.h"
 #include "match_error_codes.h"
@@ -230,9 +232,14 @@ class MatchUnitAbstract_ {
   // Iterator for entry handles
   // having a const / non-const flavor would not make sense here: handles cannot
   // be modified
-  class handle_iterator
-      : public std::iterator<std::forward_iterator_tag, handle_t> {
+  class handle_iterator {
    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = handle_t;
+    using difference_type = std::ptrdiff_t;  // default for std::iterator
+    using pointer = handle_t*;
+    using reference = handle_t&;
+
     handle_iterator(const MatchUnitAbstract_ *mu, HandleMgr::const_iterator it);
 
     const entry_handle_t &operator*() const {


### PR DESCRIPTION
std::iterator was deprecated in C++17
While the bmv2 code base officially only supports C++11, we can still observe the deprecation warnings when building on some recent platforms.