### PR TITLE
Fix Thrift support for simple_switch_grpc (#1366)

### DIFF
--- a/targets/simple_switch_grpc/CMakeLists.txt
+++ b/targets/simple_switch_grpc/CMakeLists.txt
@@ -59,6 +59,14 @@ target_link_libraries(simple_switch_grpc PRIVATE
   ${GRPCPP_LIBRARIES}
 )
 
+if(WITH_THRIFT)
+  add_definitions(-DWITH_THRIFT)
+  target_link_libraries(simple_switch_grpc PRIVATE
+         thrift
+         simpleswitch_thrift
+  )
+endif()
+
 # We follow this tutorial to link with grpc++_reflection:
 # https://github.com/grpc/grpc/blob/master/doc/server_reflection_tutorial.md
 #target_link_options(simple_switch_grpc PRIVATE


### PR DESCRIPTION
Fixes #1366, ensuring:
1. The preprocessor macro is defined during compilation, so Thrift code is included in the binary
2. Both the Thrift shared library (`libthrift.so`) and the generated static library (`libsimpleswitch_thrift.a`) are linked