### PR TITLE
Selector Packet Fanout  -  Core implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option(ENABLE_MODULES "Allow loading third-party modules at runtime" ON)
 option(REQUIRE_MODULES "Require support for loading third-party modules at runtime" OFF)
 option(ENABLE_UNDETERMINISTIC_TESTS "Run undeterministic tests (e.g. queueing) when running tests" ON)
 option(ENABLE_WERROR "Make all compiler warnings fatal" OFF)
+option(ENABLE_PKT_FANOUT "Enable action selector packet fanout support" OFF)
 option(ENABLE_WP4_16_STACKS "Implement stacks strictly as per the P4_16 specification" ON)
 
 # Set compiler flags
@@ -142,6 +143,10 @@ endif()
 
 if(ENABLE_LOGGING_MACROS)
   add_definitions(-DLOG_DEBUG_ON -DLOG_TRACE_ON)
+endif()
+
+if(ENABLE_PKT_FANOUT)
+  add_definitions(-DPKT_FANOUT_ON)
 endif()
 
 if(ENABLE_WP4_16_STACKS)

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,15 @@ AS_IF([test "x$enable_debugger" = "xyes"], [
     ])
 ])
 
+# TODO: add this to cmake build as well
+pkt_fanout_enabled=no
+AC_ARG_ENABLE([pkt_fanout],
+    AS_HELP_STRING([--enable-pkt-fanout], [Enable packet fanout support]))
+AS_IF([test "x$enable_pkt_fanout" = "xyes"], [
+    pkt_fanout_enabled=yes
+    AC_DEFINE([PKT_FANOUT_ON], [], [Enable packet fanout support])
+])
+
 logging_macros_enabled=no
 AC_ARG_ENABLE([logging_macros],
     AS_HELP_STRING([--disable-logging-macros],

--- a/include/bm/bm_sim/P4Objects.h
+++ b/include/bm/bm_sim/P4Objects.h
@@ -545,6 +545,8 @@ class P4Objects {
   void enable_arith(header_id_t header_id, int field_offset);
   void enable_arith(header_id_t header_id);
 
+  bool is_selector_fanout(
+      const Json::Value &cfg_next_nodes) const;
   std::unique_ptr<Calculation> process_cfg_selector(
       const Json::Value &cfg_selector) const;
 };

--- a/include/bm/bm_sim/action_profile.h
+++ b/include/bm/bm_sim/action_profile.h
@@ -297,10 +297,6 @@ class ActionProfile : public NamedP4Object {
 
   bool group_is_empty(grp_hdl_t grp) const;
 
-  bool is_selector_fanout_enabled() const {
-    return selector_fanout_enabled;
-  }
-
   const ActionEntry &lookup(const Packet &pkt,
                             const IndirectIndex &index) const;
 
@@ -317,7 +313,6 @@ class ActionProfile : public NamedP4Object {
   std::shared_ptr<GroupSelectionIface> grp_selector_{nullptr};
   GroupSelectionIface *grp_selector{&grp_mgr};
   std::unique_ptr<Calculation> hash{nullptr};
-  bool selector_fanout_enabled{false};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/action_profile.h
+++ b/include/bm/bm_sim/action_profile.h
@@ -297,6 +297,10 @@ class ActionProfile : public NamedP4Object {
 
   bool group_is_empty(grp_hdl_t grp) const;
 
+  bool is_selector_fanout_enabled() const {
+    return selector_fanout_enabled;
+  }
+
   const ActionEntry &lookup(const Packet &pkt,
                             const IndirectIndex &index) const;
 
@@ -313,6 +317,7 @@ class ActionProfile : public NamedP4Object {
   std::shared_ptr<GroupSelectionIface> grp_selector_{nullptr};
   GroupSelectionIface *grp_selector{&grp_mgr};
   std::unique_ptr<Calculation> hash{nullptr};
+  bool selector_fanout_enabled{false};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/action_profile.h
+++ b/include/bm/bm_sim/action_profile.h
@@ -165,6 +165,12 @@ class ActionProfile : public NamedP4Object {
   void serialize(std::ostream *out) const;
   void deserialize(std::istream *in, const P4Objects &objs);
 
+  void set_selector_fanout();
+
+  std::vector<mbr_hdl_t> get_all_mbrs_from_grp(const grp_hdl_t &grp) const;
+  std::vector<const ActionEntry*>
+  get_entries_with_mbrs(const std::vector<mbr_hdl_t> &mbrs) const;
+
  private:
   using ReadLock = boost::shared_lock<boost::shared_mutex>;
   using WriteLock = boost::unique_lock<boost::shared_mutex>;
@@ -291,6 +297,10 @@ class ActionProfile : public NamedP4Object {
 
   bool group_is_empty(grp_hdl_t grp) const;
 
+  bool is_selector_fanout_enabled() const {
+    return selector_fanout_enabled;
+  }
+
   const ActionEntry &lookup(const Packet &pkt,
                             const IndirectIndex &index) const;
 
@@ -307,6 +317,7 @@ class ActionProfile : public NamedP4Object {
   std::shared_ptr<GroupSelectionIface> grp_selector_{nullptr};
   GroupSelectionIface *grp_selector{&grp_mgr};
   std::unique_ptr<Calculation> hash{nullptr};
+  bool selector_fanout_enabled{false};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/event_logger.h
+++ b/include/bm/bm_sim/event_logger.h
@@ -99,7 +99,8 @@ class EventLogger {
 
   void action_execute(const Packet &packet,
                       const ActionFn &action_fn, const ActionData &action_data);
-
+  void fanout_gen(const Packet &packet, uint64_t table_id,
+                  uint64_t parent_pkt_copy_id);
   void config_change();
 
   static EventLogger *get() {

--- a/include/bm/bm_sim/fanout_pkt_mgr.h
+++ b/include/bm/bm_sim/fanout_pkt_mgr.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-present Contributors to the P4 Project
+/* Copyright 2025-present Contributors to the P4 Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
 #ifndef BM_BM_SIM_FANOUT_PKT_MGR_H_
 #define BM_BM_SIM_FANOUT_PKT_MGR_H_
 
-#include <vector>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 #include "logger.h"
 #include "packet.h"
 #include "match_tables.h"
@@ -35,7 +36,8 @@ struct FanoutCtx {
   MatchTableIndirect *cur_table{nullptr};
   std::function<void(const bm::Packet *)> buffer_push_fn;
 
-  FanoutCtx(const std::function<void(const bm::Packet *)> &buffer_push_fn)
+  explicit FanoutCtx(
+    const std::function<void(const bm::Packet *)> &buffer_push_fn)
       : buffer_push_fn(buffer_push_fn) { }
 };
 
@@ -97,12 +99,12 @@ class FanoutPktMgr {
 #endif
     std::mutex fanout_pkt_mutex;
     std::vector<ActionProfile*> act_profs;
-    
+
  private:
     FanoutPktMgr() = default;
     std::unordered_map<std::thread::id, FanoutCtx> fanout_ctx_map;
-    std::shared_ptr<SelectorIface> 
-    grp_selector{std::make_shared<FanoutPktSelection>()};
+    std::shared_ptr<SelectorIface>
+      grp_selector{std::make_shared<FanoutPktSelection>()};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/fanout_pkt_mgr.h
+++ b/include/bm/bm_sim/fanout_pkt_mgr.h
@@ -1,0 +1,100 @@
+/* Copyright 2013-present Contributors to the P4 Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef BM_BM_SIM_FANOUT_PKT_MGR_H_
+#define BM_BM_SIM_FANOUT_PKT_MGR_H_
+
+#include <vector>
+#include <unordered_map>
+#include "logger.h"
+#include "packet.h"
+#include "match_tables.h"
+#include "action_profile.h"
+
+namespace bm {
+class MatchTableIndirect;
+using bm::ActionProfile;
+using EntryVec = const std::vector<const ActionEntry*>;
+using SelectorIface = ActionProfile::GroupSelectionIface;
+
+struct FanoutCtx {
+  bool hit{false};
+  std::vector<Packet *> fanout_pkts;
+  const Packet * cur_pkt{nullptr};
+  ActionProfile *action_profile{nullptr};
+  MatchTableIndirect *cur_table{nullptr};
+};
+
+class FanoutPktSelection: public SelectorIface{
+ public:
+    using grp_hdl_t = ActionProfile::grp_hdl_t;
+    using mbr_hdl_t = ActionProfile::mbr_hdl_t;
+    using hash_t = ActionProfile::hash_t;
+    using MatchErrorCode = bm::MatchErrorCode;
+
+    FanoutPktSelection() = default;
+
+    // callbacks after member op, not actual member/group ops
+    void add_member_to_group(grp_hdl_t grp, mbr_hdl_t mbr) override;
+
+    void remove_member_from_group(grp_hdl_t grp, mbr_hdl_t mbr) override;
+
+    mbr_hdl_t get_from_hash(grp_hdl_t grp, hash_t h) const override;
+
+    void reset() override {}
+
+ private:
+    std::unordered_map<grp_hdl_t, std::vector<mbr_hdl_t>> groups;
+};
+
+class FanoutPktMgr {
+ public:
+    FanoutPktMgr(const FanoutPktMgr&) = delete;
+    FanoutPktMgr& operator=(const FanoutPktMgr&) = delete;
+    static FanoutPktMgr& instance() {
+      static FanoutPktMgr instance_;
+      return instance_;
+    }
+
+    inline void register_thread(std::thread::id thread_id) {
+      BMLOG_DEBUG("Registering thread {}", thread_id);
+      fanout_ctx_map.emplace(thread_id, FanoutCtx());
+    }
+    inline SelectorIface* get_grp_selector() {
+      return grp_selector;
+    }
+
+
+
+    std::vector<Packet *>& get_fanout_pkts();
+    FanoutCtx& get_fanout_ctx();
+    void set_ctx(MatchTableIndirect *table, const Packet &pkt,
+                 ActionProfile *action_profile, bool hit);
+    void reset_ctx();
+    void replicate_for_entries(const std::vector<const ActionEntry*> &entries);
+
+    std::mutex fanout_pkt_mutex;
+    // TODO(Hao): deduplicate packets fanout, optional
+
+
+ private:
+    FanoutPktMgr() = default;
+    std::unordered_map<std::thread::id, FanoutCtx> fanout_ctx_map;
+    FanoutPktSelection fanout_selection;
+    SelectorIface* grp_selector{&fanout_selection};
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_FANOUT_PKT_MGR_H_

--- a/include/bm/bm_sim/logger.h
+++ b/include/bm/bm_sim/logger.h
@@ -155,4 +155,10 @@ class Logger {
   bm::Logger::get()->error("[{}] [cxt {}] " s, (pkt).get_unique_id(),   \
                            (pkt).get_context(), ##__VA_ARGS__)
 
+#define BMLOG_WARN(...) bm::Logger::get()->warn(__VA_ARGS__)
+
+#define BMLOG_WARN_PKT(pkt, s, ...)                                    \
+  bm::Logger::get()->warn("[{}] [cxt {}] " s, (pkt).get_unique_id(),   \
+                           (pkt).get_context(), ##__VA_ARGS__)
+
 #endif  // BM_BM_SIM_LOGGER_H_

--- a/include/bm/bm_sim/match_tables.h
+++ b/include/bm/bm_sim/match_tables.h
@@ -39,6 +39,7 @@
 #include "lookup_structures.h"
 #include "action_entry.h"
 #include "action_profile.h"
+#include "fanout_pkt_mgr.h"
 
 namespace bm {
 
@@ -385,6 +386,7 @@ class MatchTable : public MatchTableAbstract {
 
 class MatchTableIndirect : public MatchTableAbstract {
  public:
+  friend class FanoutPktMgr;
   using mbr_hdl_t = ActionProfile::mbr_hdl_t;
 
   using IndirectIndex = ActionProfile::IndirectIndex;

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -32,6 +32,7 @@
 #include <atomic>
 #include <algorithm>  // for std::min
 #include <limits>
+#include <optional>
 
 #include <cassert>
 
@@ -40,6 +41,7 @@
 #include "parser_error.h"
 #include "phv_source.h"
 #include "phv_forward.h"
+#include "control_flow.h"
 
 namespace bm {
 
@@ -301,6 +303,11 @@ class Packet final {
   //! @copydoc clone_with_phv_reset_metadata
   std::unique_ptr<Packet> clone_with_phv_reset_metadata_ptr() const;
 
+  //! Clone the current packet, along with its PHV and registers.
+  Packet clone_with_phv_and_registers() const;
+  //! @copydoc clone_with_phv_and_registers
+  std::unique_ptr<Packet> clone_with_phv_and_registers_ptr() const;
+
   //! Clone the current packet, without the PHV. The value of the fields in the
   //! clone will be undefined and should not be accessed before setting it
   //! first.
@@ -314,6 +321,17 @@ class Packet final {
   Packet clone_choose_context(cxt_id_t new_cxt) const;
   //! @copydoc clone_choose_context
   std::unique_ptr<Packet> clone_choose_context_ptr(cxt_id_t new_cxt) const;
+
+  // Packet fanout related methods
+  //! Returns true if the packet has a next node set
+  bool has_next_node() const;
+  //! Get the next node, if it exists
+  const ControlFlowNode *get_next_node() const;
+  //! Set the next node, which is used to next the packet processing
+  void set_next_node(const ControlFlowNode *node);
+  //! Reset the next node
+  void reset_next_node();
+
 
   //! Deleted copy constructor
   Packet(const Packet &other) = delete;
@@ -384,6 +402,8 @@ class Packet final {
   ErrorCode error_code{ErrorCode::make_invalid()};
 
   bool checksum_error{false};
+
+  std::optional<const ControlFlowNode *> next_node{std::nullopt};
 
  private:
   static CopyIdGenerator *copy_id_gen;

--- a/include/bm/bm_sim/pipeline.h
+++ b/include/bm/bm_sim/pipeline.h
@@ -40,10 +40,12 @@ class Pipeline : public NamedP4Object {
     : NamedP4Object(name, id), first_node(first_node) {}
 
   //! Sends the \p pkt through the correct match-action tables and
-  //! condiitons. Each step is determined based on the result of the previous
+  //! conditions. Each step is determined based on the result of the previous
   //! step (table lookup or condition evaluation), according to the P4 control
   //! flow graph.
   void apply(Packet *pkt);
+  // Start from next_node instead of first_node
+  void apply_from_next_node(Packet *pkt);
 
   //! Deleted copy constructor
   Pipeline(const Pipeline &other) = delete;

--- a/src/bm_sim/CMakeLists.txt
+++ b/src/bm_sim/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(bmsim OBJECT
   event_logger.cpp
   expressions.cpp
   extern.cpp
+  fanout_pkt_mgr.cpp
   fields.cpp
   headers.cpp
   header_unions.cpp

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -37,6 +37,7 @@ event_logger.cpp \
 expressions.cpp \
 extern.cpp \
 extract.h \
+fanout_pkt_mgr.cpp \
 fields.cpp \
 headers.cpp \
 header_unions.cpp \

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -22,6 +22,8 @@
 #include <bm/bm_sim/P4Objects.h>
 #include <bm/bm_sim/phv.h>
 #include <bm/bm_sim/actions.h>
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/fanout_pkt_mgr.h>
 
 #include <iostream>
 #include <istream>
@@ -1655,8 +1657,20 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       std::unique_ptr<ActionProfile> action_profile(
           new ActionProfile(act_prof_name, act_prof_id, with_selection));
       if (with_selection) {
-        auto calc = process_cfg_selector(cfg_act_prof["selector"]);
-        action_profile->set_hash(std::move(calc));
+        // TODO(Hao): clean debug logs
+        BMLOG_DEBUG(
+            "Action profile '{}' with id {} has a selector",
+            act_prof_name, act_prof_id);
+
+        if (is_selector_fanout(cfg_act_prof["selector"])) {
+          BMLOG_DEBUG(
+              "Action profile '{}' with id {} enabled selector fanout",
+              act_prof_name, act_prof_id);
+          action_profile->set_selector_fanout();
+        } else {
+          auto calc = process_cfg_selector(cfg_act_prof["selector"]);
+          action_profile->set_hash(std::move(calc));
+        }
       }
       add_action_profile(act_prof_name, std::move(action_profile));
     }
@@ -2497,6 +2511,11 @@ P4Objects::check_hash(const std::string &name) const {
   }
   throw json_exception(EFormat() << "Unknown hash algorithm: " << name);
   return nullptr;
+}
+
+bool P4Objects::is_selector_fanout(const Json::Value &cfg_selector) const {
+  return cfg_selector.isMember("algo") &&
+         cfg_selector["algo"].asString() == "selector_fanout";
 }
 
 std::unique_ptr<Calculation>

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -2509,7 +2509,7 @@ P4Objects::check_hash(const std::string &name) const {
 bool P4Objects::is_selector_fanout(const Json::Value &cfg_selector) const {
   bool is_fanout = cfg_selector.isMember("algo") &&
          cfg_selector["algo"].asString() == "selector_fanout";
-  if(is_fanout && !FanoutPktMgr::pkt_fanout_on){
+  if (is_fanout && !FanoutPktMgr::pkt_fanout_on) {
     throw std::runtime_error("Selector fanout is not enabled, but"
                              " found selector_fanout mode used");
   }

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1659,6 +1659,7 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       if (with_selection) {
         if (is_selector_fanout(cfg_act_prof["selector"])) {
           action_profile->set_selector_fanout();
+          FanoutPktMgr::instance().act_profs.push_back(action_profile.get());
         } else {
           auto calc = process_cfg_selector(cfg_act_prof["selector"]);
           action_profile->set_hash(std::move(calc));

--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1657,15 +1657,7 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       std::unique_ptr<ActionProfile> action_profile(
           new ActionProfile(act_prof_name, act_prof_id, with_selection));
       if (with_selection) {
-        // TODO(Hao): clean debug logs
-        BMLOG_DEBUG(
-            "Action profile '{}' with id {} has a selector",
-            act_prof_name, act_prof_id);
-
         if (is_selector_fanout(cfg_act_prof["selector"])) {
-          BMLOG_DEBUG(
-              "Action profile '{}' with id {} enabled selector fanout",
-              act_prof_name, act_prof_id);
           action_profile->set_selector_fanout();
         } else {
           auto calc = process_cfg_selector(cfg_act_prof["selector"]);
@@ -2514,8 +2506,13 @@ P4Objects::check_hash(const std::string &name) const {
 }
 
 bool P4Objects::is_selector_fanout(const Json::Value &cfg_selector) const {
-  return cfg_selector.isMember("algo") &&
+  bool is_fanout = cfg_selector.isMember("algo") &&
          cfg_selector["algo"].asString() == "selector_fanout";
+  if(is_fanout && !FanoutPktMgr::pkt_fanout_on){
+    throw std::runtime_error("Selector fanout is not enabled, but"
+                             " found selector_fanout mode used");
+  }
+  return is_fanout;
 }
 
 std::unique_ptr<Calculation>

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -638,18 +638,9 @@ ActionProfile::ref_count_decrease(const IndirectIndex &index) {
 
 ActionProfile::mbr_hdl_t
 ActionProfile::choose_from_group(grp_hdl_t grp, const Packet &pkt) const {
-  // TODO(Hao): PI resets to it own grp_selector, might be a bug, so I just sets
-  //  here for now..
-  if (FanoutPktMgr::pkt_fanout_on && selector_fanout_enabled) {
-    return FanoutPktMgr::instance().get_grp_selector()->get_from_hash(grp, 0);
-  }
   if (!hash) return grp_selector->get_from_hash(grp, 0);
   hash_t h = static_cast<hash_t>(hash->output(pkt));
   return grp_selector->get_from_hash(grp, h);
-}
-
-void ActionProfile::set_selector_fanout() {
-  selector_fanout_enabled = true;
 }
 
 }  // namespace bm

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -640,7 +640,7 @@ ActionProfile::mbr_hdl_t
 ActionProfile::choose_from_group(grp_hdl_t grp, const Packet &pkt) const {
   // TODO(Hao): PI resets to it own grp_selector, might be a bug, so I just sets
   //  here for now..
-  if (selector_fanout_enabled) {
+  if (FanoutPktMgr::pkt_fanout_on && selector_fanout_enabled) {
     return FanoutPktMgr::instance().get_grp_selector()->get_from_hash(grp, 0);
   }
   if (!hash) return grp_selector->get_from_hash(grp, 0);

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -643,4 +643,8 @@ ActionProfile::choose_from_group(grp_hdl_t grp, const Packet &pkt) const {
   return grp_selector->get_from_hash(grp, h);
 }
 
+void ActionProfile::set_selector_fanout() {
+  selector_fanout_enabled = true;
+}
+
 }  // namespace bm

--- a/src/bm_sim/action_profile.cpp
+++ b/src/bm_sim/action_profile.cpp
@@ -22,6 +22,7 @@
 #include <bm/bm_sim/action_profile.h>
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/fanout_pkt_mgr.h>
 
 #include <iostream>
 #include <memory>
@@ -182,6 +183,29 @@ ActionProfile::lookup(const Packet &pkt, const IndirectIndex &index) const {
   assert(is_valid_mbr(mbr));
 
   return action_entries[mbr];
+}
+
+
+std::vector<ActionProfile::mbr_hdl_t>
+ActionProfile::get_all_mbrs_from_grp(const grp_hdl_t &grp) const {
+  assert(is_valid_grp(grp));
+  Group group;
+  MatchErrorCode rc = get_group(grp, &group);
+  _BM_UNUSED(rc);
+  assert(rc == MatchErrorCode::SUCCESS);
+  return group.mbr_handles;
+}
+
+std::vector<const ActionEntry*>
+ActionProfile::get_entries_with_mbrs(
+  const std::vector<ActionProfile::mbr_hdl_t> &mbrs) const {
+  std::vector<const ActionEntry*> entries;
+  entries.reserve(mbrs.size());
+  for (auto m : mbrs) {
+    assert(is_valid_mbr(m));
+    entries.push_back(&action_entries[m]);
+  }
+  return entries;
 }
 
 bool
@@ -524,6 +548,8 @@ void
 ActionProfile::set_group_selector(
     std::shared_ptr<GroupSelectionIface> selector) {
   WriteLock lock = lock_write();
+  BMLOG_DEBUG("Setting group selector for action profile '{}'",
+                get_name());
   grp_selector_ = selector;
   grp_selector = grp_selector_.get();
 }
@@ -612,9 +638,18 @@ ActionProfile::ref_count_decrease(const IndirectIndex &index) {
 
 ActionProfile::mbr_hdl_t
 ActionProfile::choose_from_group(grp_hdl_t grp, const Packet &pkt) const {
+  // TODO(Hao): PI resets to it own grp_selector, might be a bug, so I just sets
+  //  here for now..
+  if (selector_fanout_enabled) {
+    return FanoutPktMgr::instance().get_grp_selector()->get_from_hash(grp, 0);
+  }
   if (!hash) return grp_selector->get_from_hash(grp, 0);
   hash_t h = static_cast<hash_t>(hash->output(pkt));
   return grp_selector->get_from_hash(grp, h);
+}
+
+void ActionProfile::set_selector_fanout() {
+  selector_fanout_enabled = true;
 }
 
 }  // namespace bm

--- a/src/bm_sim/fanout_pkt_mgr.cpp
+++ b/src/bm_sim/fanout_pkt_mgr.cpp
@@ -1,0 +1,137 @@
+/* Copyright 2025-present Contributors to the P4 Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bm/bm_sim/fanout_pkt_mgr.h>
+#include <bm/bm_sim/event_logger.h>
+
+namespace bm {
+
+
+void FanoutPktSelection::add_member_to_group(grp_hdl_t grp, mbr_hdl_t mbr) {
+  (void) grp;
+  (void) mbr;
+}
+
+void FanoutPktSelection::remove_member_from_group(grp_hdl_t grp,
+        mbr_hdl_t mbr) {
+  (void) grp;
+  (void) mbr;
+}
+
+FanoutPktSelection::mbr_hdl_t
+FanoutPktSelection::get_from_hash(grp_hdl_t grp, hash_t h) const {
+  (void)h;
+  auto &ctx = FanoutPktMgr::instance().get_fanout_ctx();
+  auto *action_profile = ctx.action_profile;
+  if (!action_profile) {
+    BMLOG_ERROR("No action profile set for fanout packet selection");
+    throw std::runtime_error("No action profile set for"
+                             "fanout packet selection");
+  }
+
+  std::vector<mbr_hdl_t> mbrs = action_profile->get_all_mbrs_from_grp(grp);
+  mbr_hdl_t selected_mbr = mbrs.back();
+  mbrs.pop_back();
+
+  auto entries = action_profile->get_entries_with_mbrs(mbrs);
+  BMLOG_DEBUG("Fanout Selected member {} from group {} with hash {} "
+              "with number of entries {}",
+              selected_mbr, grp, h, entries.size());
+  FanoutPktMgr::instance().replicate_for_entries(entries);
+  return selected_mbr;
+}
+
+
+std::vector<Packet *>& FanoutPktMgr::get_fanout_pkts() {
+    std::thread::id thread_id = std::this_thread::get_id();
+    BMLOG_DEBUG("Getting fanout packets for thread {}", thread_id);
+
+    std::lock_guard<std::mutex> lock(fanout_pkt_mutex);
+    auto it = fanout_ctx_map.find(thread_id);
+    if (it == fanout_ctx_map.end()) {
+        BMLOG_ERROR("No fanout vector registered for thread {}", thread_id);
+        throw std::runtime_error("Fanout vector not found for thread");
+    }
+    return it->second.fanout_pkts;
+}
+
+FanoutCtx& FanoutPktMgr::get_fanout_ctx() {
+    std::thread::id thread_id = std::this_thread::get_id();
+    auto it = fanout_ctx_map.find(thread_id);
+
+    std::lock_guard<std::mutex> lock(fanout_pkt_mutex);
+    if (it == fanout_ctx_map.end()) {
+        BMLOG_ERROR("No fanout context registered for thread {}", thread_id);
+        throw std::runtime_error("Fanout context not found for thread");
+    }
+    return it->second;
+}
+void FanoutPktMgr::set_ctx(MatchTableIndirect *table,
+                           const Packet &pkt,
+                           ActionProfile *action_profile,
+                           bool hit) {
+    auto &ctx = get_fanout_ctx();
+    ctx.cur_table = table;
+    ctx.cur_pkt = &pkt;
+    ctx.action_profile = action_profile;
+    ctx.hit = hit;
+}
+
+void FanoutPktMgr::reset_ctx() {
+    auto &ctx = get_fanout_ctx();
+    ctx.cur_table = nullptr;
+    ctx.cur_pkt = nullptr;
+    ctx.action_profile = nullptr;
+}
+
+void FanoutPktMgr::replicate_for_entries(
+    const std::vector<const ActionEntry*> &entries) {
+    auto &fanout_pkts = get_fanout_pkts();
+    auto &ctx = get_fanout_ctx();
+    auto *match_table = ctx.cur_table;
+    const Packet &pkt = *ctx.cur_pkt;
+    bool hit = ctx.hit;
+
+    // for event logger
+    uint64_t parent_pkt_copy_id = pkt.get_copy_id();
+    uint64_t table_id = match_table->get_id();
+    for (auto entry : entries) {
+        Packet* rep_pkt = pkt.clone_with_phv_and_registers_ptr().release();
+        rep_pkt->set_egress_port(pkt.get_egress_port());
+
+        entry->action_fn(rep_pkt);
+        BMLOG_DEBUG_PKT(*rep_pkt, "Action {} applied to fanout packet",
+                        *entry);
+
+        auto act_id = entry->action_fn.get_action_id();
+        const ControlFlowNode *next_node = hit ?
+            match_table->get_next_node(act_id) :
+            match_table->get_next_node_default(act_id);
+        if (next_node == nullptr) {
+            BMLOG_DEBUG_PKT(*rep_pkt, "No next node for action id {}", act_id);
+        } else {
+            BMLOG_DEBUG_PKT(*rep_pkt, "Next node for action id {}: {}",
+                            act_id, next_node->get_name());
+        }
+        rep_pkt->set_next_node(next_node);
+        fanout_pkts.push_back(rep_pkt);
+
+        BMELOG(fanout_gen, *rep_pkt, table_id, parent_pkt_copy_id);
+    }
+
+    reset_ctx();
+}
+
+}  // namespace bm

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -722,7 +722,7 @@ MatchTableIndirect::lookup(const Packet &pkt,
       FanoutPktMgr::instance().set_ctx(this, pkt, action_profile, *hit);
     }
   }
-  
+
   const auto &entry = action_profile->lookup(pkt, index);
   // Unfortunately this has to be done at this stage and cannot be done when
   // inserting a member because for 2 match tables sharing the same action

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -715,10 +715,14 @@ MatchTableIndirect::lookup(const Packet &pkt,
         pkt, "Lookup in table '{}' yielded empty group", get_name());
     return empty_action;
   }
-  // A bit hacky, in order to get the next_table for fanout.
-  if (action_profile->is_selector_fanout_enabled()) {
-    FanoutPktMgr::instance().set_ctx(this, pkt, action_profile, *hit);
+
+  if (FanoutPktMgr::pkt_fanout_on) {
+    // A bit hacky, in order to get the next_table for fanout.
+    if (action_profile->is_selector_fanout_enabled()) {
+      FanoutPktMgr::instance().set_ctx(this, pkt, action_profile, *hit);
+    }
   }
+  
   const auto &entry = action_profile->lookup(pkt, index);
   // Unfortunately this has to be done at this stage and cannot be done when
   // inserting a member because for 2 match tables sharing the same action

--- a/src/bm_sim/match_tables.cpp
+++ b/src/bm_sim/match_tables.cpp
@@ -715,7 +715,10 @@ MatchTableIndirect::lookup(const Packet &pkt,
         pkt, "Lookup in table '{}' yielded empty group", get_name());
     return empty_action;
   }
-
+  // A bit hacky, in order to get the next_table for fanout.
+  if (action_profile->is_selector_fanout_enabled()) {
+    FanoutPktMgr::instance().set_ctx(this, pkt, action_profile, *hit);
+  }
   const auto &entry = action_profile->lookup(pkt, index);
   // Unfortunately this has to be done at this stage and cannot be done when
   // inserting a member because for 2 match tables sharing the same action

--- a/src/bm_sim/packet.cpp
+++ b/src/bm_sim/packet.cpp
@@ -165,6 +165,21 @@ Packet::clone_with_phv_ptr() const {
 }
 
 Packet
+Packet::clone_with_phv_and_registers() const {
+  copy_id_t new_copy_id = copy_id_gen->add_one(packet_id);
+  Packet pkt(cxt_id, ingress_port, packet_id, new_copy_id, ingress_length,
+             buffer.clone(buffer.get_data_size()), phv_source);
+  pkt.phv->copy_headers(*phv);
+  pkt.registers = registers;
+  return pkt;
+}
+
+std::unique_ptr<Packet>
+Packet::clone_with_phv_and_registers_ptr() const {
+  return std::unique_ptr<Packet>(new Packet(clone_with_phv_and_registers()));
+}
+
+Packet
 Packet::clone_with_phv_reset_metadata() const {
   copy_id_t new_copy_id = copy_id_gen->add_one(packet_id);
   Packet pkt(cxt_id, ingress_port, packet_id, new_copy_id, ingress_length,
@@ -205,6 +220,20 @@ Packet::clone_no_phv() const {
 std::unique_ptr<Packet>
 Packet::clone_no_phv_ptr() const {
   return clone_choose_context_ptr(cxt_id);
+}
+
+bool Packet::has_next_node() const {
+  return next_node.has_value();
+}
+const ControlFlowNode *Packet::get_next_node() const {
+  return next_node.value_or(nullptr);
+}
+void Packet::set_next_node(const ControlFlowNode *node) {
+  next_node = node;
+}
+
+void Packet::reset_next_node() {
+  next_node.reset();
 }
 
 /* Cannot get away with defaults here, we need to swap the phvs, otherwise we

--- a/src/bm_sim/pipeline.cpp
+++ b/src/bm_sim/pipeline.cpp
@@ -50,4 +50,19 @@ Pipeline::apply(Packet *pkt) {
   BMLOG_DEBUG_PKT(*pkt, "Pipeline '{}': end", get_name());
 }
 
+void Pipeline::apply_from_next_node(Packet *pkt) {
+  const ControlFlowNode *node = pkt->get_next_node();
+  BMLOG_DEBUG_PKT(*pkt, "Pipeline '{}': packet fanout from node '{}'",
+                  get_name(), node? node->get_name() : "None");
+  while (node) {
+    if (pkt->is_marked_for_exit()) {
+      BMLOG_DEBUG_PKT(*pkt, "Packet is marked for exit, interrupting pipeline");
+      break;
+    }
+    node = (*node)(pkt);
+  }
+  pkt->reset_next_node();
+  BMLOG_DEBUG_PKT(*pkt, "Pipeline '{}': fanout end", get_name());
+}
+
 }  // namespace bm

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -128,6 +128,7 @@ class SimpleSwitch::InputBuffer {
     NORMAL,
     RESUBMIT,
     RECIRCULATE,
+    SELECTOR_FANOUT,
     SENTINEL  // signal for the ingress thread to terminate
   };
 
@@ -141,6 +142,7 @@ class SimpleSwitch::InputBuffer {
                           std::move(item), true);
       case PacketType::RESUBMIT:
       case PacketType::RECIRCULATE:
+      case PacketType::SELECTOR_FANOUT:
         return push_front(&queue_hi, capacity_hi, &cvar_can_push_hi,
                           std::move(item), false);
       case PacketType::SENTINEL:
@@ -155,7 +157,7 @@ class SimpleSwitch::InputBuffer {
     Lock lock(mutex);
     cvar_can_pop.wait(
         lock, [this] { return (queue_hi.size() + queue_lo.size()) > 0; });
-    // give higher priority to resubmit/recirculate queue
+    // give higher priority to resubmit/recirculate/selector-fanout queue
     if (queue_hi.size() > 0) {
       *pItem = std::move(queue_hi.back());
       queue_hi.pop_back();
@@ -179,7 +181,10 @@ class SimpleSwitch::InputBuffer {
                  std::unique_ptr<Packet> &&item, bool blocking) {
     Lock lock(mutex);
     while (queue->size() == capacity) {
-      if (!blocking) return 0;
+      if (!blocking) {
+        BMLOG_WARN_PKT(*item, "Input buffer is full, dropping packet");
+        return 0;
+      }
       cvar->wait(lock);
     }
     queue->push_front(std::move(item));
@@ -273,11 +278,23 @@ SimpleSwitch::receive_(port_t port_num, const char *buffer, int len) {
 void
 SimpleSwitch::start_and_return_() {
   check_queueing_metadata();
-
+#ifdef PKT_FANOUT_ON
+  auto ingress_thread = std::thread(&SimpleSwitch::ingress_thread, this);
+  FanoutPktMgr::instance().register_thread(
+      ingress_thread.get_id());
+  threads_.push_back(std::move(ingress_thread));
+  for (size_t i = 0; i < nb_egress_threads; i++) {
+    auto egress_thread = std::thread(&SimpleSwitch::egress_thread, this, i);
+    FanoutPktMgr::instance().register_thread(
+        egress_thread.get_id());
+    threads_.push_back(std::move(egress_thread));
+  }
+#else
   threads_.push_back(std::thread(&SimpleSwitch::ingress_thread, this));
   for (size_t i = 0; i < nb_egress_threads; i++) {
     threads_.push_back(std::thread(&SimpleSwitch::egress_thread, this, i));
   }
+#endif
   threads_.push_back(std::thread(&SimpleSwitch::transmit_thread, this));
 }
 
@@ -492,7 +509,7 @@ SimpleSwitch::ingress_thread() {
 
     port_t ingress_port = packet->get_ingress_port();
     (void) ingress_port;
-    BMLOG_DEBUG_PKT(*packet, "Processing packet received on port {}",
+    BMLOG_DEBUG_PKT(*packet, "Processing packet received on ingress port {}",
                     ingress_port);
 
     auto ingress_packet_size =
@@ -506,19 +523,38 @@ SimpleSwitch::ingress_thread() {
        parser leave the buffer unchanged, and move the pop logic to the
        deparser. TODO? */
     const Packet::buffer_state_t packet_in_state = packet->save_buffer_state();
-    parser->parse(packet.get());
 
-    if (phv->has_field("standard_metadata.parser_error")) {
-      phv->get_field("standard_metadata.parser_error").set(
-          packet->get_error_code().get());
+    // Check if the packet has an optional continue node
+    // TODO(Hao): update the doc/simple_switch.md
+    if (packet->has_next_node()) {
+      ingress_mau->apply_from_next_node(packet.get());
+    } else {
+      parser->parse(packet.get());
+      if (phv->has_field("standard_metadata.parser_error")) {
+        phv->get_field("standard_metadata.parser_error").set(
+            packet->get_error_code().get());
+      }
+
+      if (phv->has_field("standard_metadata.checksum_error")) {
+        phv->get_field("standard_metadata.checksum_error").set(
+            packet->get_checksum_error() ? 1 : 0);
+      }
+
+      ingress_mau->apply(packet.get());
     }
 
-    if (phv->has_field("standard_metadata.checksum_error")) {
-      phv->get_field("standard_metadata.checksum_error").set(
-           packet->get_checksum_error() ? 1 : 0);
+#ifdef PKT_FANOUT_ON
+    {
+      auto &fanout_pkts = FanoutPktMgr::instance().get_fanout_pkts();
+      for (auto pkt : fanout_pkts) {
+        input_buffer->push_front(InputBuffer::PacketType::SELECTOR_FANOUT,
+          std::unique_ptr<bm::Packet>(pkt));
+        BMLOG_DEBUG_PKT(*pkt,
+          "SELECTOR_FANOUT packet pushed to ingress_buffer");
+      }
+      fanout_pkts.clear();
     }
-
-    ingress_mau->apply(packet.get());
+#endif
 
     packet->reset_exit();
 
@@ -612,8 +648,8 @@ SimpleSwitch::ingress_thread() {
                                 ingress_packet_size);
       phv_copy->get_field("standard_metadata.packet_length")
           .set(ingress_packet_size);
-      input_buffer->push_front(
-          InputBuffer::PacketType::RESUBMIT, std::move(packet_copy));
+      input_buffer->push_front(InputBuffer::PacketType::RESUBMIT,
+                               std::move(packet_copy));
       continue;
     }
 
@@ -652,40 +688,56 @@ SimpleSwitch::egress_thread(size_t worker_id) {
     egress_buffers.pop_back(worker_id, &port, &priority, &packet);
     if (packet == nullptr) break;
 
+    BMLOG_DEBUG_PKT(*packet, "Processing packet in egress port {}",
+                    worker_id);
     Deparser *deparser = this->get_deparser("deparser");
     Pipeline *egress_mau = this->get_pipeline("egress");
 
     phv = packet->get_phv();
 
-    if (phv->has_field("intrinsic_metadata.egress_global_timestamp")) {
-      phv->get_field("intrinsic_metadata.egress_global_timestamp")
-          .set(get_ts().count());
-    }
-
-    if (with_queueing_metadata) {
-      auto enq_timestamp =
-          phv->get_field("queueing_metadata.enq_timestamp").get<ts_res::rep>();
-      phv->get_field("queueing_metadata.deq_timedelta").set(
-          get_ts().count() - enq_timestamp);
-      phv->get_field("queueing_metadata.deq_qdepth").set(
-          egress_buffers.size(port, priority));
-      if (phv->has_field("queueing_metadata.qid")) {
-        auto &qid_f = phv->get_field("queueing_metadata.qid");
-        qid_f.set(priority);
+    if (packet->has_next_node()) {
+      egress_mau->apply_from_next_node(packet.get());
+    } else {
+      if (phv->has_field("intrinsic_metadata.egress_global_timestamp")) {
+        phv->get_field("intrinsic_metadata.egress_global_timestamp")
+            .set(get_ts().count());
       }
+
+      if (with_queueing_metadata) {
+        auto enq_timestamp =
+          phv->get_field("queueing_metadata.enq_timestamp").get<ts_res::rep>();
+        phv->get_field("queueing_metadata.deq_timedelta").set(
+            get_ts().count() - enq_timestamp);
+        phv->get_field("queueing_metadata.deq_qdepth").set(
+            egress_buffers.size(port, priority));
+        if (phv->has_field("queueing_metadata.qid")) {
+          auto &qid_f = phv->get_field("queueing_metadata.qid");
+          qid_f.set(priority);
+        }
+      }
+
+      phv->get_field("standard_metadata.egress_port").set(port);
+      Field &f_egress_spec = phv->get_field("standard_metadata.egress_spec");
+      // When egress_spec == drop_port the packet will be dropped, thus
+      // here we initialize egress_spec to a value different from drop_port.
+      f_egress_spec.set(drop_port + 1);
+
+      phv->get_field("standard_metadata.packet_length").set(
+          packet->get_register(RegisterAccess::PACKET_LENGTH_REG_IDX));
+
+      egress_mau->apply(packet.get());
     }
 
-    phv->get_field("standard_metadata.egress_port").set(port);
-
-    Field &f_egress_spec = phv->get_field("standard_metadata.egress_spec");
-    // When egress_spec == drop_port the packet will be dropped, thus
-    // here we initialize egress_spec to a value different from drop_port.
-    f_egress_spec.set(drop_port + 1);
-
-    phv->get_field("standard_metadata.packet_length").set(
-        packet->get_register(RegisterAccess::PACKET_LENGTH_REG_IDX));
-
-    egress_mau->apply(packet.get());
+#ifdef PKT_FANOUT_ON
+    {
+      auto &fanout_pkts = FanoutPktMgr::instance().get_fanout_pkts();
+      for (auto pkt : fanout_pkts) {
+        egress_buffers.push_front(worker_id, 0, std::unique_ptr<Packet>(pkt));
+        BMLOG_DEBUG_PKT(*pkt, "SELECTOR_FANOUT packet pushed to egress_buffer");
+      }
+      fanout_pkts.clear();
+    }
+#endif
 
     auto clone_mirror_session_id =
         RegisterAccess::get_clone_mirror_session_id(packet.get());

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -289,7 +289,7 @@ SimpleSwitch::start_and_return_() {
          BMLOG_DEBUG_PKT(*pkt,
            "SELECTOR_FANOUT packet pushed to ingress_buffer");
         });
-        
+
     threads_.push_back(std::move(ingress_thread));
     for (size_t i = 0; i < nb_egress_threads; i++) {
       auto egress_thread = std::thread(&SimpleSwitch::egress_thread, this, i);
@@ -298,7 +298,7 @@ SimpleSwitch::start_and_return_() {
           egress_thread.get_id(), [&](const bm::Packet *pkt) {
             this->egress_buffers.push_front(i, 0,
               std::unique_ptr<bm::Packet>(const_cast<bm::Packet *>(pkt)));
-            BMLOG_DEBUG_PKT(*pkt, 
+            BMLOG_DEBUG_PKT(*pkt,
               "SELECTOR_FANOUT packet pushed to egress_buffer");
           });
 
@@ -696,7 +696,7 @@ SimpleSwitch::egress_thread(size_t worker_id) {
 
     phv = packet->get_phv();
     Field &f_egress_spec = phv->get_field("standard_metadata.egress_spec");
-    
+
     if (packet->has_next_node()) {
       egress_mau->apply_from_next_node(packet.get());
     } else {

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -279,6 +279,7 @@ void
 SimpleSwitch::start_and_return_() {
   check_queueing_metadata();
   if (FanoutPktMgr::pkt_fanout_on) {
+    FanoutPktMgr::instance().set_grp_selector();
     auto ingress_thread = std::thread(&SimpleSwitch::ingress_thread, this);
     FanoutPktMgr::instance().register_thread(
         ingress_thread.get_id(), [&](const bm::Packet *pkt) {

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -27,6 +27,8 @@
 #include <bm/bm_sim/switch.h>
 #include <bm/bm_sim/event_logger.h>
 #include <bm/bm_sim/simple_pre_lag.h>
+#include <bm/bm_sim/action_profile.h>
+#include <bm/bm_sim/fanout_pkt_mgr.h>
 
 #include <memory>
 #include <chrono>
@@ -56,6 +58,7 @@ using bm::Pipeline;
 using bm::McSimplePreLAG;
 using bm::Field;
 using bm::FieldList;
+using bm::FanoutPktMgr;
 using bm::packet_id_t;
 using bm::p4object_id_t;
 

--- a/tools/runtime_CLI.py
+++ b/tools/runtime_CLI.py
@@ -1536,7 +1536,7 @@ class RuntimeAPI(cmd.Cmd):
 
     @handle_bad_input
     def do_table_indirect_set_default_with_group(self, line):
-        "Set default group for indirect match table: table_indirect_set_default <table name> <group handle>"
+        "Set default group for indirect match table: table_indirect_set_default_with_group <table name> <group handle>"
 
         table_name, handle = self.indirect_set_default_common(line, ws=True)
 


### PR DESCRIPTION
This PR is derived from #1316 .
The testcases will be in another PR.

Main updates after #1316 :
1. Added command-line option `--enable-pkt-fanout` to `configure`, which defines `PKT_FANOUT_ON`. Is not supported in cmake for now. 
2. Raise an exception when `selector_fanout` mode is used while the above option is not given.
3. Set the `grp_selector` for all specified selectors during switch `start_and_return_`, less intrusive.
4. Previously, replicated pkts are pushed to ingress/egress-buffers in the `ingress/egree_thread` after the original packet gets processed. Now the logic is colocated with packet replication, which is much cleaner. 