### PR TITLE
Fix test build: use p4info.pb.h instead of p4info.grpc.pb.h

### DIFF
--- a/targets/simple_switch_grpc/tests/base_test.h
+++ b/targets/simple_switch_grpc/tests/base_test.h
@@ -13,7 +13,7 @@
 #ifndef SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_
 #define SIMPLE_SWITCH_GRPC_TESTS_BASE_TEST_H_
 
-#include <p4/config/v1/p4info.grpc.pb.h>
+#include <p4/config/v1/p4info.pb.h>
 #include <p4/v1/p4runtime.grpc.pb.h>
 
 #include <gtest/gtest.h>

--- a/targets/simple_switch_grpc/tests/utils.h
+++ b/targets/simple_switch_grpc/tests/utils.h
@@ -13,7 +13,7 @@
 #ifndef SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_
 #define SIMPLE_SWITCH_GRPC_TESTS_UTILS_H_
 
-#include <p4/config/v1/p4info.grpc.pb.h>
+#include <p4/config/v1/p4info.pb.h>
 
 #include <chrono>
 #include <condition_variable>


### PR DESCRIPTION
The `p4/config/v1/p4info.proto` file in the P4Runtime repository only defines data structures (Messages) and does not define any gRPC services (unlike `p4runtime.proto`). Consequently, the newer gRPC compiler plugin does not generate a `p4info.grpc.pb.h` header for it.