### PR TITLE
fix: correct copyright holder in install-uv.sh

### DIFF
--- a/tools/install-uv.sh
+++ b/tools/install-uv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2026 OpenAI
+# SPDX-FileCopyrightText: 2026 The P4 Language Consortium
 # SPDX-License-Identifier: Apache-2.0
 
 set -eu


### PR DESCRIPTION
Fixes #1397

The copyright header incorrectly listed "OpenAI" as the copyright holder. Changing to "The P4 Language Consortium" to be consistent with other files in this repository.