### PR TITLE
Add/modify MGID logging bm_sim.

### DIFF
--- a/src/bm_sim/simple_pre.cpp
+++ b/src/bm_sim/simple_pre.cpp
@@ -290,7 +290,8 @@ McSimplePre::replicate(const McSimplePre::McIn ingress_info) const {
       }
     }
   }
-  BMLOG_DEBUG("number of packets replicated : {}", egress_info_list.size());
+  BMLOG_DEBUG("number of packets replicated : {} for MGID: {}",
+             egress_info_list.size(), ingress_info.mgid);
   return egress_info_list;
 }
 

--- a/src/bm_sim/simple_pre_lag.cpp
+++ b/src/bm_sim/simple_pre_lag.cpp
@@ -199,7 +199,8 @@ McSimplePreLAG::replicate(const McSimplePre::McIn ingress_info) const {
       }
     }
   }
-  BMLOG_DEBUG("number of packets replicated : {}", egress_info_list.size());
+  BMLOG_DEBUG("number of packets replicated : {} for MGID: {}",
+             egress_info_list.size(), ingress_info.mgid);
   return egress_info_list;
 }
 


### PR DESCRIPTION
* Log MGID in simple_pre_lag.cpp in addition to simple_pre.cpp.
* Change the log message to be consistent with other MGID logging.