### PR TITLE
packet trace format and utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ include_directories(
 find_package(Threads REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread program_options)
 find_package(jsoncpp REQUIRED)
+find_package(Protobuf REQUIRED)
 
 # Check for the presence of an include file and report an error if not found
 #
@@ -170,8 +171,7 @@ if(WITH_THRIFT)
 endif()
 
 if(WITH_PI)
-  # Find Protobuf and gRPC
-  find_package(Protobuf REQUIRED)
+  # Find gRPC
   find_package(gRPC REQUIRED)
 
   # Verify that PI headers are present
@@ -220,6 +220,7 @@ if(WITH_THRIFT)
 endif()
 
 add_subdirectory(third_party)
+add_subdirectory(proto)
 add_subdirectory(src)
 add_subdirectory(include)
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ bazel_dep(name = "nanomsg", version = "1.2.2")
 bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1", repo_name = "com_github_p4lang_p4runtime")
 bazel_dep(name = "package_metadata", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "33.5", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "xxhash", version = "0.8.3.bcr.1")
 
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ endif
 # The targets directory (simple_switch, etc.) depends on libbmpi (from PI) and
 # gtest (from third_party), so those must appear before MAYBE_TARGETS in this
 # list.
-SUBDIRS = $(MAYBE_THRIFT) third_party src include \
+SUBDIRS = $(MAYBE_THRIFT) third_party proto src include \
 $(MAYBE_TESTS) $(MAYBE_PI) $(MAYBE_TARGETS) tools $(MAYBE_PDFIXED)
 
 # I am leaving all style-related files (cpplint) out of dist on purpose, maybe

--- a/configure.ac
+++ b/configure.ac
@@ -275,14 +275,14 @@ AC_TYPE_SIZE_T
 AC_TYPE_UINT64_T
 AC_LANG_POP(C++)
 
+AC_PATH_PROG([PROTOC], [protoc], [])
+AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found])])
+
+PKG_CHECK_MODULES([PROTOBUF], [protobuf >= 3.0.0])
+AC_SUBST([PROTOBUF_CFLAGS])
+AC_SUBST([PROTOBUF_LIBS])
+
 AS_IF([test "$want_pi" = yes], [
-	AC_PATH_PROG([PROTOC], [protoc], [])
-	AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found])])
-
-	PKG_CHECK_MODULES([PROTOBUF], [protobuf >= 3.0.0])
-	AC_SUBST([PROTOBUF_CFLAGS])
-	AC_SUBST([PROTOBUF_LIBS])
-
 	PKG_CHECK_MODULES([GRPC], [grpc++ >= 1.3.0 grpc >= 3.0.0])
 	AC_SUBST([GRPC_CFLAGS])
 	AC_SUBST([GRPC_LIBS])
