### PR TITLE
Fix #1243.

### DIFF
--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -75,14 +75,12 @@ SwitchWContexts::receive(port_t port_num, const char *buffer, int len) {
 
 void
 SwitchWContexts::start_and_return() {
-  {
-    std::unique_lock<std::mutex> config_lock(config_mutex);
-    if (!config_loaded && !enable_swap) {
-      Logger::get()->error(
-          "The switch was started with no P4 and config swap is disabled");
-    }
-    config_loaded_cv.wait(config_lock, [this]() { return config_loaded; });
+  std::unique_lock<std::mutex> config_lock(config_mutex);
+  if (!config_loaded && !enable_swap) {
+    Logger::get()->error(
+        "The switch was started with no P4 and config swap is disabled");
   }
+  config_loaded_cv.wait(config_lock, [this]() { return config_loaded; });
   start();  // DevMgr::start
   start_and_return_();
   // Starts any registered periodically-executing externs

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -80,6 +80,8 @@ SwitchWContexts::start_and_return() {
     Logger::get()->error(
         "The switch was started with no P4 and config swap is disabled");
   }
+  // The lock is held until the config is loaded to avoid race conditions with   
+  // starting the PIGrpcServerRunV2 (P4RT server).
   config_loaded_cv.wait(config_lock, [this]() { return config_loaded; });
   start();  // DevMgr::start
   start_and_return_();

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -80,8 +80,8 @@ SwitchWContexts::start_and_return() {
     Logger::get()->error(
         "The switch was started with no P4 and config swap is disabled");
   }
-  // We keep holding the lock as the start_and_return_ callback, which is implemented
-  // by targets, may access the P4 config for some validations.
+  // We keep holding the lock as the start_and_return_ callback, which is
+  // implemented by targets, may access the P4 config for some validations.
   config_loaded_cv.wait(config_lock, [this]() { return config_loaded; });
   start();  // DevMgr::start
   start_and_return_();

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -80,8 +80,8 @@ SwitchWContexts::start_and_return() {
     Logger::get()->error(
         "The switch was started with no P4 and config swap is disabled");
   }
-  // The lock is held until the config is loaded to avoid race conditions with   
-  // starting the PIGrpcServerRunV2 (P4RT server).
+  // We keep holding the lock as the start_and_return_ callback, which is implemented
+  // by targets, may access the P4 config for some validations.
   config_loaded_cv.wait(config_lock, [this]() { return config_loaded; });
   start();  // DevMgr::start
   start_and_return_();


### PR DESCRIPTION
Fix race conditions when passing a BMv2 JSON Config into the command-line arguments when initializing SimpleSwitch.