### PR TITLE
bazel: add nanomsg support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,8 +53,8 @@ expand_template(
         "#cmakedefine BM_HAVE_VECTOR @BM_HAVE_VECTOR@": "#define BM_HAVE_VECTOR 1",
         "#cmakedefine BM_LOG_DEBUG_ON @BM_LOG_DEBUG_ON@": "#define BM_LOG_DEBUG_ON 1",
         "#cmakedefine BM_LOG_TRACE_ON @BM_LOG_TRACE_ON@": "#define BM_LOG_TRACE_ON 1",
+        "#cmakedefine BM_NANOMSG_ON @BM_NANOMSG_ON@": "#define BM_NANOMSG_ON 1",
         # disabled
-        "#cmakedefine BM_NANOMSG_ON @BM_NANOMSG_ON@": "/* #undef BM_NANOMSG_ON */",
         "#cmakedefine BM_THRIFT_ON @BM_THRIFT_ON@": "/* #undef BM_THRIFT_ON */",
         "#cmakedefine BM_THRIFT_VERSION @BM_THRIFT_VERSION@": "/* #undef BM_THRIFT_VERSION */",
         # enabled
@@ -67,4 +67,5 @@ cc_library(
     name = "bm_headers",
     hdrs = glob(["include/bm/**/*.h"]) + [":config_h"],
     includes = ["include"],
+    deps = ["@nanomsg"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,7 @@ bazel_dep(name = "googleapis", version = "0.0.0-20260130-c0fcb356", repo_name = 
 bazel_dep(name = "grpc", version = "1.76.0", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "jsoncpp", version = "1.9.6.bcr.2")
 bazel_dep(name = "libpcap", version = "1.10.5.bcr.3")
+bazel_dep(name = "nanomsg", version = "1.2.2")
 bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1", repo_name = "com_github_p4lang_p4runtime")
 bazel_dep(name = "package_metadata", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "33.5", repo_name = "com_google_protobuf")

--- a/src/bm_sim/BUILD.bazel
+++ b/src/bm_sim/BUILD.bazel
@@ -46,6 +46,7 @@ cc_library(
         "@gmp",
         "@jsoncpp",
         "@libpcap",
+        "@nanomsg",
         "@xxhash",
     ],
 )


### PR DESCRIPTION
Since my upstream PR https://github.com/bazelbuild/bazel-central-registry/pull/8991 has been merged, we can now support nanomsg in the bmv2 Bazel build.