### PR TITLE
include libpcap when checking for pcap symbol

### DIFF
--- a/src/BMI/CMakeLists.txt
+++ b/src/BMI/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Check for pcap_set_immediate_mode
 include(CheckSymbolExists)
+
+set(_OLD_CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+set(CMAKE_REQUIRED_LIBRARIES pcap)
+
 check_symbol_exists(pcap_set_immediate_mode "pcap.h" HAVE_PCAP_SET_IMMEDIATE_MODE)
+
+set(CMAKE_REQUIRED_LIBRARIES "${_OLD_CMAKE_REQUIRED_LIBRARIES}")
 
 # Create bmi library
 add_library(bmi OBJECT


### PR DESCRIPTION
Link the pcap library when checking for `pcap_set_immediate_mode` function.

If the pcap library is not loaded, then the test for `pcap_set_immediate_mode` will always fail, and so `WITH_PCAP_FIX` will never be defined. This results in no packets being captured on the interface as it is not placed in promiscuous mode.