### PR TITLE
remove linkage to libboost_system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ include_directories(
 
 # Find required packages
 find_package(Threads REQUIRED)
-find_package(Boost REQUIRED COMPONENTS thread program_options filesystem system)
+find_package(Boost REQUIRED COMPONENTS thread program_options filesystem)
 
 # Check for the presence of an include file and report an error if not found
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(bmall
   # FIXME: Is this scope correct?
   PUBLIC
     jsoncpp
-    Boost::system
     Boost::program_options
     Boost::filesystem
 )

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,4 +35,4 @@ $(top_builddir)/thrift_src/libruntimestubs.la
 endif
 
 libbmall_la_LIBADD += \
--lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+$(THRIFT_LIB) -lboost_program_options -lboost_filesystem

--- a/targets/l2_switch/CMakeLists.txt
+++ b/targets/l2_switch/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(l2_switch
   bmsim
   bmi
   jsoncpp
-  Boost::system
   Boost::program_options
   Boost::filesystem
   ${THRIFT_LIBRARIES}

--- a/targets/l2_switch/Makefile.am
+++ b/targets/l2_switch/Makefile.am
@@ -11,4 +11,4 @@ $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/thrift_src/libruntimestubs.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+$(THRIFT_LIB) -lboost_program_options -lboost_filesystem

--- a/targets/pna_nic/CMakeLists.txt
+++ b/targets/pna_nic/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(pnanic
   bmsim
   bmi
   jsoncpp
-  Boost::system
   Boost::program_options
   Boost::filesystem
   ${THRIFT_LIBRARIES}

--- a/targets/pna_nic/Makefile.am
+++ b/targets/pna_nic/Makefile.am
@@ -21,7 +21,7 @@ libpnanic_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+$(THRIFT_LIB) -lboost_program_options -lboost_filesystem
 
 if COND_THRIFT
 

--- a/targets/psa_switch/CMakeLists.txt
+++ b/targets/psa_switch/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(psaswitch
   bmsim
   bmi
   jsoncpp
-  Boost::system
   Boost::program_options
   Boost::filesystem
   ${THRIFT_LIBRARIES}

--- a/targets/psa_switch/Makefile.am
+++ b/targets/psa_switch/Makefile.am
@@ -21,7 +21,7 @@ libpsaswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+$(THRIFT_LIB) -lboost_program_options -lboost_filesystem
 
 if COND_THRIFT
 

--- a/targets/simple_router/CMakeLists.txt
+++ b/targets/simple_router/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(simple_router
   bmi
   runtimestubs
   jsoncpp
-  Boost::system
   Boost::program_options
   Boost::filesystem
   ${THRIFT_LIBRARIES}

--- a/targets/simple_router/Makefile.am
+++ b/targets/simple_router/Makefile.am
@@ -6,4 +6,4 @@ $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/thrift_src/libruntimestubs.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+$(THRIFT_LIB) -lboost_program_options -lboost_filesystem

--- a/targets/simple_switch/CMakeLists.txt
+++ b/targets/simple_switch/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(simpleswitch
   bmsim
   bmi
   jsoncpp
-  Boost::system
   Boost::program_options
   Boost::filesystem
   ${THRIFT_LIBRARIES}

--- a/targets/simple_switch/Makefile.am
+++ b/targets/simple_switch/Makefile.am
@@ -33,7 +33,7 @@ libsimpleswitch_la_LIBADD = \
 $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/src/BMI/libbmi.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system $(THRIFT_LIB) -lboost_program_options -lboost_filesystem
+$(THRIFT_LIB) -lboost_program_options -lboost_filesystem
 
 libsimpleswitch_runner_la_LIBADD = \
 $(PI_LIB) \

--- a/targets/simple_switch/tests/CMakeLists.txt
+++ b/targets/simple_switch/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ foreach(TEST ${TESTS})
     simpleswitch
     test_utils
     ${THRIFT_LIBRARIES}
-    Boost::system
     Boost::filesystem
     Boost::program_options
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,7 +94,6 @@ foreach(TEST_NAME ${TESTS})
     jsoncpp
     testutils
     ${THRIFT_LIBRARIES}
-    Boost::system
     Boost::filesystem
     Boost::program_options
   )
@@ -155,7 +154,6 @@ target_link_libraries(test_all
   jsoncpp
   testutils
   ${THRIFT_LIBRARIES}
-  Boost::system
   Boost::filesystem
   Boost::program_options
 )

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,7 @@ $(top_builddir)/thrift_src/libruntimestubs.la \
 $(THRIFT_LIB) \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
 $(builddir)/libtestutils.la \
--lboost_system -lboost_filesystem -lboost_program_options
+-lboost_filesystem -lboost_program_options
 
 # Define unit tests
 common_source = main.cpp bmi_stubs.c primitives.cpp

--- a/tests/stress_tests/CMakeLists.txt
+++ b/tests/stress_tests/CMakeLists.txt
@@ -24,7 +24,6 @@ foreach(target ${TESTS})
     bmsim
     jsoncpp
     ${THRIFT_LIBRARIES}
-    Boost::system
     Boost::filesystem
     Boost::program_options
   )

--- a/tests/stress_tests/Makefile.am
+++ b/tests/stress_tests/Makefile.am
@@ -7,7 +7,7 @@ $(top_builddir)/third_party/gtest/libgtest.la \
 $(top_builddir)/src/bm_apps/libbmapps.la \
 $(top_builddir)/src/bm_sim/libbmsim.la \
 $(top_builddir)/third_party/jsoncpp/libjson.la \
--lboost_system -lboost_filesystem -lboost_program_options
+-lboost_filesystem -lboost_program_options
 
 # TODO(antonin): should the traffic.bin files be generated at compile time by
 # running the Python generator (instead of being checked in)?


### PR DESCRIPTION
Boost's system library has been a stub since version 1.69 [1], and header-only since 1.89 [2]. Because we try to link against it, building fails with boost 1.89 or newer. Since boost 1.69 has been released back in 2018 [3], I don't think that any reasonable targets still rely on it.

[1] https://github.com/boostorg/system/issues/132#issuecomment-3146378680
[2] https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3
[3] https://www.boost.org/releases/1.69.0/