### PR TITLE
Fix include issue for std::lower_bound in g++15

### DIFF
--- a/src/bm_sim/lpm_trie.h
+++ b/src/bm_sim/lpm_trie.h
@@ -18,11 +18,12 @@
 
 #include <bm/bm_sim/bytecontainer.h>
 
-#include <algorithm> 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace bm {


### PR DESCRIPTION
The change fixes https://github.com/p4lang/p4c/actions/runs/15490297907/job/43614080729?pr=5310#step:5:3194 where std::lower_bound with compare functor cannot be found. 

In newer g++, the header file that defines std::lower_bound with a compare factor is only ported with `<algorithm>`, which was not included in `lpm_trie.h`. Previous versions of g++ seem to have the header file included with `<vector>`, thus compiled.
