### PR TITLE
Fix #1291 Do not assert when --dump-packet-data option is enabled ...

### DIFF
--- a/src/bm_sim/dev_mgr.cpp
+++ b/src/bm_sim/dev_mgr.cpp
@@ -282,10 +282,11 @@ DevMgr::clear_port_stats(port_t port_num) {
 std::string
 DevMgr::sample_packet_data(const char *buffer, int len) {
   size_t amount = std::min(dump_packet_data, static_cast<size_t>(len));
-  std::ostringstream ret;
-  if (amount > 0) {
-      utils::dump_hexstring(ret, &buffer[0], &buffer[amount]);
+  if (amount == 0) {
+      return "";
   }
+  std::ostringstream ret;
+  utils::dump_hexstring(ret, &buffer[0], &buffer[amount]);
   return ret.str();
 }
 

--- a/src/bm_sim/dev_mgr.cpp
+++ b/src/bm_sim/dev_mgr.cpp
@@ -282,7 +282,6 @@ DevMgr::clear_port_stats(port_t port_num) {
 std::string
 DevMgr::sample_packet_data(const char *buffer, int len) {
   size_t amount = std::min(dump_packet_data, static_cast<size_t>(len));
-  assert(amount > 0);
   std::ostringstream ret;
   utils::dump_hexstring(ret, &buffer[0], &buffer[amount]);
   return ret.str();

--- a/src/bm_sim/dev_mgr.cpp
+++ b/src/bm_sim/dev_mgr.cpp
@@ -283,7 +283,9 @@ std::string
 DevMgr::sample_packet_data(const char *buffer, int len) {
   size_t amount = std::min(dump_packet_data, static_cast<size_t>(len));
   std::ostringstream ret;
-  utils::dump_hexstring(ret, &buffer[0], &buffer[amount]);
+  if (amount > 0) {
+      utils::dump_hexstring(ret, &buffer[0], &buffer[amount]);
+  }
   return ret.str();
 }
 


### PR DESCRIPTION
... when sending a length 0 packet.

Granted this is an unusual situation, but there are test programs for p4c and p4testgen where p4testgen creates tests where the expected output packet is 0 bytes long, and if you run them while enabling --dump-packet-data N option for behavioral-model, simple_switch crashes with an assert.