### PR TITLE
Fix jsoncpp package name for ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV BM_RUNTIME_DEPS libboost-program-options1.71.0 \
                     libboost-filesystem1.71.0 \
                     libboost-thread1.71.0 \
                     libgmp10 \
-                    libjsoncpp25 \
+                    libjsoncpp1 \
                     libpcap0.8 \
                     libxxhash0 \
                     python3 \

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -31,7 +31,7 @@ ENV BM_RUNTIME_DEPS libboost-program-options1.71.0 \
                     libboost-filesystem1.71.0 \
                     libboost-thread1.71.0 \
                     libgmp10 \
-                    libjsoncpp25 \
+                    libjsoncpp1 \
                     libpcap0.8 \
                     libxxhash0 \
                     python3 \


### PR DESCRIPTION
Fixes https://github.com/p4lang/behavioral-model/actions/runs/26198569485/job/77083312494.

- https://launchpad.net/ubuntu/focal/+package/libjsoncpp1
- https://launchpad.net/ubuntu/jammy/+package/libjsoncpp25