### PR TITLE
Feature/configurable pre limits

### DIFF
--- a/include/bm/bm_sim/simple_pre.h
+++ b/include/bm/bm_sim/simple_pre.h
@@ -82,6 +82,10 @@ class McSimplePre {
   };
 
  public:
+  static constexpr int DEFAULT_MGID_TABLE_SIZE = 4096;
+  static constexpr int DEFAULT_L1_MAX_ENTRIES = 4096;
+  static constexpr int DEFAULT_L2_MAX_ENTRIES = 8192;
+
   static constexpr size_t PORT_MAP_SIZE = 512;
   using PortMap = McPre::Set<PORT_MAP_SIZE>;
 
@@ -145,10 +149,6 @@ class McSimplePre {
   McSimplePre &operator=(McSimplePre &&other) = delete;
 
  protected:
-  static constexpr int DEFAULT_MGID_TABLE_SIZE = 4096;
-  static constexpr int DEFAULT_L1_MAX_ENTRIES = 4096;
-  static constexpr int DEFAULT_L2_MAX_ENTRIES = 8192;
-
   int mgid_table_size;
   int l1_max_entries;
   int l2_max_entries;

--- a/include/bm/bm_sim/simple_pre.h
+++ b/include/bm/bm_sim/simple_pre.h
@@ -88,7 +88,13 @@ class McSimplePre {
   static constexpr size_t LAG_MAP_SIZE = 512;
   using LagMap = McPre::Set<LAG_MAP_SIZE>;
 
-  McSimplePre() {}
+  explicit McSimplePre(
+      int mgid_table_size = DEFAULT_MGID_TABLE_SIZE,
+      int l1_max_entries = DEFAULT_L1_MAX_ENTRIES,
+      int l2_max_entries = DEFAULT_L2_MAX_ENTRIES)
+      : mgid_table_size(mgid_table_size),
+        l1_max_entries(l1_max_entries),
+        l2_max_entries(l2_max_entries) {}
   McReturnCode mc_mgrp_create(const mgrp_t, mgrp_hdl_t *);
   McReturnCode mc_mgrp_destroy(const mgrp_hdl_t);
   McReturnCode mc_node_create(const rid_t,
@@ -139,9 +145,13 @@ class McSimplePre {
   McSimplePre &operator=(McSimplePre &&other) = delete;
 
  protected:
-  static constexpr int MGID_TABLE_SIZE = 4096;
-  static constexpr int L1_MAX_ENTRIES = 4096;
-  static constexpr int L2_MAX_ENTRIES = 8192;
+  static constexpr int DEFAULT_MGID_TABLE_SIZE = 4096;
+  static constexpr int DEFAULT_L1_MAX_ENTRIES = 4096;
+  static constexpr int DEFAULT_L2_MAX_ENTRIES = 8192;
+
+  int mgid_table_size;
+  int l1_max_entries;
+  int l2_max_entries;
 
   struct MgidEntry {
     mgrp_t mgid{};

--- a/include/bm/bm_sim/simple_pre_lag.h
+++ b/include/bm/bm_sim/simple_pre_lag.h
@@ -39,6 +39,12 @@ class McSimplePreLAG : public McSimplePre {
   static constexpr int LAG_MAX_ENTRIES = 256;
   using lag_id_t = uint16_t;
 
+  explicit McSimplePreLAG(
+      int mgid_table_size = McSimplePre::DEFAULT_MGID_TABLE_SIZE,
+      int l1_max_entries = McSimplePre::DEFAULT_L1_MAX_ENTRIES,
+      int l2_max_entries = McSimplePre::DEFAULT_L2_MAX_ENTRIES)
+      : McSimplePre(mgid_table_size, l1_max_entries, l2_max_entries) {}
+
   McReturnCode mc_node_create(const rid_t rid,
                               const PortMap &port_map,
                               const LagMap &lag_map,

--- a/src/bm_sim/simple_pre.cpp
+++ b/src/bm_sim/simple_pre.cpp
@@ -35,7 +35,7 @@ McSimplePre::McReturnCode
 McSimplePre::mc_mgrp_create(const mgrp_t mgid, mgrp_hdl_t *mgrp_hdl) {
   boost::unique_lock<boost::shared_mutex> lock(mutex);
   size_t num_entries = mgid_entries.size();
-  if (num_entries >= MGID_TABLE_SIZE) {
+  if (num_entries >= static_cast<size_t>(mgid_table_size)) {
     Logger::get()->error("mgrp create failed, mgid table full");
     return TABLE_FULL;
   }
@@ -62,11 +62,11 @@ McSimplePre::mc_node_create(const rid_t rid,
   l2_hdl_t l2_hdl;
   size_t num_l1_entries = l1_entries.size();
   size_t num_l2_entries = l2_entries.size();
-  if (num_l1_entries >= L1_MAX_ENTRIES) {
+  if (num_l1_entries >= static_cast<size_t>(l1_max_entries)) {
     Logger::get()->error("node create failed, l1 table full");
     return TABLE_FULL;
   }
-  if (num_l2_entries >= L2_MAX_ENTRIES) {
+  if (num_l2_entries >= static_cast<size_t>(l2_max_entries)) {
     Logger::get()->error("node create failed, l2 table full");
     return TABLE_FULL;
   }

--- a/src/bm_sim/simple_pre_lag.cpp
+++ b/src/bm_sim/simple_pre_lag.cpp
@@ -38,11 +38,11 @@ McSimplePreLAG::mc_node_create(const rid_t rid,
   l2_hdl_t l2_hdl;
   size_t num_l1_entries = l1_entries.size();
   size_t num_l2_entries = l2_entries.size();
-  if (num_l1_entries >= L1_MAX_ENTRIES) {
+  if (num_l1_entries >= static_cast<size_t>(l1_max_entries)) {
     Logger::get()->error("node create failed, l1 table full");
     return TABLE_FULL;
   }
-  if (num_l2_entries >= L2_MAX_ENTRIES) {
+  if (num_l2_entries >= static_cast<size_t>(l2_max_entries)) {
     Logger::get()->error("node create failed, l2 table full");
     return TABLE_FULL;
   }

--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -22,6 +22,8 @@
 
 #include <bm/config.h>
 
+#include <climits>
+
 #include <bm/SimpleSwitch.h>
 #include <bm/bm_runtime/bm_runtime.h>
 #include <bm/bm_sim/options_parse.h>
@@ -95,6 +97,11 @@ main(int argc, char* argv[]) {
       mgid_table_size = SimpleSwitch::default_mgid_table_size;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
+    if (mgid_table_size == 0 || mgid_table_size > INT_MAX) {
+      std::cerr << "max-mc-groups must be between 1 and "
+                << INT_MAX << std::endl;
+      std::exit(1);
+    }
   }
 
   uint32_t l1_max_entries = 0xffffffff;
@@ -105,6 +112,11 @@ main(int argc, char* argv[]) {
       l1_max_entries = SimpleSwitch::default_l1_max_entries;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
+    if (l1_max_entries == 0 || l1_max_entries > INT_MAX) {
+      std::cerr << "max-l1-entries must be between 1 and "
+                << INT_MAX << std::endl;
+      std::exit(1);
+    }
   }
 
   uint32_t l2_max_entries = 0xffffffff;
@@ -115,6 +127,11 @@ main(int argc, char* argv[]) {
       l2_max_entries = SimpleSwitch::default_l2_max_entries;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
+    if (l2_max_entries == 0 || l2_max_entries > INT_MAX) {
+      std::cerr << "max-l2-entries must be between 1 and "
+                << INT_MAX << std::endl;
+      std::exit(1);
+    }
   }
 
   simple_switch = new SimpleSwitch(enable_swap_flag, drop_port,

--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -28,6 +28,7 @@
 #include <bm/bm_sim/target_parser.h>
 
 #include <climits>
+#include <string>
 
 #include "simple_switch.h"
 
@@ -53,13 +54,16 @@ main(int argc, char* argv[]) {
       "Number of priority queues (default is 1)");
   simple_switch_parser.add_uint_option(
       "max-mc-groups",
-      "Maximum number of multicast groups (default is 4096)");
+      "Maximum number of multicast groups (default is "
+      + std::to_string(SimpleSwitch::default_mgid_table_size) + ")");
   simple_switch_parser.add_uint_option(
       "max-l1-entries",
-      "Maximum number of L1 multicast entries (default is 4096)");
+      "Maximum number of L1 multicast entries (default is "
+      + std::to_string(SimpleSwitch::default_l1_max_entries) + ")");
   simple_switch_parser.add_uint_option(
       "max-l2-entries",
-      "Maximum number of L2 multicast entries (default is 8192)");
+      "Maximum number of L2 multicast entries (default is "
+      + std::to_string(SimpleSwitch::default_l2_max_entries) + ")");
 
   bm::OptionsParser parser;
   parser.parse(argc, argv, &simple_switch_parser);

--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -49,6 +49,15 @@ main(int argc, char* argv[]) {
   simple_switch_parser.add_uint_option(
       "priority-queues",
       "Number of priority queues (default is 1)");
+  simple_switch_parser.add_uint_option(
+      "max-mc-groups",
+      "Maximum number of multicast groups (default is 4096)");
+  simple_switch_parser.add_uint_option(
+      "max-l1-entries",
+      "Maximum number of L1 multicast entries (default is 4096)");
+  simple_switch_parser.add_uint_option(
+      "max-l2-entries",
+      "Maximum number of L2 multicast entries (default is 8192)");
 
   bm::OptionsParser parser;
   parser.parse(argc, argv, &simple_switch_parser);
@@ -78,8 +87,40 @@ main(int argc, char* argv[]) {
       std::exit(1);
   }
 
+  uint32_t mgid_table_size = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "max-mc-groups", &mgid_table_size);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      mgid_table_size = SimpleSwitch::default_mgid_table_size;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
+  uint32_t l1_max_entries = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "max-l1-entries", &l1_max_entries);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      l1_max_entries = SimpleSwitch::default_l1_max_entries;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
+  uint32_t l2_max_entries = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "max-l2-entries", &l2_max_entries);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      l2_max_entries = SimpleSwitch::default_l2_max_entries;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
   simple_switch = new SimpleSwitch(enable_swap_flag, drop_port,
-                                   priority_queues);
+                                   priority_queues,
+                                   mgid_table_size, l1_max_entries,
+                                   l2_max_entries);
 
   int status = simple_switch->init_from_options_parser(parser);
   if (status != 0) std::exit(status);

--- a/targets/simple_switch/main.cpp
+++ b/targets/simple_switch/main.cpp
@@ -22,12 +22,12 @@
 
 #include <bm/config.h>
 
-#include <climits>
-
 #include <bm/SimpleSwitch.h>
 #include <bm/bm_runtime/bm_runtime.h>
 #include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/target_parser.h>
+
+#include <climits>
 
 #include "simple_switch.h"
 

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -199,7 +199,10 @@ class SimpleSwitch::InputBuffer {
 };
 
 SimpleSwitch::SimpleSwitch(bool enable_swap, port_t drop_port,
-                           size_t nb_queues_per_port)
+                           size_t nb_queues_per_port,
+                           int mgid_table_size,
+                           int l1_max_entries,
+                           int l2_max_entries)
   : Switch(enable_swap),
     drop_port(drop_port),
     input_buffer(new InputBuffer(
@@ -216,7 +219,7 @@ SimpleSwitch::SimpleSwitch(bool enable_swap, port_t drop_port,
         _BM_UNUSED(pkt_id);
         this->transmit_fn(port_num, buffer, len);
     }),
-    pre(new McSimplePreLAG()),
+    pre(new McSimplePreLAG(mgid_table_size, l1_max_entries, l2_max_entries)),
     start(clock::now()),
     mirroring_sessions(new MirroringSessions()) {
   add_component<McSimplePreLAG>(pre);

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -75,6 +75,9 @@ class SimpleSwitch : public Switch {
 
   static constexpr port_t default_drop_port = 511;
   static constexpr size_t default_nb_queues_per_port = 1;
+  static constexpr int default_mgid_table_size = 4096;
+  static constexpr int default_l1_max_entries = 4096;
+  static constexpr int default_l2_max_entries = 8192;
 
  private:
   using clock = std::chrono::high_resolution_clock;
@@ -83,7 +86,10 @@ class SimpleSwitch : public Switch {
   // by default, swapping is off
   explicit SimpleSwitch(bool enable_swap = false,
                         port_t drop_port = default_drop_port,
-                        size_t nb_queues_per_port = default_nb_queues_per_port);
+                        size_t nb_queues_per_port = default_nb_queues_per_port,
+                        int mgid_table_size = default_mgid_table_size,
+                        int l1_max_entries = default_l1_max_entries,
+                        int l2_max_entries = default_l2_max_entries);
 
   ~SimpleSwitch();
 

--- a/targets/simple_switch/simple_switch.h
+++ b/targets/simple_switch/simple_switch.h
@@ -75,9 +75,12 @@ class SimpleSwitch : public Switch {
 
   static constexpr port_t default_drop_port = 511;
   static constexpr size_t default_nb_queues_per_port = 1;
-  static constexpr int default_mgid_table_size = 4096;
-  static constexpr int default_l1_max_entries = 4096;
-  static constexpr int default_l2_max_entries = 8192;
+  static constexpr int default_mgid_table_size =
+      bm::McSimplePre::DEFAULT_MGID_TABLE_SIZE;
+  static constexpr int default_l1_max_entries =
+      bm::McSimplePre::DEFAULT_L1_MAX_ENTRIES;
+  static constexpr int default_l2_max_entries =
+      bm::McSimplePre::DEFAULT_L2_MAX_ENTRIES;
 
  private:
   using clock = std::chrono::high_resolution_clock;

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -24,6 +24,7 @@
 #include <bm/bm_grpc/pem.h>
 
 #include <exception>
+#include <climits>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -245,6 +246,11 @@ main(int argc, char* argv[]) {
           sswitch_grpc::SimpleSwitchGrpcRunner::default_mgid_table_size;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
+    if (mgid_table_size == 0 || mgid_table_size > INT_MAX) {
+      std::cerr << "max-mc-groups must be between 1 and "
+                << INT_MAX << std::endl;
+      std::exit(1);
+    }
   }
 
   uint32_t l1_max_entries = 0xffffffff;
@@ -256,6 +262,11 @@ main(int argc, char* argv[]) {
           sswitch_grpc::SimpleSwitchGrpcRunner::default_l1_max_entries;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
+    if (l1_max_entries == 0 || l1_max_entries > INT_MAX) {
+      std::cerr << "max-l1-entries must be between 1 and "
+                << INT_MAX << std::endl;
+      std::exit(1);
+    }
   }
 
   uint32_t l2_max_entries = 0xffffffff;
@@ -267,6 +278,11 @@ main(int argc, char* argv[]) {
           sswitch_grpc::SimpleSwitchGrpcRunner::default_l2_max_entries;
     else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
       std::exit(1);
+    if (l2_max_entries == 0 || l2_max_entries > INT_MAX) {
+      std::cerr << "max-l2-entries must be between 1 and "
+                << INT_MAX << std::endl;
+      std::exit(1);
+    }
   }
 
   auto &runner = sswitch_grpc::SimpleSwitchGrpcRunner::get_instance(

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -81,6 +81,15 @@ main(int argc, char* argv[]) {
   simple_switch_parser.add_uint_option(
     "priority-queues",
     "Number of priority queues (default is 1)");
+  simple_switch_parser.add_uint_option(
+      "max-mc-groups",
+      "Maximum number of multicast groups (default is 4096)");
+  simple_switch_parser.add_uint_option(
+      "max-l1-entries",
+      "Maximum number of L1 multicast entries (default is 4096)");
+  simple_switch_parser.add_uint_option(
+      "max-l2-entries",
+      "Maximum number of L2 multicast entries (default is 8192)");
 
   bm::OptionsParser parser;
   parser.parse(argc, argv, &simple_switch_parser);
@@ -227,6 +236,39 @@ main(int argc, char* argv[]) {
       std::exit(1);
   }
 
+  uint32_t mgid_table_size = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "max-mc-groups", &mgid_table_size);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      mgid_table_size =
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_mgid_table_size;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
+  uint32_t l1_max_entries = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "max-l1-entries", &l1_max_entries);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      l1_max_entries =
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_l1_max_entries;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
+  uint32_t l2_max_entries = 0xffffffff;
+  {
+    auto rc = simple_switch_parser.get_uint_option(
+        "max-l2-entries", &l2_max_entries);
+    if (rc == bm::TargetParserBasic::ReturnCode::OPTION_NOT_PROVIDED)
+      l2_max_entries =
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_l2_max_entries;
+    else if (rc != bm::TargetParserBasic::ReturnCode::SUCCESS)
+      std::exit(1);
+  }
+
   auto &runner = sswitch_grpc::SimpleSwitchGrpcRunner::get_instance(
       !disable_swap_flag,
       grpc_server_addr,
@@ -234,7 +276,8 @@ main(int argc, char* argv[]) {
       dp_grpc_server_addr,
       drop_port,
       grpc_server_ssl ? ssl_options : nullptr,
-      priority_queues);
+      priority_queues,
+      mgid_table_size, l1_max_entries, l2_max_entries);
   int status = runner.init_and_start(parser);
   if (status != 0) std::exit(status);
 

--- a/targets/simple_switch_grpc/main.cpp
+++ b/targets/simple_switch_grpc/main.cpp
@@ -84,13 +84,22 @@ main(int argc, char* argv[]) {
     "Number of priority queues (default is 1)");
   simple_switch_parser.add_uint_option(
       "max-mc-groups",
-      "Maximum number of multicast groups (default is 4096)");
+      "Maximum number of multicast groups (default is "
+      + std::to_string(
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_mgid_table_size)
+      + ")");
   simple_switch_parser.add_uint_option(
       "max-l1-entries",
-      "Maximum number of L1 multicast entries (default is 4096)");
+      "Maximum number of L1 multicast entries (default is "
+      + std::to_string(
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_l1_max_entries)
+      + ")");
   simple_switch_parser.add_uint_option(
       "max-l2-entries",
-      "Maximum number of L2 multicast entries (default is 8192)");
+      "Maximum number of L2 multicast entries (default is "
+      + std::to_string(
+          sswitch_grpc::SimpleSwitchGrpcRunner::default_l2_max_entries)
+      + ")");
 
   bm::OptionsParser parser;
   parser.parse(argc, argv, &simple_switch_parser);

--- a/targets/simple_switch_grpc/switch_runner.cpp
+++ b/targets/simple_switch_grpc/switch_runner.cpp
@@ -501,9 +501,14 @@ SimpleSwitchGrpcRunner::SimpleSwitchGrpcRunner(
     std::string dp_grpc_server_addr,
     bm::DevMgrIface::port_t drop_port,
     std::shared_ptr<SSLOptions> ssl_options,
-    size_t nb_queues_per_port)
+    size_t nb_queues_per_port,
+    int mgid_table_size,
+    int l1_max_entries,
+    int l2_max_entries)
     : simple_switch(new SimpleSwitch(enable_swap, drop_port,
-                                     nb_queues_per_port)),
+                                     nb_queues_per_port,
+                                     mgid_table_size, l1_max_entries,
+                                     l2_max_entries)),
       grpc_server_addr(grpc_server_addr), cpu_port(cpu_port),
       dp_grpc_server_addr(dp_grpc_server_addr),
       dp_service(nullptr),

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -53,6 +53,9 @@ class SimpleSwitchGrpcRunner {
  public:
   static constexpr bm::DevMgrIface::port_t default_drop_port = 511;
   static constexpr size_t default_nb_queues_per_port = 1;
+  static constexpr int default_mgid_table_size = 4096;
+  static constexpr int default_l1_max_entries = 4096;
+  static constexpr int default_l2_max_entries = 8192;
 
   // there is no real need for a singleton here, except for the fact that we use
   // PIGrpcServerRunAddr, ... which uses static state
@@ -63,10 +66,14 @@ class SimpleSwitchGrpcRunner {
       std::string dp_grpc_server_addr = "",
       bm::DevMgrIface::port_t drop_port = default_drop_port,
       std::shared_ptr<SSLOptions> ssl_options = nullptr,
-      size_t nb_queues_per_port = default_nb_queues_per_port) {
+      size_t nb_queues_per_port = default_nb_queues_per_port,
+      int mgid_table_size = default_mgid_table_size,
+      int l1_max_entries = default_l1_max_entries,
+      int l2_max_entries = default_l2_max_entries) {
     static SimpleSwitchGrpcRunner instance(
         enable_swap, grpc_server_addr, cpu_port, dp_grpc_server_addr,
-        drop_port, ssl_options, nb_queues_per_port);
+        drop_port, ssl_options, nb_queues_per_port,
+        mgid_table_size, l1_max_entries, l2_max_entries);
     return instance;
   }
 
@@ -87,7 +94,10 @@ class SimpleSwitchGrpcRunner {
                          bm::DevMgrIface::port_t drop_port = default_drop_port,
                          std::shared_ptr<SSLOptions> ssl_options = nullptr,
                          size_t nb_queues_per_port =
-                             default_nb_queues_per_port);
+                             default_nb_queues_per_port,
+                         int mgid_table_size = default_mgid_table_size,
+                         int l1_max_entries = default_l1_max_entries,
+                         int l2_max_entries = default_l2_max_entries);
   ~SimpleSwitchGrpcRunner();
 
   void port_status_cb(bm::DevMgrIface::port_t port,

--- a/targets/simple_switch_grpc/switch_runner.h
+++ b/targets/simple_switch_grpc/switch_runner.h
@@ -22,6 +22,7 @@
 #define SIMPLE_SWITCH_GRPC_SWITCH_RUNNER_H_
 
 #include <bm/bm_sim/dev_mgr.h>
+#include <bm/bm_sim/simple_pre.h>
 
 #include <grpcpp/server.h>
 
@@ -53,9 +54,12 @@ class SimpleSwitchGrpcRunner {
  public:
   static constexpr bm::DevMgrIface::port_t default_drop_port = 511;
   static constexpr size_t default_nb_queues_per_port = 1;
-  static constexpr int default_mgid_table_size = 4096;
-  static constexpr int default_l1_max_entries = 4096;
-  static constexpr int default_l2_max_entries = 8192;
+  static constexpr int default_mgid_table_size =
+      bm::McSimplePre::DEFAULT_MGID_TABLE_SIZE;
+  static constexpr int default_l1_max_entries =
+      bm::McSimplePre::DEFAULT_L1_MAX_ENTRIES;
+  static constexpr int default_l2_max_entries =
+      bm::McSimplePre::DEFAULT_L2_MAX_ENTRIES;
 
   // there is no real need for a singleton here, except for the fact that we use
   // PIGrpcServerRunAddr, ... which uses static state

--- a/tests/test_pre.cpp
+++ b/tests/test_pre.cpp
@@ -435,3 +435,87 @@ TEST(McSimplePreLAG, LAGEmptyMembership) {
   auto egress_info = pre.replicate(ingress_info);
   ASSERT_EQ(0u, egress_info.size());
 }
+
+TEST(McSimplePre, ConfigurableLimits) {
+  // Create a PRE with very small limits
+  McSimplePre pre(2 /* mgid_table_size */,
+                  2 /* l1_max_entries */,
+                  2 /* l2_max_entries */);
+
+  McSimplePre::mgrp_hdl_t mgrp_hdl1, mgrp_hdl2, mgrp_hdl3;
+  McSimplePre::McReturnCode rc;
+
+  // Create 2 groups - should succeed (limit is 2)
+  rc = pre.mc_mgrp_create(1, &mgrp_hdl1);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+  rc = pre.mc_mgrp_create(2, &mgrp_hdl2);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+
+  // 3rd group should fail with TABLE_FULL
+  rc = pre.mc_mgrp_create(3, &mgrp_hdl3);
+  ASSERT_EQ(rc, McSimplePre::TABLE_FULL);
+
+  // Create 2 nodes - should succeed (l1 limit is 2)
+  McSimplePre::l1_hdl_t l1_hdl1, l1_hdl2, l1_hdl3;
+  McSimplePre::PortMap port_map;
+  port_map[1] = 1;
+
+  rc = pre.mc_node_create(0x100, port_map, &l1_hdl1);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+  rc = pre.mc_node_create(0x101, port_map, &l1_hdl2);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+
+  // 3rd node should fail with TABLE_FULL
+  rc = pre.mc_node_create(0x102, port_map, &l1_hdl3);
+  ASSERT_EQ(rc, McSimplePre::TABLE_FULL);
+}
+
+TEST(McSimplePre, DefaultLimits) {
+  // Default constructor should use the original hardcoded values
+  McSimplePre pre;
+
+  McSimplePre::McReturnCode rc;
+  McSimplePre::mgrp_hdl_t mgrp_hdl;
+
+  // Should be able to create at least one group (limit is 4096 by default)
+  rc = pre.mc_mgrp_create(1, &mgrp_hdl);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+
+  // Clean up
+  rc = pre.mc_mgrp_destroy(mgrp_hdl);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+}
+
+TEST(McSimplePreLAG, ConfigurableLimits) {
+  // Create a PRE LAG with small limits
+  McSimplePreLAG pre(2 /* mgid_table_size */,
+                     2 /* l1_max_entries */,
+                     2 /* l2_max_entries */);
+
+  McSimplePre::mgrp_hdl_t mgrp_hdl1, mgrp_hdl2, mgrp_hdl3;
+  McSimplePre::McReturnCode rc;
+
+  // Create 2 groups - should succeed
+  rc = pre.mc_mgrp_create(1, &mgrp_hdl1);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+  rc = pre.mc_mgrp_create(2, &mgrp_hdl2);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+
+  // 3rd group should fail with TABLE_FULL
+  rc = pre.mc_mgrp_create(3, &mgrp_hdl3);
+  ASSERT_EQ(rc, McSimplePre::TABLE_FULL);
+
+  // Create 2 nodes with LAG - should succeed
+  McSimplePreLAG::l1_hdl_t l1_hdl1, l1_hdl2, l1_hdl3;
+  McSimplePreLAG::LagMap lag_map;
+  lag_map[1] = 1;
+
+  rc = pre.mc_node_create(0x100, {}, lag_map, &l1_hdl1);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+  rc = pre.mc_node_create(0x101, {}, lag_map, &l1_hdl2);
+  ASSERT_EQ(rc, McSimplePre::SUCCESS);
+
+  // 3rd node should fail with TABLE_FULL
+  rc = pre.mc_node_create(0x102, {}, lag_map, &l1_hdl3);
+  ASSERT_EQ(rc, McSimplePre::TABLE_FULL);
+}


### PR DESCRIPTION
 ## Changes

### Core Library (`bm_sim`)
- **[McSimplePre](cci:1://file:///home/p4/src/behavioral-model/include/bm/bm_sim/simple_pre.h:136:2-137:49)**: Converted `MGID_TABLE_SIZE`, `L1_MAX_ENTRIES`, and `L2_MAX_ENTRIES` to non-static instance members. Added a constructor to accept these values, using the original values as defaults.
- **[McSimplePreLAG](cci:1://file:///home/p4/src/behavioral-model/include/bm/bm_sim/simple_pre_lag.h:41:2-45:71)**: Updated to forward configuration parameters to the base [McSimplePre](cci:1://file:///home/p4/src/behavioral-model/include/bm/bm_sim/simple_pre.h:136:2-137:49) class.
- **Capacity Checks**: Updated internal logic in both classes to use the configurable instance members instead of the old static constants.

### Switch Targets
- **`simple_switch`**: Added 3 new command-line options and threaded them through the [SimpleSwitch](cci:1://file:///home/p4/src/behavioral-model/targets/simple_switch/simple_switch.h:138:2-138:46) constructor to the PRE.
- **`simple_switch_grpc`**: Added the same 3 command-line options and updated the [SimpleSwitchGrpcRunner](cci:1://file:///home/p4/src/behavioral-model/targets/simple_switch_grpc/switch_runner.cpp:496:0-517:1) to pass them to the underlying switch instance.

### New CLI Options
Both `simple_switch` and `simple_switch_grpc` now support:
- `--max-mc-groups <uint>`: Maximum number of multicast groups (default: 4096)
- `--max-l1-entries <uint>`: Maximum number of L1 multicast entries (default: 4096)
- `--max-l2-entries <uint>`: Maximum number of L2 multicast entries (default: 8192)

## Verification
- **Unit Tests**: Added 3 new test cases to [tests/test_pre.cpp](cci:7://file:///home/p4/src/behavioral-model/tests/test_pre.cpp:0:0-0:0):
    - `McSimplePre.ConfigurableLimits`: Verifies `TABLE_FULL` is correctly triggered when custom small limits are exceeded.
    - `McSimplePre.DefaultLimits`: Verifies that the default constructor still uses the original hardcoded limits.
    - `McSimplePreLAG.ConfigurableLimits`: Verifies the same behavior for the LAG-enabled PRE variant.
- All 9 PRE unit tests (existing + new) pass successfully.
- Build verified for both `simple_switch` and `simple_switch_grpc` targets.

## Backward Compatibility
The original hardcoded values are preserved as default constructor arguments and default CLI option values. No existing P4 programs or switch configurations are affected by these changes.

Fixes #1342
