### PR TITLE
option to warn/return 0 on invalid field read

### DIFF
--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -460,8 +460,7 @@ class Data {
   //! Could have named it get_value(), but wanted to avoid accidental
   //! modification of the value when someone intended to call the const
   //! version of get_value()
-  Bignum &get_nc_value()
-  {
+  Bignum &get_nc_value() {
     return value;
   }
 

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -446,8 +446,31 @@ class Data {
   Data &operator=(Data &&other) = default;
 
  protected:
-  Bignum value{0};
   bool arith{true};
+
+  //! Get the internal value as a constant Bignum
+  const Bignum &get_value() const {
+    return value;
+  }
+
+  //! Get the internal value as a Bignum that can be modified.
+  //! (nc = non-const)
+  //! Could have named it get_value(), but wanted to avoid accidental
+  //! modification of the value when someone intended to call the const
+  //! version of get_value()
+  Bignum &get_nc_value()
+  {
+    return value;
+  }
+
+  //! Set the internal value from a Bignum. This is used
+  //! by derived classes that need to modify the value.
+  void set_value(const Bignum &v) {
+    value = v;
+  }
+
+ private:
+  Bignum value{0};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -96,7 +96,7 @@ class Data {
 
   //! Returns a value less than zero if Data is negative, a value greater than
   //! zero if Data is positive, and zero if Data is zero.
-  int sign() const { return value.sign(); }
+  int sign() const { return get_value().sign(); }
 
   // TODO(Antonin): need to figure out what to do with signed values
   //! Set the value of Data from any integral type
@@ -123,12 +123,12 @@ class Data {
 
   //! Set the value of Data from another data instance
   void set(const Data &data) {
-    value = data.value;
+    value = data.get_value();
     export_bytes();
   }
 
   void set(Data &&data) {
-    value = std::move(data.value);
+    value = std::move(data.get_value());
     export_bytes();
   }
 
@@ -185,41 +185,41 @@ class Data {
            typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
   T get() const {
     assert(arith);
-    return value.convert_to<typename std::remove_const<T>::type>();
+    return get_value().convert_to<typename std::remove_const<T>::type>();
   }
 
   //! Get the value of Data has an unsigned integer
   unsigned int get_uint() const {
     assert(arith);
-    return value.convert_to<unsigned int>();
+    return get_value().convert_to<unsigned int>();
   }
 
   //! Get the value of Data has a `uint64_t`
   uint64_t get_uint64() const {
     assert(arith);
-    return value.convert_to<uint64_t>();
+    return get_value().convert_to<uint64_t>();
   }
 
   //! get the value of Data has an integer
   int get_int() const {
     assert(arith);
-    return value.convert_to<int>();
+    return get_value().convert_to<int>();
   }
 
   //! get the binary representation of Data has a string. There is no sign
   //! support.
   std::string get_string() const {
     assert(arith);
-    const size_t export_size = bignum::export_size_in_bytes(value);
+    const size_t export_size = bignum::export_size_in_bytes(get_value());
     std::string s(export_size, '\x00');
     // this is not technically correct, but works for all compilers
-    bignum::export_bytes(&s[0], export_size, value);
+    bignum::export_bytes(&s[0], export_size, get_value());
     return s;
   }
 
   std::string get_string_repr() const {
     assert(arith);
-    return value.convert_to<std::string>();
+    return get_value().convert_to<std::string>();
   }
 
   bool get_arith() const { return arith; }
@@ -229,14 +229,14 @@ class Data {
   //! NC
   void add(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    value = src1.value + src2.value;
+    value = src1.get_value() + src2.get_value();
     export_bytes();
   }
 
   //! NC
   void sub(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    value = src1.value - src2.value;
+    value = src1.get_value() - src2.get_value();
     export_bytes();
   }
 
@@ -244,8 +244,8 @@ class Data {
   //! and \p src2 > 0.
   void mod(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    assert(src1.value >= 0 && src2.value > 0);
-    value = src1.value % src2.value;
+    assert(src1.get_value() >= 0 && src2.get_value() > 0);
+    value = src1.get_value() % src2.get_value();
     export_bytes();
   }
 
@@ -253,73 +253,73 @@ class Data {
   //! 0 and \p src2 > 0.
   void divide(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    assert(src1.value >= 0 && src2.value > 0);
-    value = src1.value / src2.value;
+    assert(src1.get_value() >= 0 && src2.get_value() > 0);
+    value = src1.get_value() / src2.get_value();
     export_bytes();
   }
 
   //! NC
   void multiply(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    value = src1.value * src2.value;
+    value = src1.get_value() * src2.get_value();
     export_bytes();
   }
 
   //! NC
   void shift_left(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    assert(src2.value >= 0);
-    value = src1.value << (src2.get_uint());
+    assert(src2.get_value() >= 0);
+    value = src1.get_value() << (src2.get_uint());
     export_bytes();
   }
 
   //! NC
   void shift_right(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    assert(src2.value >= 0);
-    value = src1.value >> (src2.get_uint());
+    assert(src2.get_value() >= 0);
+    value = src1.get_value() >> (src2.get_uint());
     export_bytes();
   }
 
   //! NC
   void shift_left(const Data &src1, unsigned int src2) {
     assert(src1.arith);
-    value = src1.value << src2;
+    value = src1.get_value() << src2;
     export_bytes();
   }
 
   //! NC
   void shift_right(const Data &src1, unsigned int src2) {
     assert(src1.arith);
-    value = src1.value >> src2;
+    value = src1.get_value() >> src2;
     export_bytes();
   }
 
   //! NC
   void bit_and(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    value = src1.value & src2.value;
+    value = src1.get_value() & src2.get_value();
     export_bytes();
   }
 
   //! NC
   void bit_or(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    value = src1.value | src2.value;
+    value = src1.get_value() | src2.get_value();
     export_bytes();
   }
 
   //! NC
   void bit_xor(const Data &src1, const Data &src2) {
     assert(src1.arith && src2.arith);
-    value = src1.value ^ src2.value;
+    value = src1.get_value() ^ src2.get_value();
     export_bytes();
   }
 
   //! NC
   void bit_neg(const Data &src) {
     assert(src.arith);
-    value = ~src.value;
+    value = ~src.get_value();
     export_bytes();
   }
 
@@ -331,12 +331,12 @@ class Data {
     Bignum mask = (one << uwidth) - 1;
     Bignum max = (one << (uwidth - 1)) - 1;
     Bignum min = -(one << (uwidth - 1));
-    if (src.value < min || src.value > max) {
-      value = src.value & mask;
+    if (src.get_value() < min || src.get_value() > max) {
+      value = src.get_value() & mask;
       if (value > max)
         value -= (one << uwidth);
     } else {
-      value = src.value;
+      value = src.get_value();
     }
     export_bytes();
   }
@@ -348,12 +348,12 @@ class Data {
     static const Bignum one(1);
     unsigned int uwidth = width.get_uint();
     Bignum max = (one << uwidth) - 1;
-    if (src.value > max)
+    if (src.get_value() > max)
       value = max;
-    else if (src.value < 0)
+    else if (src.get_value() < 0)
       value = 0;
     else
-      value = src.value;
+      value = src.get_value();
     export_bytes();
   }
 
@@ -365,12 +365,12 @@ class Data {
     unsigned int uwidth = width.get_uint();
     Bignum max = (one << (uwidth - 1)) - 1;
     Bignum min = -(one << (uwidth - 1));
-    if (src.value > max)
+    if (src.get_value() > max)
       value = max;
-    else if (src.value < min)
+    else if (src.get_value() < min)
       value = min;
     else
-      value = src.value;
+      value = src.get_value();
     export_bytes();
   }
 
@@ -378,13 +378,13 @@ class Data {
   template<typename T,
            typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
   bool test_eq(T i) const {
-    return (value == i);
+    return (get_value() == i);
   }
 
   //! NC
   friend bool operator==(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
-    return lhs.value == rhs.value;
+    return lhs.get_value() == rhs.get_value();
   }
 
   //! NC
@@ -396,31 +396,31 @@ class Data {
   //! NC
   friend bool operator>(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
-    return lhs.value > rhs.value;
+    return lhs.get_value() > rhs.get_value();
   }
 
   //! NC
   friend bool operator>=(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
-    return lhs.value >= rhs.value;
+    return lhs.get_value() >= rhs.get_value();
   }
 
   //! NC
   friend bool operator<(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
-    return lhs.value < rhs.value;
+    return lhs.get_value() < rhs.get_value();
   }
 
   //! NC
   friend bool operator<=(const Data &lhs, const Data &rhs) {
     assert(lhs.arith && rhs.arith);
-    return lhs.value <= rhs.value;
+    return lhs.get_value() <= rhs.get_value();
   }
 
   //! NC
   friend std::ostream& operator<<(std::ostream &out, const Data &d) {
     assert(d.arith);
-    out << d.value;
+    out << d.get_value();
     return out;
   }
 
@@ -428,7 +428,7 @@ class Data {
   //! NC
   Data(const Data &other)
     : arith(other.arith) {
-    if (other.arith) value = other.value;
+    if (other.arith) value = other.get_value();
   }
 
   // Copy assignment operator

--- a/include/bm/bm_sim/data.h
+++ b/include/bm/bm_sim/data.h
@@ -224,6 +224,8 @@ class Data {
 
   bool get_arith() const { return arith; }
 
+  virtual bool is_valid() const { return true; }
+
   // TODO(antonin): overload operators for those ?
 
   //! NC
@@ -449,7 +451,7 @@ class Data {
   bool arith{true};
 
   //! Get the internal value as a constant Bignum
-  const Bignum &get_value() const {
+  virtual const Bignum &get_value() const {
     return value;
   }
 

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -187,20 +187,20 @@ class Field : public Data {
     return written_to;
   }
 
-  static void set_warn_on_uninit_read(bool warn) {
-    warn_on_uninit_read = warn;
-    handle_uninit_read = warn_on_uninit_read || ret_zero_on_uninit_read;
+  static void set_warn_on_invalid_hdr_read(bool warn) {
+    warn_on_invalid_hdr_read = warn;
+    handle_invalid_hdr_read = warn_on_invalid_hdr_read || ret_zero_on_invalid_hdr_read;
   }
 
-  static void set_ret_zero_on_uninit_read(bool ret_zero) {
-    ret_zero_on_uninit_read = ret_zero;
-    handle_uninit_read = warn_on_uninit_read || ret_zero_on_uninit_read;
+  static void set_ret_zero_on_invalid_hdr_read(bool ret_zero) {
+    ret_zero_on_invalid_hdr_read = ret_zero;
+    handle_invalid_hdr_read = warn_on_invalid_hdr_read || ret_zero_on_invalid_hdr_read;
   }
 
  protected:
-   static bool warn_on_uninit_read;
-   static bool ret_zero_on_uninit_read;
-   static bool handle_uninit_read;
+   static bool warn_on_invalid_hdr_read;
+   static bool ret_zero_on_invalid_hdr_read;
+   static bool handle_invalid_hdr_read;
 
    static Bignum zero;
 

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -105,6 +105,7 @@ class Field : public Data {
     std::fill(bytes.begin(), bytes.end(), 0);  // very important !
 
     auto value = get_value();
+    auto value_orig = value;
     if (is_saturating) {
       if (value < min) value = min;
       else if (value > max) value = max;
@@ -129,7 +130,7 @@ class Field : public Data {
       }
     }
     // Write the value back if it changed
-    if (value != get_value()) {
+    if (value != value_orig) {
       set_value(value);
     }
     written_to = true;

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -67,6 +67,7 @@ class Field : public Data {
   }
 
   void sync_value() {
+    auto &value = get_nc_value();
     bignum::import_bytes(&value, bytes.data(), nbytes);
     if (is_signed && bignum::test_bit(value, nbits - 1)) {
       bignum::clear_bit(&value, nbits - 1);
@@ -103,6 +104,7 @@ class Field : public Data {
   void export_bytes() override {
     std::fill(bytes.begin(), bytes.end(), 0);  // very important !
 
+    auto value = get_value();
     if (is_saturating) {
       if (value < min) value = min;
       else if (value > max) value = max;
@@ -125,6 +127,10 @@ class Field : public Data {
         // bignum representation of 1000 0001, which is what we wanted
         bignum::export_bytes(bytes.data(), nbytes, value - min - min);
       }
+    }
+    // Write the value back if it changed
+    if (value != get_value()) {
+      set_value(value);
     }
     written_to = true;
     DEBUGGER_NOTIFY_UPDATE(*packet_id, my_id, bytes.data(), nbits);

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -172,6 +172,8 @@ class Field : public Data {
     return VL;
   }
 
+  bool is_valid() const override;
+
   //! Set the value of the written_to flag for the field. This flag can be
   //! queried at any time using get_written_to() and is used to check whether
   //! the field has been modified since written_to was last set to `false`.
@@ -184,6 +186,25 @@ class Field : public Data {
   bool get_written_to() const {
     return written_to;
   }
+
+  static void set_warn_on_uninit_read(bool warn) {
+    warn_on_uninit_read = warn;
+    handle_uninit_read = warn_on_uninit_read || ret_zero_on_uninit_read;
+  }
+
+  static void set_ret_zero_on_uninit_read(bool ret_zero) {
+    ret_zero_on_uninit_read = ret_zero;
+    handle_uninit_read = warn_on_uninit_read || ret_zero_on_uninit_read;
+  }
+
+ protected:
+   static bool warn_on_uninit_read;
+   static bool ret_zero_on_uninit_read;
+   static bool handle_uninit_read;
+
+   static Bignum zero;
+
+   const Bignum &get_value() const override;
 
  private:
   int nbits;

--- a/include/bm/bm_sim/fields.h
+++ b/include/bm/bm_sim/fields.h
@@ -189,22 +189,24 @@ class Field : public Data {
 
   static void set_warn_on_invalid_hdr_read(bool warn) {
     warn_on_invalid_hdr_read = warn;
-    handle_invalid_hdr_read = warn_on_invalid_hdr_read || ret_zero_on_invalid_hdr_read;
+    handle_invalid_hdr_read =
+        warn_on_invalid_hdr_read || ret_zero_on_invalid_hdr_read;
   }
 
   static void set_ret_zero_on_invalid_hdr_read(bool ret_zero) {
     ret_zero_on_invalid_hdr_read = ret_zero;
-    handle_invalid_hdr_read = warn_on_invalid_hdr_read || ret_zero_on_invalid_hdr_read;
+    handle_invalid_hdr_read =
+        warn_on_invalid_hdr_read || ret_zero_on_invalid_hdr_read;
   }
 
  protected:
-   static bool warn_on_invalid_hdr_read;
-   static bool ret_zero_on_invalid_hdr_read;
-   static bool handle_invalid_hdr_read;
+  static bool warn_on_invalid_hdr_read;
+  static bool ret_zero_on_invalid_hdr_read;
+  static bool handle_invalid_hdr_read;
 
-   static Bignum zero;
+  static Bignum zero;
 
-   const Bignum &get_value() const override;
+  const Bignum &get_value() const override;
 
  private:
   int nbits;

--- a/include/bm/bm_sim/headers.h
+++ b/include/bm/bm_sim/headers.h
@@ -206,6 +206,19 @@ class Header : public NamedP4Object {
     return fields.at(field_offset);
   }
 
+  //! Get the field offset of a Field, or -1 if it can't be found
+  int get_field_offset(const Field *field) const {
+    for (size_t res = 0; res < fields.size(); res++) {
+      if (&fields[res] == field) return res;
+    }
+    return -1;
+  }
+
+  //! Get the field offset of a Field, or -1 if it can't be found
+  int get_field_offset(const Field &field) const {
+    return get_field_offset(&field);
+  }
+
   const HeaderType &get_header_type() const { return header_type; }
 
   //! Returns an integral id which represents the header type of the

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -101,6 +101,8 @@ class OptionsParser {
   size_t dump_packet_data{0};
   int max_port_count{default_max_port_count};
   std::unordered_set<std::string> options_provided{};
+  bool warn_on_uninit_read{false};
+  bool ret_zero_on_uninit_read{false};
 };
 
 }  // namespace bm

--- a/include/bm/bm_sim/options_parse.h
+++ b/include/bm/bm_sim/options_parse.h
@@ -101,8 +101,8 @@ class OptionsParser {
   size_t dump_packet_data{0};
   int max_port_count{default_max_port_count};
   std::unordered_set<std::string> options_provided{};
-  bool warn_on_uninit_read{false};
-  bool ret_zero_on_uninit_read{false};
+  bool warn_on_invalid_hdr_read{false};
+  bool ret_zero_on_invalid_hdr_read{false};
 };
 
 }  // namespace bm

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -27,9 +27,9 @@
 
 namespace bm {
 
-bool Field::warn_on_uninit_read = false;
-bool Field::ret_zero_on_uninit_read = false;
-bool Field::handle_uninit_read = false;
+bool Field::warn_on_invalid_hdr_read = false;
+bool Field::ret_zero_on_invalid_hdr_read = false;
+bool Field::handle_invalid_hdr_read = false;
 
 Bignum Field::zero{0};
 
@@ -162,13 +162,13 @@ Field::is_valid() const {
 
 const Bignum &
 Field::get_value() const {
-  if (handle_uninit_read && !is_valid()) {
-    if (warn_on_uninit_read) {
+  if (handle_invalid_hdr_read && !is_valid()) {
+    if (warn_on_invalid_hdr_read) {
       assert(parent_hdr);
       Logger::get()->warn("Reading an invalid field (header: {}, field offset: {})",
                           parent_hdr->get_name(), parent_hdr->get_field_offset(this));
     }
-    if (ret_zero_on_uninit_read) {
+    if (ret_zero_on_invalid_hdr_read) {
       return zero;
     }
   }

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -54,7 +54,8 @@ Field::reserve_VL(size_t max_bytes) {
 void
 Field::swap_values(Field *other) {
   // do not swap arith!
-  std::swap(value, other->value);
+  // FIXME: review correctness after adding validity support
+  std::swap(get_nc_value(), other->get_nc_value());
   std::swap(bytes, other->bytes);
   if (VL) {
     std::swap(nbits, other->nbits);
@@ -132,7 +133,7 @@ void
 Field::copy_value(const Field &src) {
   // it's important to have a way of copying a field value without the
   // packet_id pointer. This is used by PHV::copy_headers().
-  value = src.value;
+  set_value(src.get_value());
   bytes = src.bytes;
   if (VL) {
     nbits = src.nbits;

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -61,7 +61,6 @@ Field::reserve_VL(size_t max_bytes) {
 void
 Field::swap_values(Field *other) {
   // do not swap arith!
-  // FIXME: review correctness after adding validity support
   std::swap(get_nc_value(), other->get_nc_value());
   std::swap(bytes, other->bytes);
   if (VL) {

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -153,6 +153,9 @@ Field::copy_value(const Field &src) {
 
 bool
 Field::is_valid() const {
+  // FIXME: Consider using the written_to flag in the evalutation. Would
+  // need to make sure this is cleared whenever the header is marked invalid.
+
   // Hidden fields assumed always valid. Needed for header validity bit.
   return hidden || !parent_hdr || parent_hdr->is_valid();
 }

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -165,8 +165,9 @@ Field::get_value() const {
   if (handle_invalid_hdr_read && !is_valid()) {
     if (warn_on_invalid_hdr_read) {
       assert(parent_hdr);
-      Logger::get()->warn("Reading an invalid field (header: {}, field offset: {})",
-                          parent_hdr->get_name(), parent_hdr->get_field_offset(this));
+      Logger::get()->warn(
+          "Reading an invalid field (header: {}, field offset: {})",
+          parent_hdr->get_name(), parent_hdr->get_field_offset(this));
     }
     if (ret_zero_on_invalid_hdr_read) {
       return zero;

--- a/src/bm_sim/fields.cpp
+++ b/src/bm_sim/fields.cpp
@@ -20,11 +20,18 @@
 
 #include <bm/bm_sim/fields.h>
 #include <bm/bm_sim/headers.h>
+#include <bm/bm_sim/logger.h>
 
 #include <algorithm>  // for std::swap
 #include "extract.h"
 
 namespace bm {
+
+bool Field::warn_on_uninit_read = false;
+bool Field::ret_zero_on_uninit_read = false;
+bool Field::handle_uninit_read = false;
+
+Bignum Field::zero{0};
 
 Field::Field(int nbits, Header *parent_hdr, bool arith_flag, bool is_signed,
              bool hidden, bool VL, bool is_saturating)
@@ -142,6 +149,27 @@ Field::copy_value(const Field &src) {
     min = src.min;
     max = src.max;
   }
+}
+
+bool
+Field::is_valid() const {
+  // Hidden fields assumed always valid. Needed for header validity bit.
+  return hidden || !parent_hdr || parent_hdr->is_valid();
+}
+
+const Bignum &
+Field::get_value() const {
+  if (handle_uninit_read && !is_valid()) {
+    if (warn_on_uninit_read) {
+      assert(parent_hdr);
+      Logger::get()->warn("Reading an invalid field (header: {}, field offset: {})",
+                          parent_hdr->get_name(), parent_hdr->get_field_offset(this));
+    }
+    if (ret_zero_on_uninit_read) {
+      return zero;
+    }
+  }
+  return Data::get_value();
 }
 
 }  // namespace bm

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -441,6 +441,9 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
       outstream << "Target parser returned an error\n";
     }
   }
+
+  warn_on_uninit_read = vm.count("warn-on-uninit-read") > 0;
+  ret_zero_on_uninit_read = vm.count("ret-zero-on-uninit-read") > 0;
 }
 
 void

--- a/src/bm_sim/options_parse.cpp
+++ b/src/bm_sim/options_parse.cpp
@@ -442,8 +442,8 @@ OptionsParser::parse(int argc, char *argv[], TargetParserIface *tp,
     }
   }
 
-  warn_on_uninit_read = vm.count("warn-on-uninit-read") > 0;
-  ret_zero_on_uninit_read = vm.count("ret-zero-on-uninit-read") > 0;
+  warn_on_invalid_hdr_read = vm.count("warn-on-invalid-hdr-read") > 0;
+  ret_zero_on_invalid_hdr_read = vm.count("ret-zero-on-invalid-hdr-read") > 0;
 }
 
 void

--- a/src/bm_sim/stateful.cpp
+++ b/src/bm_sim/stateful.cpp
@@ -33,6 +33,7 @@ Register::Register(int nbits, const RegisterArray *register_array)
 
 void
 Register::export_bytes() {
+  auto &value = get_nc_value();
   value &= mask;
   register_array->notify(*this);
 }

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -24,6 +24,7 @@
 #include <bm/bm_sim/_assert.h>
 #include <bm/bm_sim/debugger.h>
 #include <bm/bm_sim/event_logger.h>
+#include <bm/bm_sim/fields.h>
 #include <bm/bm_sim/logger.h>
 #include <bm/bm_sim/options_parse.h>
 #include <bm/bm_sim/packet.h>
@@ -321,6 +322,9 @@ SwitchWContexts::init_from_options_parser(
   dump_packet_data = parser.dump_packet_data;
 
   max_port_count = parser.max_port_count;
+
+  Field::set_warn_on_uninit_read(parser.warn_on_uninit_read);
+  Field::set_ret_zero_on_uninit_read(parser.ret_zero_on_uninit_read);
 
   // TODO(unknown): is this the right place to do this?
   set_packet_handler(packet_handler, static_cast<void *>(this));

--- a/src/bm_sim/switch.cpp
+++ b/src/bm_sim/switch.cpp
@@ -323,8 +323,8 @@ SwitchWContexts::init_from_options_parser(
 
   max_port_count = parser.max_port_count;
 
-  Field::set_warn_on_uninit_read(parser.warn_on_uninit_read);
-  Field::set_ret_zero_on_uninit_read(parser.ret_zero_on_uninit_read);
+  Field::set_warn_on_invalid_hdr_read(parser.warn_on_invalid_hdr_read);
+  Field::set_ret_zero_on_invalid_hdr_read(parser.ret_zero_on_invalid_hdr_read);
 
   // TODO(unknown): is this the right place to do this?
   set_packet_handler(packet_handler, static_cast<void *>(this));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Include directories
 include_directories(SYSTEM
   ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/gtest/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/gmock/include
 )
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -102,6 +103,10 @@ foreach(TEST_NAME ${TESTS})
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endforeach()
 
+target_link_libraries(test_fields
+  gmock
+)
+
 # Create test_all executable
 add_executable(test_all 
   ${COMMON_SOURCES}
@@ -147,6 +152,7 @@ add_executable(test_all
 
 target_link_libraries(test_all
   gtest
+  gmock
   bmruntime
   bmapps
   bmsim

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ libtestutils_la_LIBADD = $(top_builddir)/src/bm_sim/libbmsim.la
 AM_CPPFLAGS += \
 -I$(top_srcdir)/src/bm_sim \
 -I$(top_srcdir)/src/BMI \
+-isystem $(top_srcdir)/third_party/gmock/include \
 -isystem $(top_srcdir)/third_party/gtest/include \
 -isystem $(top_srcdir)/third_party/jsoncpp/include \
 -DTESTDATADIR=\"$(abs_srcdir)/testdata\"
@@ -22,6 +23,7 @@ endif
 
 LDADD = \
 $(top_builddir)/third_party/gtest/libgtest.la \
+$(top_builddir)/third_party/gmock/libgmock.la \
 $(top_builddir)/src/bm_runtime/libbmruntime.la \
 $(top_builddir)/src/bm_apps/libbmapps.la \
 $(top_builddir)/src/bm_sim/libbmsim.la \

--- a/tests/test_fields.cpp
+++ b/tests/test_fields.cpp
@@ -19,8 +19,11 @@
  */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <bm/bm_sim/fields.h>
+#include <bm/bm_sim/phv.h>
+#include <bm/bm_sim/logger.h>
 
 #include <string>
 #include <vector>
@@ -29,6 +32,9 @@
 using bm::ByteContainer;
 using bm::Data;
 using bm::Field;
+using bm::HeaderType;
+using bm::PHV;
+using bm::PHVFactory;
 
 using ::testing::TestWithParam;
 using ::testing::Range;
@@ -301,3 +307,204 @@ TEST(FieldTest, ExportBytesVLLarge) {
   f.export_bytes();
   EXPECT_NE(0u, f.get<uint64_t>());
 }
+
+class FieldValidityTest : public ::testing::TestWithParam<std::tuple<bool, bool>>
+{
+protected:
+  PHVFactory phv_factory;
+  std::unique_ptr<PHV> phv;
+
+  HeaderType testHeaderType;
+  bm::header_id_t testHeader0{0}, testHeader1{1};
+
+  bool warn_on_uninit_read{false};
+  bool ret_zero_on_uninit_read{false};
+
+  std::stringstream ss;
+
+  FieldValidityTest()
+      : testHeaderType("test_t", 0) {
+    testHeaderType.push_back_field("f16", 16);
+    testHeaderType.push_back_field("f48", 48);
+    phv_factory.push_back_header("test0", testHeader0, testHeaderType);
+    phv_factory.push_back_header("test1", testHeader1, testHeaderType);
+
+    // Capture the logger output to verify warnings about invalid field reads
+    bm::Logger::set_logger_ostream(ss);
+  }
+
+  ~FieldValidityTest() {
+    // Unset the logger
+    bm::Logger::unset_logger();
+  }
+
+  void SetUp() override {
+    warn_on_uninit_read = std::get<0>(GetParam());
+    ret_zero_on_uninit_read = std::get<1>(GetParam());
+
+    Field::set_warn_on_uninit_read(warn_on_uninit_read);
+    Field::set_ret_zero_on_uninit_read(ret_zero_on_uninit_read);
+
+    phv = phv_factory.create();
+  }
+
+  void TearDown() override {
+    // Reset the uninit read mode in Field to default values for other tests
+    Field::set_warn_on_uninit_read(false);
+    Field::set_ret_zero_on_uninit_read(false);
+  }
+};
+
+TEST_P(FieldValidityTest, UninitReadHandling) {
+  auto &f0 = phv->get_field(testHeader0, 0);
+  auto &f1 = phv->get_field(testHeader1, 0);
+
+  int f0_exp = 0;
+  int f1_exp = 0;
+
+  std::string warn_substr0 = "Reading an invalid field (header: test0, field offset: 0)";
+  std::string warn_substr1 = "Reading an invalid field (header: test1, field offset: 0)";
+
+  // Initially, both headers should be invalid
+  EXPECT_FALSE(f0.is_valid());
+  EXPECT_FALSE(f1.is_valid());
+
+  // Expect zero before first write
+  f0_exp = 0;
+  f1_exp = 0;
+
+  EXPECT_EQ(f0.get_int(), f0_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  EXPECT_EQ(f1.get_int(), f1_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr1));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  // Mark header 0 as valid, then write into f0 and verify that the reads are as expected
+  f0_exp = 42;
+
+  phv->get_header(testHeader0).mark_valid();
+
+  EXPECT_TRUE(f0.is_valid());
+  EXPECT_FALSE(f1.is_valid());
+
+  f0.set(42);
+
+  EXPECT_EQ(f0.get_int(), f0_exp);
+  EXPECT_EQ(ss.str(), "");
+  ss.str("");
+
+  EXPECT_EQ(f1.get_int(), f1_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr1));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  // Mark header 1 as valid and copy fields from header 0,
+  // then verify that the reads are as expected
+  f0_exp = 42;
+  f1_exp = 42;
+
+  phv->get_header(testHeader1).mark_valid();
+  phv->get_header(testHeader1).copy_fields(phv->get_header(testHeader0));
+
+  EXPECT_EQ(f0.get_int(), f0_exp);
+  EXPECT_EQ(ss.str(), "");
+  ss.str("");
+
+  EXPECT_EQ(f1.get_int(), f1_exp);
+  EXPECT_EQ(ss.str(), "");
+  ss.str("");
+
+  // Mark header 0 as invalid and verify fields are as expected
+  f0_exp = ret_zero_on_uninit_read ? 0 : 42;
+  f1_exp = 42;
+
+  phv->get_header(testHeader0).mark_invalid();
+
+  EXPECT_FALSE(f0.is_valid());
+  EXPECT_TRUE(f1.is_valid());
+
+  EXPECT_EQ(f0.get_int(), f0_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  EXPECT_EQ(f1.get_int(), f1_exp);
+  EXPECT_EQ(ss.str(), "");
+  ss.str("");
+
+  // Mark header 1 as invalid and verify fields are as expected
+  f0_exp = ret_zero_on_uninit_read ? 0 : 42;
+  f1_exp = ret_zero_on_uninit_read ? 0 : 42;
+
+  phv->get_header(testHeader1).mark_invalid();
+
+  EXPECT_FALSE(f0.is_valid());
+  EXPECT_FALSE(f1.is_valid());
+
+  EXPECT_EQ(f0.get_int(), f0_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  EXPECT_EQ(f1.get_int(), f1_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr1));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  // Copy from invalid header to valid header
+  // Write into f0 without marking valid
+  f0_exp = ret_zero_on_uninit_read ? 0 : 43;
+  f1_exp = ret_zero_on_uninit_read ? 0 : 43;
+
+  f0.set(43);
+  phv->get_header(testHeader1).mark_valid();
+  phv->get_header(testHeader1).copy_fields(phv->get_header(testHeader0));
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  EXPECT_EQ(f0.get_int(), f0_exp);
+  if (warn_on_uninit_read) {
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
+  } else {
+    EXPECT_EQ(ss.str(), "");
+  }
+  ss.str("");
+
+  EXPECT_EQ(f1.get_int(), f1_exp);
+  EXPECT_EQ(ss.str(), "");
+  ss.str("");
+}
+
+INSTANTIATE_TEST_SUITE_P(UninitReadHandlingTest,
+                         FieldValidityTest,
+                         ::testing::Combine(
+                          ::testing::Bool(),  // warn_on_uninit_read
+                          ::testing::Bool()   // ret_zero_on_uninit_read
+                         )
+                        );

--- a/tests/test_fields.cpp
+++ b/tests/test_fields.cpp
@@ -308,9 +308,9 @@ TEST(FieldTest, ExportBytesVLLarge) {
   EXPECT_NE(0u, f.get<uint64_t>());
 }
 
-class FieldValidityTest : public ::testing::TestWithParam<std::tuple<bool, bool>>
-{
-protected:
+class FieldValidityTest :
+    public ::testing::TestWithParam<std::tuple<bool, bool>> {
+ protected:
   PHVFactory phv_factory;
   std::unique_ptr<PHV> phv;
 
@@ -349,7 +349,8 @@ protected:
   }
 
   void TearDown() override {
-    // Reset the invalid header read mode in Field to default values for other tests
+    // Reset the invalid header read mode in Field
+    // to default values for other tests
     Field::set_warn_on_invalid_hdr_read(false);
     Field::set_ret_zero_on_invalid_hdr_read(false);
   }
@@ -362,8 +363,10 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   int f0_exp = 0;
   int f1_exp = 0;
 
-  std::string warn_substr0 = "Reading an invalid field (header: test0, field offset: 0)";
-  std::string warn_substr1 = "Reading an invalid field (header: test1, field offset: 0)";
+  std::string warn_substr0 =
+      "Reading an invalid field (header: test0, field offset: 0)";
+  std::string warn_substr1 =
+      "Reading an invalid field (header: test1, field offset: 0)";
 
   // Initially, both headers should be invalid
   EXPECT_FALSE(f0.is_valid());
@@ -389,7 +392,8 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   }
   ss.str("");
 
-  // Mark header 0 as valid, then write into f0 and verify that the reads are as expected
+  // Mark header 0 as valid, then write into f0
+  // and verify that the reads are as expected
   f0_exp = 42;
 
   phv->get_header(testHeader0).mark_valid();
@@ -504,7 +508,5 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
 INSTANTIATE_TEST_SUITE_P(UninitReadHandlingTest,
                          FieldValidityTest,
                          ::testing::Combine(
-                          ::testing::Bool(),  // warn_on_invalid_hdr_read
-                          ::testing::Bool()   // ret_zero_on_invalid_hdr_read
-                         )
-                        );
+                          ::testing::Bool(),    // warn_on_invalid_hdr_read
+                          ::testing::Bool()));  // ret_zero_on_invalid_hdr_read

--- a/tests/test_fields.cpp
+++ b/tests/test_fields.cpp
@@ -317,8 +317,8 @@ protected:
   HeaderType testHeaderType;
   bm::header_id_t testHeader0{0}, testHeader1{1};
 
-  bool warn_on_uninit_read{false};
-  bool ret_zero_on_uninit_read{false};
+  bool warn_on_invalid_hdr_read{false};
+  bool ret_zero_on_invalid_hdr_read{false};
 
   std::stringstream ss;
 
@@ -339,19 +339,19 @@ protected:
   }
 
   void SetUp() override {
-    warn_on_uninit_read = std::get<0>(GetParam());
-    ret_zero_on_uninit_read = std::get<1>(GetParam());
+    warn_on_invalid_hdr_read = std::get<0>(GetParam());
+    ret_zero_on_invalid_hdr_read = std::get<1>(GetParam());
 
-    Field::set_warn_on_uninit_read(warn_on_uninit_read);
-    Field::set_ret_zero_on_uninit_read(ret_zero_on_uninit_read);
+    Field::set_warn_on_invalid_hdr_read(warn_on_invalid_hdr_read);
+    Field::set_ret_zero_on_invalid_hdr_read(ret_zero_on_invalid_hdr_read);
 
     phv = phv_factory.create();
   }
 
   void TearDown() override {
-    // Reset the uninit read mode in Field to default values for other tests
-    Field::set_warn_on_uninit_read(false);
-    Field::set_ret_zero_on_uninit_read(false);
+    // Reset the invalid header read mode in Field to default values for other tests
+    Field::set_warn_on_invalid_hdr_read(false);
+    Field::set_ret_zero_on_invalid_hdr_read(false);
   }
 };
 
@@ -374,7 +374,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   f1_exp = 0;
 
   EXPECT_EQ(f0.get_int(), f0_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -382,7 +382,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   ss.str("");
 
   EXPECT_EQ(f1.get_int(), f1_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr1));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -404,7 +404,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   ss.str("");
 
   EXPECT_EQ(f1.get_int(), f1_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr1));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -428,7 +428,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   ss.str("");
 
   // Mark header 0 as invalid and verify fields are as expected
-  f0_exp = ret_zero_on_uninit_read ? 0 : 42;
+  f0_exp = ret_zero_on_invalid_hdr_read ? 0 : 42;
   f1_exp = 42;
 
   phv->get_header(testHeader0).mark_invalid();
@@ -437,7 +437,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   EXPECT_TRUE(f1.is_valid());
 
   EXPECT_EQ(f0.get_int(), f0_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -449,8 +449,8 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   ss.str("");
 
   // Mark header 1 as invalid and verify fields are as expected
-  f0_exp = ret_zero_on_uninit_read ? 0 : 42;
-  f1_exp = ret_zero_on_uninit_read ? 0 : 42;
+  f0_exp = ret_zero_on_invalid_hdr_read ? 0 : 42;
+  f1_exp = ret_zero_on_invalid_hdr_read ? 0 : 42;
 
   phv->get_header(testHeader1).mark_invalid();
 
@@ -458,7 +458,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   EXPECT_FALSE(f1.is_valid());
 
   EXPECT_EQ(f0.get_int(), f0_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -466,7 +466,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   ss.str("");
 
   EXPECT_EQ(f1.get_int(), f1_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr1));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -475,13 +475,13 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
 
   // Copy from invalid header to valid header
   // Write into f0 without marking valid
-  f0_exp = ret_zero_on_uninit_read ? 0 : 43;
-  f1_exp = ret_zero_on_uninit_read ? 0 : 43;
+  f0_exp = ret_zero_on_invalid_hdr_read ? 0 : 43;
+  f1_exp = ret_zero_on_invalid_hdr_read ? 0 : 43;
 
   f0.set(43);
   phv->get_header(testHeader1).mark_valid();
   phv->get_header(testHeader1).copy_fields(phv->get_header(testHeader0));
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -489,7 +489,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
   ss.str("");
 
   EXPECT_EQ(f0.get_int(), f0_exp);
-  if (warn_on_uninit_read) {
+  if (warn_on_invalid_hdr_read) {
     EXPECT_THAT(ss.str(), ::testing::HasSubstr(warn_substr0));
   } else {
     EXPECT_EQ(ss.str(), "");
@@ -504,7 +504,7 @@ TEST_P(FieldValidityTest, UninitReadHandling) {
 INSTANTIATE_TEST_SUITE_P(UninitReadHandlingTest,
                          FieldValidityTest,
                          ::testing::Combine(
-                          ::testing::Bool(),  // warn_on_uninit_read
-                          ::testing::Bool()   // ret_zero_on_uninit_read
+                          ::testing::Bool(),  // warn_on_invalid_hdr_read
+                          ::testing::Bool()   // ret_zero_on_invalid_hdr_read
                          )
                         );


### PR DESCRIPTION
Add configurable options when reading an invalid field (currently defined as reading a field in a header that is not valid):
* Report a warning.
* Return zero.

Each of these behaviors can be enabled independently. The default behavior is to maintain the existing behavior (no warning, return the last written value, even if the header is invalid.)

Addresses #1370.