### PR TITLE
Migrate from `boost::variant` to `std::variant`

### DIFF
--- a/include/bm/bm_sim/calculations.h
+++ b/include/bm/bm_sim/calculations.h
@@ -62,9 +62,8 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
-
-#include "boost/variant.hpp"
 
 #include "bytecontainer.h"
 #include "named_p4object.h"
@@ -256,7 +255,7 @@ class BufBuilder {
 
   struct Deparse;  // defined in calculations.cpp
 
-  std::vector<boost::variant<field_t, constant_t, header_t> > entries{};
+  std::vector<std::variant<field_t, constant_t, header_t>> entries{};
   bool with_payload{false};
 };
 

--- a/include/bm/bm_sim/field_lists.h
+++ b/include/bm/bm_sim/field_lists.h
@@ -23,13 +23,13 @@
 #ifndef BM_BM_SIM_FIELD_LISTS_H_
 #define BM_BM_SIM_FIELD_LISTS_H_
 
-#include <utility>  // for pair<>
-#include <vector>
-#include <unordered_set>
 #include <string>
+#include <unordered_set>
+#include <utility>  // for pair<>
+#include <variant>
+#include <vector>
 
 #include <boost/functional/hash.hpp>
-#include <boost/variant.hpp>
 
 #include "phv_forward.h"
 #include "bytecontainer.h"
@@ -66,7 +66,7 @@ class FieldList {
     }
   };
 
-  struct FieldListVisitor : boost::static_visitor<> {
+  struct FieldListVisitor {
     void operator()(const field_t &) { }
     void operator()(const constant_t &) { }
   };
@@ -95,7 +95,9 @@ class FieldList {
   void visit(T &visitor) {
     static_assert(std::is_base_of<FieldListVisitor, T>::value,
                   "Invalid visitor, must inherit from from FieldListVisitor");
-    std::for_each(fields.begin(), fields.end(), boost::apply_visitor(visitor));
+    for (const auto &field : fields) {
+      std::visit(visitor, field);
+    }
   }
 
   void copy_fields_between_phvs(PHV *dst, const PHV *src) {
@@ -117,7 +119,7 @@ class FieldList {
   }
 
  private:
-  using field_list_member_t = boost::variant<field_t, constant_t>;
+  using field_list_member_t = std::variant<field_t, constant_t>;
 
   struct FieldKeyHash {
     std::size_t operator()(const field_t& f) const {

--- a/src/bm_sim/calculations.cpp
+++ b/src/bm_sim/calculations.cpp
@@ -61,7 +61,7 @@ BufBuilder::append_payload() {
   with_payload = true;
 }
 
-struct BufBuilder::Deparse : public boost::static_visitor<> {
+struct BufBuilder::Deparse {
   Deparse(const PHV &phv, ByteContainer *buf, int init_offset = 0)
       : phv(phv), buf(buf), nbits(init_offset) { }
 
@@ -116,8 +116,9 @@ BufBuilder::operator()(const Packet &pkt, ByteContainer *buf) const {
   buf->clear();
   const PHV *phv = pkt.get_phv();
   Deparse visitor(*phv, buf);
-  std::for_each(entries.begin(), entries.end(),
-                boost::apply_visitor(visitor));
+  for (const auto &entry : entries) {
+    std::visit(visitor, entry);
+  }
   if (with_payload) {
     size_t curr = buf->size();
     size_t psize = pkt.get_data_size();


### PR DESCRIPTION
Part of https://github.com/p4lang/behavioral-model/issues/1360.