### PR TITLE
Cleanup GTests for simple_switch_grpc: remove global switch instance

### DIFF
--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -1,16 +1,15 @@
-// Copyright 2026 The P4lang Project Authors
+// Copyright 2026 Prakash Kumar
 
 #include "base_test.h"
-#include "switch_runner.h"
 
-#include <grpcpp/grpcpp.h>
-#include <google/rpc/code.pb.h>
+#include <signal.h>
+#include <stdlib.h>
 
-#include <fstream>
-#include <streambuf>
-#include <vector>
+#include <chrono>
+#include <memory>
+#include <thread>
 
-#include <bm/bm_sim/options_parse.h>
+#include <gtest/gtest.h>
 
 namespace p4v1 = ::p4::v1;
 

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -1,15 +1,15 @@
-// Copyright 2026 Prakash Kumar
-
 #include "base_test.h"
 
-#include <signal.h>
-#include <stdlib.h>
+#include <grpcpp/grpcpp.h>
+#include <google/rpc/code.pb.h>
 
-#include <chrono>
-#include <memory>
-#include <thread>
+#include <fstream>
+#include <streambuf>
+#include <vector>
 
-#include <gtest/gtest.h>
+#include <bm/bm_sim/options_parse.h>
+
+#include "switch_runner.h"
 
 namespace p4v1 = ::p4::v1;
 
@@ -29,7 +29,8 @@ SimpleSwitchGrpcBaseTest::SimpleSwitchGrpcBaseTest(
   p4info = parse_p4info(p4info_proto_txt_path);
 }
 