@@ -309,6 +309,7 @@ AC_CONFIG_FILES([Makefile
 		third_party/gmock/Makefile
 		third_party/gtest/Makefile
 		third_party/spdlog/Makefile
+		proto/Makefile
 		include/Makefile
 		src/Makefile
 		src/bm_sim/Makefile

--- a/include/bm/bm_sim/packet.h
+++ b/include/bm/bm_sim/packet.h
@@ -35,6 +35,8 @@
 
 namespace bm {
 
+class PacketTraceContext;
+
 //! Integral type used to identify a given data packet
 using packet_id_t = uint64_t;
 
@@ -122,6 +124,10 @@ class Packet final {
   //! Set the egress_port of the packet, which is the target responsibility.
   void set_egress_port(int port) { egress_port = port; }
   void set_ingress_port(int port) { ingress_port = port; }
+
+  //! Get or set the trace context for structured packet tracing.
+  PacketTraceContext* get_trace_ctx() const { return trace_ctx.get(); }
+  void set_trace_ctx(std::unique_ptr<PacketTraceContext> ctx);
 
   //! Obtains the copy_id of a packet, used to differentiate all the clones
   //! generated from the same incoming data packet. See get_packet_id() for more
@@ -376,6 +382,9 @@ class Packet final {
   ErrorCode error_code{ErrorCode::make_invalid()};
 
   bool checksum_error{false};
+
+  // Per-packet trace context for structured tracing.
+  std::unique_ptr<PacketTraceContext> trace_ctx;
 
  private:
   static CopyIdGenerator *copy_id_gen;

--- a/include/bm/bm_sim/packet_tracer.h
+++ b/include/bm/bm_sim/packet_tracer.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Yuao Ma
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! @file packet_tracer.h
+//!
+//! Protobuf-based structured packet tracing backend.
+
+#ifndef BM_BM_SIM_PACKET_TRACER_H_
+#define BM_BM_SIM_PACKET_TRACER_H_
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "packet_trace.pb.h"
+
+namespace bm {
+
+class Packet;
+
+class TraceTreeWrapper {
+ public:
+  TraceTreeWrapper(uint64_t packet_id, uint32_t ingress_port);
+  ~TraceTreeWrapper();
+
+ private:
+  friend class PacketTraceContext;
+
+  p4::bm::PacketTrace root_trace_;
+};
+
+//! Per-packet trace accumulator. One instance is attached to each Packet object
+//! when tracing is enabled. Accumulates TraceEvent messages in chronological
+//! order.
+class PacketTraceContext {
+ public:
+  PacketTraceContext(uint64_t packet_id, uint32_t ingress_port);
+  PacketTraceContext(std::shared_ptr<TraceTreeWrapper> tree_wrapper,
+                     p4::bm::TraceTree* node);
+
+  std::shared_ptr<TraceTreeWrapper> get_wrapper() const {
+    return tree_wrapper_;
+  }
+
+ private:
+  std::shared_ptr<TraceTreeWrapper> tree_wrapper_;
+  p4::bm::TraceTree* current_node_;
+};
+
+//! Protobuf trace backend.
+class PacketTracer {
+ public:
+  static PacketTracer* get() {
+    static PacketTracer instance;
+    return &instance;
+  }
+
+  //! Set the output directory for trace files.
+  void set_output_dir(const std::string& output_dir);
+
+  //! Write a completed trace to the output directory as txtpb.
+  void flush_trace(const p4::bm::PacketTrace& trace);
+
+ private:
+  PacketTracer() = default;
+
+  bool enabled_{false};
+  std::string output_dir_;
+};
+
+}  // namespace bm
+
+#endif  // BM_BM_SIM_PACKET_TRACER_H_

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Yuao Ma
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+proto_library(
+    name = "packet_trace_proto",
+    srcs = ["packet_trace.proto"],
+    strip_import_prefix = "",
+)
+
+cc_proto_library(
+    name = "packet_trace_cc_proto",
+    deps = [":packet_trace_proto"],
+)

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 Yuao Ma
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/packet_trace.proto)
+set(PROTOFLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}")
+set(PROTOC_GEN_CPP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cpp_out)
+
+set(PROTO_CPP_FILES
+  ${PROTOC_GEN_CPP_DIR}/packet_trace.pb.cc
+  ${PROTOC_GEN_CPP_DIR}/packet_trace.pb.h
+)
+
+add_custom_command(
+  OUTPUT ${PROTO_CPP_FILES}
+  COMMAND mkdir -p ${PROTOC_GEN_CPP_DIR}
+  COMMAND ${Protobuf_PROTOC_EXECUTABLE} ${PROTO_SRC} --cpp_out ${PROTOC_GEN_CPP_DIR} ${PROTOFLAGS}
+  DEPENDS ${PROTO_SRC}
+  COMMENT "Generating protobuf files for packet trace"
+)
+
+add_custom_target(genproto_packet_trace
+  DEPENDS ${PROTO_CPP_FILES}
+)
+
+add_library(bm_packet_trace_proto STATIC
+  ${PROTO_CPP_FILES}
+)
+
+add_dependencies(bm_packet_trace_proto genproto_packet_trace)
+
+target_include_directories(bm_packet_trace_proto PUBLIC
+  ${PROTOC_GEN_CPP_DIR}
+)
+
+target_link_libraries(bm_packet_trace_proto PUBLIC protobuf::libprotobuf)

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Yuao Ma
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
+
+noinst_LTLIBRARIES = libbm_packet_trace.la
+
+proto = $(srcdir)/packet_trace.proto
+PROTOFLAGS = -I$(srcdir)
+
+proto_cpp_files = \
+	cpp_out/packet_trace.pb.cc \
+	cpp_out/packet_trace.pb.h
+
+BUILT_SOURCES = $(proto_cpp_files)
+
+proto_files.ts: $(proto)
+	@rm -f proto_files.tmp
+	@touch proto_files.tmp
+	@mkdir -p $(builddir)/cpp_out
+	$(PROTOC) $^ --cpp_out $(builddir)/cpp_out $(PROTOFLAGS)
+	@mv -f proto_files.tmp $@
+
+$(BUILT_SOURCES): proto_files.ts
+	@if test -f $@; then :; else \
+		trap 'rm -rf proto_files.lock proto_files.ts' 1 2 13 15; \
+		if mkdir proto_files.lock 2>/dev/null; then \
+			rm -f proto_files.ts; \
+			$(MAKE) $(AM_MAKEFLAGS) proto_files.ts; \
+			result=$$?; rm -rf proto_files.lock; exit $$result; \
+		else \
+			while test -d proto_files.lock; do sleep 1; done; \
+			test -f proto_files.ts; \
+		fi; \
+	fi
+
+AM_CPPFLAGS += -I$(builddir)/cpp_out
+
+nodist_libbm_packet_trace_la_SOURCES = $(proto_cpp_files)
+libbm_packet_trace_la_CXXFLAGS =
+
+CLEANFILES = $(BUILT_SOURCES) proto_files.ts

--- a/proto/packet_trace.proto
+++ b/proto/packet_trace.proto
@@ -86,8 +86,6 @@ message TraceEvent {
     // Packet replication engine (PRE) events.
     CloneEvent clone = 7;
     MulticastEvent multicast = 8;
-    ResubmitEvent resubmit = 9;
-    RecirculateEvent recirculate = 10;
 
     // Deparser events.
     DeparserEmitEvent deparser_emit = 11;
@@ -172,12 +170,6 @@ message MulticastEvent {
   uint32 multicast_group_id = 1;
   uint32 replica_count = 2;
 }
-
-// Fired when a packet is resubmitted (re-enters the ingress pipeline).
-message ResubmitEvent {}
-
-// Fired when a packet is recirculated (deparsed packet loops back to ingress).
-message RecirculateEvent {}
 
 // Fired when the deparser emits a valid header to the output packet buffer.
 message DeparserEmitEvent {

--- a/proto/packet_trace.proto
+++ b/proto/packet_trace.proto
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Yuao Ma
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// BMv2 Structured Packet Trace
+//
+// A structured, programmatic representation of a packet's journey through a P4
+// pipeline in BMv2. Designed for use by automated tools for test coverage
+// measurement, automated test generation, root-cause analysis, and human
+// comprehension.
+
+syntax = "proto3";
+
+package p4.bm;
+
+// Top-level trace for one packet copy through the pipeline.
+message PacketTrace {
+  uint64 packet_id = 1;
+  uint32 ingress_port = 2;
+  TraceTree root = 3;
+}
+
+// Recursive trace structure: a sequence of events followed by an outcome.
+message TraceTree {
+  repeated TraceEvent events = 1;
+  oneof outcome {
+    // All branches happen simultaneously; outputs are the union.
+    // Used for clone and multicast.
+    Replication replication = 2;
+
+    // The same packet continues as another parser-to-deparser pass.
+    // Used for resubmit and recirculate.
+    Continuation continuation = 3;
+
+    // Terminal: packet emitted on a port.
+    Transmit transmit = 4;
+
+    // Terminal: packet discarded.
+    Drop drop = 5;
+  }
+}
+
+// All branches execute; their output packets are the union.
+// Used for any mechanism that sends copies to multiple ports (clone,
+// multicast).
+message Replication {
+  repeated TraceTree branches = 1;
+}
+
+// The same packet continues as another parser-to-deparser pass.
+// Used for resubmit and recirculate.
+message Continuation {
+  enum Kind {
+    KIND_UNSPECIFIED = 0;
+    RESUBMIT = 1;
+    RECIRCULATE = 2;
+  }
+  Kind kind = 1;
+  TraceTree next = 2;
+}
+
+// Packet was transmitted out of a port.
+message Transmit {
+  uint32 egress_port = 1;
+  uint32 packet_size = 2;
+}
+
+// Packet was dropped.
+message Drop {}
+
+// A single event in the packet trace.
+message TraceEvent {
+  oneof event {
+    // Pipeline lifecycle.
+    PipelineStageEvent pipeline_stage = 1;
+
+    // Parser events.
+    ParserTransitionEvent parser_transition = 2;
+    ParserExtractEvent parser_extract = 3;
+
+    // Control flow events.
+    TableLookupEvent table_lookup = 4;
+    ActionExecutionEvent action_execution = 5;
+    ConditionEvalEvent condition_eval = 6;
+
+    // Packet replication engine (PRE) events.
+    CloneEvent clone = 7;
+    MulticastEvent multicast = 8;
+    ResubmitEvent resubmit = 9;
+    RecirculateEvent recirculate = 10;
+
+    // Deparser events.
+    DeparserEmitEvent deparser_emit = 11;
+    ChecksumUpdateEvent checksum_update = 12;
+  }
+}
+
+// Fired when the pipeline enters or exits a processing stage.
+message PipelineStageEvent {
+  string stage_name = 1;
+
+  enum StageKind {
+    STAGE_KIND_UNSPECIFIED = 0;
+    PARSER = 1;
+    CONTROL = 2;
+    DEPARSER = 3;
+  }
+  StageKind stage_kind = 2;
+
+  enum Direction {
+    DIRECTION_UNSPECIFIED = 0;
+    ENTER = 1;
+    EXIT = 2;
+  }
+  Direction direction = 3;
+}
+
+// Fired on every parser state transition, including the final transition to
+// the implicit "accept" or "reject" state.
+message ParserTransitionEvent {
+  string parser_name = 1;
+  // Name of the state being left. Empty for the initial transition.
+  string from_state = 2;
+  // Name of the state being entered. Empty string for "accept" (end of
+  // parsing). "reject" for parser errors.
+  string to_state = 3;
+}
+
+// Fired on every parser header extraction.
+message ParserExtractEvent {
+  string header_name = 1;
+}
+
+// Fired on every table.apply() call. Records hit/miss, matched entry, and
+// selected action.
+message TableLookupEvent {
+  string table_name = 1;
+  bool hit = 2;
+  // Entry handle of the matched entry. Only meaningful on hit.
+  uint32 entry_handle = 3;
+  // Name of the action selected (either from the matched entry or the default
+  // action on miss).
+  string action_name = 4;
+  // Human-readable description of the matched entry (match key + action data).
+  string entry_info = 5;
+}
+
+// Fired when an action begins executing.
+message ActionExecutionEvent {
+  string action_name = 1;
+}
+
+// Fired on every if/else condition evaluation.
+message ConditionEvalEvent {
+  string condition_name = 1;
+  bool result = 2;
+}
+
+// Fired when clone (ingress or egress) is triggered.
+message CloneEvent {
+  enum CloneType {
+    CLONE_TYPE_UNSPECIFIED = 0;
+    INGRESS = 1;
+    EGRESS = 2;
+  }
+  CloneType clone_type = 1;
+  uint32 mirror_session_id = 2;
+}
+
+// Fired when multicast replication occurs.
+message MulticastEvent {
+  uint32 multicast_group_id = 1;
+  uint32 replica_count = 2;
+}
+
+// Fired when a packet is resubmitted (re-enters the ingress pipeline).
+message ResubmitEvent {}
+
+// Fired when a packet is recirculated (deparsed packet loops back to ingress).
+message RecirculateEvent {}
+
+// Fired when the deparser emits a valid header to the output packet buffer.
+message DeparserEmitEvent {
+  string header_name = 1;
+}
+
+// Fired when a checksum is updated by the deparser.
+message ChecksumUpdateEvent {
+  string checksum_name = 1;
+}

--- a/src/bm_sim/BUILD.bazel
+++ b/src/bm_sim/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
     linkopts = ["-ldl"],
     deps = [
         "//:bm_headers",
+        "//proto:packet_trace_cc_proto",
         "//src/BMI:bmi",
         "//third_party:spdlog",
         "@boost.container",

--- a/src/bm_sim/CMakeLists.txt
+++ b/src/bm_sim/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(bmsim OBJECT
   options_parse.cpp
   P4Objects.cpp
   packet.cpp
+  packet_tracer.cpp
   parser.cpp
   parser_error.cpp
   pcap_file.cpp
@@ -87,3 +88,11 @@ target_link_libraries(bmsim PUBLIC
 if(WITH_NANOMSG)
   target_link_libraries(bmsim PUBLIC ${NANOMSG_LIBRARY})
 endif()
+
+target_include_directories(bmsim PRIVATE 
+  ${CMAKE_CURRENT_BINARY_DIR}/../../proto/cpp_out
+)
+
+target_link_libraries(bmsim PUBLIC
+  bm_packet_trace_proto
+)

--- a/src/bm_sim/Makefile.am
+++ b/src/bm_sim/Makefile.am
@@ -58,6 +58,7 @@ meters.cpp \
 options_parse.cpp \
 P4Objects.cpp \
 packet.cpp \
+packet_tracer.cpp \
 parser.cpp \
 parser_error.cpp \
 pcap_file.cpp \
@@ -82,3 +83,9 @@ version.h
 
 libbmsim_la_SOURCES += \
 core/primitives.cpp
+
+libbmsim_la_LIBADD = \
+$(top_builddir)/proto/libbm_packet_trace.la \
+$(PROTOBUF_LIBS)
+
+AM_CPPFLAGS += -I$(top_builddir)/proto/cpp_out

--- a/src/bm_sim/packet.cpp
+++ b/src/bm_sim/packet.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/packet_tracer.h>
 #include <bm/bm_sim/phv.h>
 #include <xxhash.h>
 
@@ -209,6 +210,7 @@ Packet::Packet(Packet &&other) noexcept
   phv_source(other.phv_source), registers(other.registers) {
   buffer = std::move(other.buffer);
   phv = std::move(other.phv);
+  trace_ctx = std::move(other.trace_ctx);
 }
 
 Packet &
@@ -229,8 +231,13 @@ Packet::operator=(Packet &&other) noexcept {
 
   std::swap(buffer, other.buffer);
   std::swap(phv, other.phv);
+  std::swap(trace_ctx, other.trace_ctx);
 
   return *this;
+}
+
+void Packet::set_trace_ctx(std::unique_ptr<PacketTraceContext> ctx) {
+  trace_ctx = std::move(ctx);
 }
 
 Packet

--- a/src/bm_sim/packet_tracer.cpp
+++ b/src/bm_sim/packet_tracer.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Yuao Ma
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/packet_tracer.h>
+#include <google/protobuf/text_format.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace bm {
+
+// ---------- TraceTreeWrapper ----------
+
+TraceTreeWrapper::TraceTreeWrapper(uint64_t packet_id, uint32_t ingress_port) {
+  root_trace_.set_packet_id(packet_id);
+  root_trace_.set_ingress_port(ingress_port);
+}
+
+TraceTreeWrapper::~TraceTreeWrapper() {
+  PacketTracer::get()->flush_trace(root_trace_);
+}
+
+// ---------- PacketTraceContext ----------
+
+PacketTraceContext::PacketTraceContext(uint64_t packet_id,
+                                       uint32_t ingress_port) {
+  tree_wrapper_ = std::make_shared<TraceTreeWrapper>(packet_id, ingress_port);
+  current_node_ = tree_wrapper_->root_trace_.mutable_root();
+}
+
+PacketTraceContext::PacketTraceContext(
+    std::shared_ptr<TraceTreeWrapper> tree_wrapper, p4::bm::TraceTree* node)
+    : tree_wrapper_(std::move(tree_wrapper)), current_node_(node) {}
+
+// ---------- PacketTracer ----------
+
+void PacketTracer::set_output_dir(const std::string& output_dir) {
+  output_dir_ = output_dir;
+  enabled_ = true;
+  BMLOG_DEBUG("Packet tracer initialized with output directory: {}",
+              output_dir);
+}
+
+void PacketTracer::flush_trace(const p4::bm::PacketTrace& trace) {
+  if (!enabled_) return;
+
+  std::string txtpb;
+  google::protobuf::TextFormat::PrintToString(trace, &txtpb);
+
+  std::ostringstream filename;
+  filename << output_dir_ << "/trace_" << trace.packet_id() << ".txtpb";
+
+  std::ofstream out(filename.str());
+  if (out.is_open()) {
+    out << txtpb;
+    out.close();
+  } else {
+    BMLOG_ERROR("Failed to write trace to {}", filename.str());
+  }
+}
+
+}  // namespace bm

--- a/src/bm_sim/packet_tracer.cpp
+++ b/src/bm_sim/packet_tracer.cpp
@@ -7,8 +7,8 @@
 #include <bm/bm_sim/packet_tracer.h>
 #include <google/protobuf/text_format.h>
 
+#include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <string>
 #include <utility>
 
@@ -40,6 +40,14 @@ PacketTraceContext::PacketTraceContext(
 // ---------- PacketTracer ----------
 
 void PacketTracer::set_output_dir(const std::string& output_dir) {
+  std::error_code ec;
+  std::filesystem::create_directories(output_dir, ec);
+  if (ec) {
+    BMLOG_ERROR("Failed to create trace output directory '{}': {}", output_dir,
+                ec.message());
+    return;
+  }
+
   output_dir_ = output_dir;
   enabled_ = true;
   BMLOG_DEBUG("Packet tracer initialized with output directory: {}",
@@ -52,15 +60,14 @@ void PacketTracer::flush_trace(const p4::bm::PacketTrace& trace) {
   std::string txtpb;
   google::protobuf::TextFormat::PrintToString(trace, &txtpb);
 
-  std::ostringstream filename;
-  filename << output_dir_ << "/trace_" << trace.packet_id() << ".txtpb";
+  auto path = std::filesystem::path(output_dir_) /
+              ("trace_" + std::to_string(trace.packet_id()) + ".txtpb");
 
-  std::ofstream out(filename.str());
+  std::ofstream out(path);
   if (out.is_open()) {
     out << txtpb;
-    out.close();
   } else {
-    BMLOG_ERROR("Failed to write trace to {}", filename.str());
+    BMLOG_ERROR("Failed to write trace to {}", path.string());
   }
 }
 


### PR DESCRIPTION
This PR introduces the first phase of packet trace support, focusing primarily on the following foundational additions:

- Defines the structured data format for packet tracing. I initially considered a flattened format using `packet_id` and `copy_id` to track packets. However, since handling packet forks is unnatural and complex in a flattened structure, I opted for a recursive trace tree format instead.
- Adjusts all three build systems (bazel, cmake, and autotools).
- Introduces the foundational C++ classes and structures for managing the trace tree.