### PR TITLE
tools: use POSIX find operator in check_style.sh

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -25,7 +25,7 @@ bin_SCRIPTS += bm_CLI
 
 EXTRA_DIST += bm_CLI.in
 
-endif  # COND_THRIF
+endif  # COND_THRIFT
 
 if COND_NANOMSG
 

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -13,7 +13,7 @@ return_status=0
 function run_cpplint() {
     # $1 is directory
     # $2 is root
-    python3 $THIS_DIR/cpplint.py --root=$2 $( find $1 -name \*.h -or -name \*.cpp )
+    python3 $THIS_DIR/cpplint.py --root=$2 $( find $1 -name \*.h -o -name \*.cpp )
     return_status=$(($return_status || $?))
 }
 


### PR DESCRIPTION
Replace GNU-specific find -or usage with the POSIX-standard -o
operator in tools/check_style.sh.

- find $1 -name \*.h -or -name \*.cpp
+ find $1 -name \*.h -o -name \*.cpp

This is a behavior-preserving portability cleanup