### PR TITLE
bugfix: "make distclean"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,9 @@ if COND_PI
     MAYBE_PI = PI services
 endif
 
-# simple_switch depends on libbmpi so PI needs to appear first
+# The targets directory (simple_switch, etc.) depends on libbmpi (from PI) and
+# gtest (from third_party), so those must appear before MAYBE_TARGETS in this
+# list.
 SUBDIRS = $(MAYBE_THRIFT) third_party src include \
 $(MAYBE_TESTS) $(MAYBE_PI) $(MAYBE_TARGETS) tools $(MAYBE_PDFIXED)
 

--- a/targets/simple_switch_grpc/tests/Makefile.am
+++ b/targets/simple_switch_grpc/tests/Makefile.am
@@ -1,8 +1,5 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
-# Ensures that gtest has been built
-SUBDIRS = ../../../third_party
-
 # for deprecated Protobuf fields
 AM_CXXFLAGS += -Wno-error=deprecated-declarations
 


### PR DESCRIPTION
Before this change, third_party shows up in two different Makefiles, and distclean tries to clean it twice, which failed on the second try.

I hit this while building with debian packaging tools, which runs a distclean at some point.

The fix is to remove the duplicate build of third_party, though that does mean one must be careful with build order.