### PR TITLE
Remove dead bmv2.org references from README and CI workflow

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -23,13 +23,15 @@ jobs:
     - name: Run Doxygen
       run: |
         doxygen Doxyfile
-    - name: Upload to S3
-      uses: jakejarvis/s3-sync-action@v0.5.1
-      with:
-        args: --acl public-read --follow-symlinks --delete
-      env:
-        AWS_S3_BUCKET: 'bmv2.org'
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-west-2'
-        SOURCE_DIR: 'doxygen-out/html'
+    # Disabled: bmv2.org domain is no longer owned/available, this step
+    # consistently fails due to invalid bucket/credentials. See issue #1408.
+    # - name: Upload to S3
+    #   uses: jakejarvis/s3-sync-action@v0.5.1
+    #   with:
+    #     args: --acl public-read --follow-symlinks --delete
+    #   env:
+    #     AWS_S3_BUCKET: 'bmv2.org'
+    #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #     AWS_REGION: 'us-west-2'
+    #     SOURCE_DIR: 'doxygen-out/html'

--- a/README.md
+++ b/README.md
@@ -422,8 +422,7 @@ writing some doxygen documentation specifically targetted at programmers who
 want to implement their own switch model using the bmv2 building blocks. You can
 generate this documentation yourself (if you have doxygen installed) by running
 `doxygen Doxyfile`. The output can be found under the `doxygen-out`
-directory. You can also browse this documentation
-[online](http://bmv2.org).
+directory.
 
 ### What else is new in bmv2?
 


### PR DESCRIPTION
Fixes #1408

Removes the dead link to bmv2.org from the README and disables the 
S3 upload step in the Doxygen CI workflow, which was consistently 
failing since the domain is no longer owned/available, as discussed 
in the issue.