### PR TITLE
Always call packet->reset_exit() at beginning of Pipeline::apply()

### DIFF
--- a/src/bm_sim/pipeline.cpp
+++ b/src/bm_sim/pipeline.cpp
@@ -28,6 +28,7 @@ namespace bm {
 
 void
 Pipeline::apply(Packet *pkt) {
+  pkt->reset_exit();
   BMELOG(pipeline_start, *pkt, *this);
   // TODO(antonin)
   // this is temporary while we experiment with the debugger

--- a/targets/pna_nic/pna_nic.cpp
+++ b/targets/pna_nic/pna_nic.cpp
@@ -200,7 +200,6 @@ PnaNic::main_thread() {
     
     Pipeline *main_mau = this->get_pipeline("main_control");
     main_mau->apply(packet.get());
-    packet->reset_exit();
 
     Deparser *deparser = this->get_deparser("main_deparser");
     deparser->deparse(packet.get());

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -424,7 +424,6 @@ PsaSwitch::ingress_thread() {
 
     Pipeline *ingress_mau = this->get_pipeline("ingress");
     ingress_mau->apply(packet.get());
-    packet->reset_exit();
 
     const auto &f_ig_cos = phv->get_field("psa_ingress_output_metadata.class_of_service");
     const auto ig_cos = f_ig_cos.get_uint();
@@ -561,7 +560,6 @@ PsaSwitch::egress_thread(size_t worker_id) {
 
     Pipeline *egress_mau = this->get_pipeline("egress");
     egress_mau->apply(packet.get());
-    packet->reset_exit();
     // TODO(peter): add stf test where exit is invoked but packet still gets recirc'd
     phv->get_field("psa_egress_deparser_input_metadata.egress_port").set(
         phv->get_field("psa_egress_parser_input_metadata.egress_port"));

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -520,8 +520,6 @@ SimpleSwitch::ingress_thread() {
 
     ingress_mau->apply(packet.get());
 
-    packet->reset_exit();
-
     Field &f_egress_spec = phv->get_field("standard_metadata.egress_spec");
     port_t egress_spec = f_egress_spec.get_uint();
 


### PR DESCRIPTION
The only place the code checks for is_marked_for_exit() is inside of Pipeline::apply(), so by resetting exit flag at beginning of Pipeline::apply, no users of Pipeline class need to worry about the exit flag at all.  It is handled completely locally within Pipeline::apply(), and could even be a local variable of Pipeline::appply() if the primitive made that straightforward (which it does not).