### PR TITLE
tools: fix COND_THRIFT in Makefile.am

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -25,7 +25,7 @@ bin_SCRIPTS += bm_CLI
 
 EXTRA_DIST += bm_CLI.in
 
-endif  # COND_THRIF
+endif  # COND_THRIFT
 
 if COND_NANOMSG
 


### PR DESCRIPTION
## Summary

Fixes a typo in `tools/Makefile.am`:

```make
endif  # COND_THRIF
```

→

```make
endif  # COND_THRIFT
```

This change only corrects the comment typo and does not affect functionality.