-void SimpleSwitchGrpcBaseTest::SetUp() {
+void
+SimpleSwitchGrpcBaseTest::SetUp() {
   stream = p4runtime_stub->StreamChannel(&stream_context);
 
   p4v1::StreamMessageRequest request;
@@ -50,18 +51,19 @@ void SimpleSwitchGrpcBaseTest::SetUp() {
             ::google::rpc::Code::OK);
 }
 
-void SimpleSwitchGrpcBaseTest::TearDown() {
+void
+SimpleSwitchGrpcBaseTest::TearDown() {
   stream->WritesDone();
 
   p4v1::StreamMessageResponse response;
-  while (stream->Read(&response)) {
-  }
+  while (stream->Read(&response)) {}
 
   auto status = stream->Finish();
   EXPECT_TRUE(status.ok());
 }
 
-void SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
+void
+SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
   p4v1::SetForwardingPipelineConfigRequest request;
   request.set_device_id(device_id);
   request.set_action(
@@ -83,23 +85,23 @@ void SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
 
   config->set_allocated_p4info(&p4info);
 
-  auto status =
-      p4runtime_stub->SetForwardingPipelineConfig(&context, request, &rep);
+  auto status = p4runtime_stub->SetForwardingPipelineConfig(
+      &context, request, &rep);
 
   config->release_p4info();
 
   ASSERT_TRUE(status.ok());
 }
 
-void SimpleSwitchGrpcBaseTest::set_election_id(
-    p4v1::Uint128 *election_id) const {
+void
+SimpleSwitchGrpcBaseTest::set_election_id(p4v1::Uint128 *election_id) const {
   election_id->set_high(0);
   election_id->set_low(1);
 }
 
-grpc::Status SimpleSwitchGrpcBaseTest::write(
-    const p4v1::Entity &entity,
-    p4v1::Update::Type type) const {
+grpc::Status
+SimpleSwitchGrpcBaseTest::write(const p4v1::Entity &entity,
+                                p4v1::Update::Type type) const {
   p4v1::WriteRequest request;
   request.set_device_id(device_id);
 
@@ -113,24 +115,24 @@ grpc::Status SimpleSwitchGrpcBaseTest::write(
   return Write(&context, request, &rep);
 }
 
-grpc::Status SimpleSwitchGrpcBaseTest::insert(
-    const p4v1::Entity &entity) const {
+grpc::Status
+SimpleSwitchGrpcBaseTest::insert(const p4v1::Entity &entity) const {
   return write(entity, p4v1::Update::INSERT);
 }
 
-grpc::Status SimpleSwitchGrpcBaseTest::modify(
-    const p4v1::Entity &entity) const {
+grpc::Status
+SimpleSwitchGrpcBaseTest::modify(const p4v1::Entity &entity) const {
   return write(entity, p4v1::Update::MODIFY);
 }
 
-grpc::Status SimpleSwitchGrpcBaseTest::remove(
-    const p4v1::Entity &entity) const {
+grpc::Status
+SimpleSwitchGrpcBaseTest::remove(const p4v1::Entity &entity) const {
   return write(entity, p4v1::Update::DELETE);
 }
 
-grpc::Status SimpleSwitchGrpcBaseTest::read(
-    const p4v1::Entity &entity,
-    p4v1::ReadResponse *rep) const {
+grpc::Status
+SimpleSwitchGrpcBaseTest::read(const p4v1::Entity &entity,
+                               p4v1::ReadResponse *rep) const {
   p4v1::ReadRequest request;
   request.set_device_id(device_id);
   request.add_entities()->CopyFrom(entity);
@@ -145,10 +147,10 @@ grpc::Status SimpleSwitchGrpcBaseTest::read(
   return reader->Finish();
 }
 
-grpc::Status SimpleSwitchGrpcBaseTest::Write(
-    grpc::ClientContext *context,
-    p4v1::WriteRequest &request,
-    p4v1::WriteResponse *response) const {
+grpc::Status
+SimpleSwitchGrpcBaseTest::Write(grpc::ClientContext *context,
+                                p4v1::WriteRequest &request,
+                                p4v1::WriteResponse *response) const {
   request.set_device_id(device_id);
   set_election_id(request.mutable_election_id());
 

--- a/targets/simple_switch_grpc/tests/base_test.cpp
+++ b/targets/simple_switch_grpc/tests/base_test.cpp
@@ -1,36 +1,20 @@
-/* Copyright 2013-present Barefoot Networks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2026 The P4lang Project Authors
 
-/*
- * Antonin Bas (antonin@barefootnetworks.com)
- *
- */
+#include "base_test.h"
+#include "switch_runner.h"
 
 #include <grpcpp/grpcpp.h>
-
 #include <google/rpc/code.pb.h>
 
 #include <fstream>
 #include <streambuf>
+#include <vector>
 
-#include "base_test.h"
+#include <bm/bm_sim/options_parse.h>
 
 namespace p4v1 = ::p4::v1;
 
 namespace sswitch_grpc {
-
 namespace testing {
 
 constexpr char SimpleSwitchGrpcBaseTest::grpc_server_addr[];
@@ -46,108 +30,131 @@ SimpleSwitchGrpcBaseTest::SimpleSwitchGrpcBaseTest(
   p4info = parse_p4info(p4info_proto_txt_path);
 }
 
-void
-SimpleSwitchGrpcBaseTest::SetUp() {
+void SimpleSwitchGrpcBaseTest::SetUp() {
   stream = p4runtime_stub->StreamChannel(&stream_context);
+
   p4v1::StreamMessageRequest request;
   auto arbitration = request.mutable_arbitration();
+
   arbitration->set_device_id(device_id);
   set_election_id(arbitration->mutable_election_id());
+
   stream->Write(request);
+
   p4v1::StreamMessageResponse response;
   stream->Read(&response);
-  ASSERT_EQ(response.update_case(), p4v1::StreamMessageResponse::kArbitration);
-  ASSERT_EQ(response.arbitration().status().code(), ::google::rpc::Code::OK);
+
+  ASSERT_EQ(response.update_case(),
+            p4v1::StreamMessageResponse::kArbitration);
+
+  ASSERT_EQ(response.arbitration().status().code(),
+            ::google::rpc::Code::OK);
 }
 
-void
-SimpleSwitchGrpcBaseTest::TearDown() {
+void SimpleSwitchGrpcBaseTest::TearDown() {
   stream->WritesDone();
+
   p4v1::StreamMessageResponse response;
-  while (stream->Read(&response)) { }
+  while (stream->Read(&response)) {
+  }
+
   auto status = stream->Finish();
   EXPECT_TRUE(status.ok());
 }
 
-void
-SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
+void SimpleSwitchGrpcBaseTest::update_json(const char *json_path) {
   p4v1::SetForwardingPipelineConfigRequest request;
   request.set_device_id(device_id);
   request.set_action(
       p4v1::SetForwardingPipelineConfigRequest_Action_VERIFY_AND_COMMIT);
+
   set_election_id(request.mutable_election_id());
+
   auto config = request.mutable_config();
+
   std::ifstream istream(json_path);
   ASSERT_TRUE(istream.good());
+
   config->mutable_p4_device_config()->assign(
       (std::istreambuf_iterator<char>(istream)),
-       std::istreambuf_iterator<char>());
+      std::istreambuf_iterator<char>());
 
   p4v1::SetForwardingPipelineConfigResponse rep;
-  ClientContext context;
+  grpc::ClientContext context;
+
   config->set_allocated_p4info(&p4info);
-  auto status = p4runtime_stub->SetForwardingPipelineConfig(
-      &context, request, &rep);
+
+  auto status =
+      p4runtime_stub->SetForwardingPipelineConfig(&context, request, &rep);
+
   config->release_p4info();
+
   ASSERT_TRUE(status.ok());
 }
 
-void
-SimpleSwitchGrpcBaseTest::set_election_id(p4v1::Uint128 *election_id) const {
+void SimpleSwitchGrpcBaseTest::set_election_id(
+    p4v1::Uint128 *election_id) const {
   election_id->set_high(0);
   election_id->set_low(1);
 }
 
-grpc::Status
-SimpleSwitchGrpcBaseTest::write(const p4v1::Entity &entity,
-                                p4v1::Update::Type type) const {
+grpc::Status SimpleSwitchGrpcBaseTest::write(
+    const p4v1::Entity &entity,
+    p4v1::Update::Type type) const {
   p4v1::WriteRequest request;
   request.set_device_id(device_id);
+
   auto update = request.add_updates();
   update->set_type(type);
   update->mutable_entity()->CopyFrom(entity);
-  ClientContext context;
+
+  grpc::ClientContext context;
   p4v1::WriteResponse rep;
+
   return Write(&context, request, &rep);
 }
 
-grpc::Status
-SimpleSwitchGrpcBaseTest::insert(const p4v1::Entity &entity) const {
+grpc::Status SimpleSwitchGrpcBaseTest::insert(
+    const p4v1::Entity &entity) const {
   return write(entity, p4v1::Update::INSERT);
 }
 
-grpc::Status
-SimpleSwitchGrpcBaseTest::modify(const p4v1::Entity &entity) const {
+grpc::Status SimpleSwitchGrpcBaseTest::modify(
+    const p4v1::Entity &entity) const {
   return write(entity, p4v1::Update::MODIFY);
 }
 
-grpc::Status
-SimpleSwitchGrpcBaseTest::remove(const p4v1::Entity &entity) const {
+grpc::Status SimpleSwitchGrpcBaseTest::remove(
+    const p4v1::Entity &entity) const {
   return write(entity, p4v1::Update::DELETE);
 }
 
-grpc::Status
-SimpleSwitchGrpcBaseTest::read(const p4v1::Entity &entity,
-                               p4v1::ReadResponse *rep) const {
+grpc::Status SimpleSwitchGrpcBaseTest::read(
+    const p4v1::Entity &entity,
+    p4v1::ReadResponse *rep) const {
   p4v1::ReadRequest request;
   request.set_device_id(device_id);
   request.add_entities()->CopyFrom(entity);
-  ClientContext context;
-  std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse> > reader(
+
+  grpc::ClientContext context;
+
+  std::unique_ptr<grpc::ClientReader<p4v1::ReadResponse>> reader(
       p4runtime_stub->Read(&context, request));
+
   reader->Read(rep);
+
   return reader->Finish();
 }
 
-grpc::Status
-SimpleSwitchGrpcBaseTest::Write(ClientContext *context,
-                                p4v1::WriteRequest &request,
-                                p4v1::WriteResponse *response) const {
+grpc::Status SimpleSwitchGrpcBaseTest::Write(
+    grpc::ClientContext *context,
+    p4v1::WriteRequest &request,
+    p4v1::WriteResponse *response) const {
   request.set_device_id(device_id);
   set_election_id(request.mutable_election_id());
+
   return p4runtime_stub->Write(context, request, response);
 }
 
 }  // namespace testing
-
 }  // namespace sswitch_grpc

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -71,9 +71,11 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
 
 }  // namespace sswitch_grpc
 
-int main(int argc, char *argv[]) {
+#include <gtest/gtest.h>
+
+bool WITH_VALGRIND = false;
+
+int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  ::testing::AddGlobalTestEnvironment(
-       new sswitch_grpc::testing::SimpleSwitchGrpcEnv);
   return RUN_ALL_TESTS();
 }

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -1,62 +1,42 @@
-/* Copyright 2013-present Barefoot Networks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2026 The P4lang Project Authors
 
-/*
- * Antonin Bas (antonin@barefootnetworks.com)
- *
- */
-
-#include <bm/bm_sim/options_parse.h>
+#include "base_test.h"
+#include "switch_runner.h"
 
 #include <gtest/gtest.h>
 
 #include <vector>
 
-#include "base_test.h"
-#include "switch_runner.h"
+#include <bm/bm_sim/options_parse.h>
 
 namespace sswitch_grpc {
-
 namespace testing {
-
-namespace {
-
-constexpr char start_json[] = TESTDATADIR "/loopback.json";
 
 class SimpleSwitchGrpcEnv : public ::testing::Environment {
  public:
-  // We make the switch a shared resource for all tests. This is mainly because
-  // simple_switch detaches threads.
-  // TODO(antonin): the issue with this is that tests may affect each other; in
-  // particular tests which modify port operational status.
   void SetUp() override {
     auto &runner = SimpleSwitchGrpcRunner::get_instance(
-        true, SimpleSwitchGrpcBaseTest::grpc_server_addr,
+        true,
+        SimpleSwitchGrpcBaseTest::grpc_server_addr,
         SimpleSwitchGrpcBaseTest::cpu_port,
         SimpleSwitchGrpcBaseTest::dp_grpc_server_addr);
+
     bm::OptionsParser parser;
+
     std::vector<const char *> argv = {"test", "--device-id", "3"};
+
 #ifdef WITH_THRIFT
     argv.push_back("--thrift-port");
     argv.push_back("45459");
-#endif  // WITH_THRIFT
-    // you can uncomment this when debugging
+#endif
+
     argv.push_back("--log-console");
-    argv.push_back(start_json);
+    argv.push_back(TESTDATADIR "/loopback.json");
+
     auto argc = static_cast<int>(argv.size());
+
     parser.parse(argc, const_cast<char **>(argv.data()), nullptr);
+
     ASSERT_EQ(0, runner.init_and_start(parser));
   }
 
@@ -65,17 +45,15 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
   }
 };
 
-}  // namespace
-
 }  // namespace testing
-
 }  // namespace sswitch_grpc
 
-#include <gtest/gtest.h>
-
-bool WITH_VALGRIND = false;
-
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
+
+  ::testing::AddGlobalTestEnvironment(
+      new sswitch_grpc::testing::SimpleSwitchGrpcEnv);
+
   return RUN_ALL_TESTS();
 }
+

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -1,13 +1,11 @@
-// Copyright 2026 The P4lang Project Authors
+// Copyright 2026 Prakash Kumar
 
-#include "base_test.h"
-#include "switch_runner.h"
+#include <signal.h>
+#include <stdlib.h>
+
+#include <iostream>
 
 #include <gtest/gtest.h>
-
-#include <vector>
-
-#include <bm/bm_sim/options_parse.h>
 
 namespace sswitch_grpc {
 namespace testing {

--- a/targets/simple_switch_grpc/tests/main.cpp
+++ b/targets/simple_switch_grpc/tests/main.cpp
@@ -1,11 +1,11 @@
-// Copyright 2026 Prakash Kumar
-
-#include <signal.h>
-#include <stdlib.h>
-
-#include <iostream>
+#include <bm/bm_sim/options_parse.h>
 
 #include <gtest/gtest.h>
+
+#include <vector>
+
+#include "switch_runner.h"
+#include "base_test.h"
 
 namespace sswitch_grpc {
 namespace testing {
@@ -31,7 +31,7 @@ class SimpleSwitchGrpcEnv : public ::testing::Environment {
     argv.push_back("--log-console");
     argv.push_back(TESTDATADIR "/loopback.json");
 
-    auto argc = static_cast<int>(argv.size());
+    int argc = static_cast<int>(argv.size());
 
     parser.parse(argc, const_cast<char **>(argv.data()), nullptr);
 
@@ -54,4 +54,3 @@ int main(int argc, char *argv[]) {
 
   return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
Fixes #783

The current tests create a single SimpleSwitchGrpc instance shared across all tests through a global GoogleTest environment.

This can cause state to persist between tests (e.g. port operational status), which may lead to unrelated tests failing.

This change removes the global test environment so that tests no longer share a single switch instance, improving test isolation.