### PR TITLE
feat: add configurable log rotation options (fixes #930)

### DIFF
--- a/include/bm/bm_sim/logger.h
+++ b/include/bm/bm_sim/logger.h
@@ -89,9 +89,13 @@ class Logger {
   static void set_logger_console();
 
   //! Log all messages to the given file. If \p force_flush is true, the logger
-  //! will flush to disk after every log message.
+  //! will flush to disk after every log message. \p max_size is the maximum
+  //! size of a single log file in bytes before rotation. \p max_files is the
+  //! number of rotated backup files to keep.
   static void set_logger_file(const std::string &filename,
-                              bool force_flush = false);
+                              bool force_flush = false,
+                              size_t max_size = 1024 * 1024 * 5,
+                              size_t max_files = 3);
 
   //! Log all messages to the given output stream. Mostly used for testing.
   // NOLINTNEXTLINE(runtime/references)

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -90,6 +90,10 @@ class OptionsParser {
   Logger::LogLevel log_level{Logger::LogLevel::TRACE};
   // by default file logs are not "force-flushed" to disk
   bool log_flush{false};
+  // max size of a single log file (in bytes) before rotation
+  size_t log_max_size{1024 * 1024 * 5};
+  // number of rotated backup log files to keep
+  size_t log_max_files{3};
   std::string notifications_addr{};
   bool debugger{false};
   std::string debugger_addr{};

--- a/src/bm_sim/logger.cpp
+++ b/src/bm_sim/logger.cpp
@@ -40,10 +40,11 @@ Logger::set_logger_console() {
 }
 
 void
-Logger::set_logger_file(const std::string &filename, bool force_flush) {
+Logger::set_logger_file(const std::string &filename, bool force_flush,
+                         size_t max_size, size_t max_files) {
   unset_logger();
   auto logger_ = spdlog::rotating_logger_mt("bmv2", filename,
-                                            1024 * 1024 * 5, 3, force_flush);
+                                            max_size, max_files, force_flush);
   logger = logger_.get();
   set_pattern();
   logger_->set_level(to_spd_level(LogLevel::DEBUG));

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -128,6 +128,11 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
        "'trace', 'debug', 'info', 'warn', 'error', off'; default is 'trace'")
       ("log-flush", "If used with '--log-file', the logger will flush to disk "
        "after every log message")
+      ("log-file-max-size", po::value<size_t>(),
+       "Maximum size of a single log file (in bytes) before rotation; "
+       "default is 5242880 (5 MB)")
+      ("log-file-max-files", po::value<size_t>(),
+       "Maximum number of rotated backup log files to keep; default is 3")
 #ifdef BM_NANOMSG_ON
       ("notifications-addr", po::value<std::string>(),
        "Specify the nanomsg address to use for notifications "
@@ -326,6 +331,28 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
                 << "not specified\n";
     } else {
       log_flush = true;
+    }
+  }
+
+  if (vm.count("log-file-max-size")) {
+    if (!vm.count("log-file")) {
+      outstream << "Ignoring --log-file-max-size option because --log-file "
+                << "not specified\n";
+    } else {
+      log_max_size = vm["log-file-max-size"].as<size_t>();
+      if (log_max_size == 0) {
+        outstream << "Error: --log-file-max-size must be greater than 0\n";
+        exit(1);
+      }
+    }
+  }
+
+  if (vm.count("log-file-max-files")) {
+    if (!vm.count("log-file")) {
+      outstream << "Ignoring --log-file-max-files option because --log-file "
+                << "not specified\n";
+    } else {
+      log_max_files = vm["log-file-max-files"].as<size_t>();
     }
   }
 

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -253,7 +253,8 @@ SwitchWContexts::init_from_options_parser(
     Logger::set_logger_console();
 
   if (parser.file_logger != "")
-    Logger::set_logger_file(parser.file_logger, parser.log_flush);
+    Logger::set_logger_file(parser.file_logger, parser.log_flush,
+                            parser.log_max_size, parser.log_max_files);
 
   Logger::set_log_level(parser.log_level);
 


### PR DESCRIPTION
Add --log-file-max-size and --log-file-max-files CLI options to allow users to configure the maximum log file size before rotation and the number of rotated backup files to keep.

Previously these values were hardcoded to 5MB and 3 files respectively. The new options default to the same values for backward compatibility.

fixes #930