### PR TITLE
Clean up some .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 # Python byte code
 *.pyc
 
-build/*
+build/
 lib*
 
 # Vim

--- a/targets/l2_switch/.gitignore
+++ b/targets/l2_switch/.gitignore
@@ -1,3 +1,1 @@
-/build
 /l2_switch
-/*.pcap

--- a/targets/l2_switch/learn_client/.gitignore
+++ b/targets/l2_switch/learn_client/.gitignore
@@ -1,2 +1,1 @@
-/build
 /learn_client

--- a/targets/psa_switch/.gitignore
+++ b/targets/psa_switch/.gitignore
@@ -1,5 +1,3 @@
-/build
 /psa_switch
-/*.pcap
 pswitch_runtime
 psa_switch_CLI

--- a/targets/simple_router/.gitignore
+++ b/targets/simple_router/.gitignore
@@ -1,3 +1,1 @@
-/build
 /simple_router
-/*.pcap

--- a/targets/simple_switch/.gitignore
+++ b/targets/simple_switch/.gitignore
@@ -1,5 +1,3 @@
-/build
 /simple_switch
-/*.pcap
 sswitch_runtime
 simple_switch_CLI

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,3 @@
-build/
 test*
 !test*.cpp
 !stress_tests*


### PR DESCRIPTION
- Use `build/` instead of `build/*` in the root `.gitignore` so it could cover subdirectory cases recursively.
- Remove `/*.pcap` patterns from subdirectories because root `.gitignore` already contains `*.pcap`.