### PR TITLE
fix(pdfixed): validate dev_id bounds in notification APIs

### DIFF
--- a/pdfixed/src/pd_notifications.cpp
+++ b/pdfixed/src/pd_notifications.cpp
@@ -144,6 +144,10 @@ NotificationsListener *listeners[NUM_DEVICES];
 int pd_notifications_add_device(int dev_id, const char *notifications_addr,
                                 NotificationCb ageing_cb,
                                 NotificationCb learning_cb) {
+  if (dev_id < 0 || dev_id >= NUM_DEVICES) {
+    std::cerr << "Invalid device id " << dev_id << "\n";
+    return -1;
+  }
   assert(!listeners[dev_id]);
   listeners[dev_id] = new NotificationsListener(dev_id, notifications_addr);
   listeners[dev_id]->register_ageing_cb(ageing_cb);
@@ -153,6 +157,10 @@ int pd_notifications_add_device(int dev_id, const char *notifications_addr,
 }
 
 int pd_notifications_remove_device(int dev_id) {
+  if (dev_id < 0 || dev_id >= NUM_DEVICES) {
+    std::cerr << "Invalid device id " << dev_id << "\n";
+    return -1;
+  }
   assert(listeners[dev_id]);
   delete listeners[dev_id];
   listeners[dev_id] = nullptr;


### PR DESCRIPTION
## Summary

Bounds checks added to `dev_id` in:

* `pd_notifications_add_device()`
* `pd_notifications_remove_device()`

Both functions used `listeners[dev_id]` without checking if `dev_id` is in bounds, which might result in array access out of bounds.

The patch adds the check for `dev_id` and returns an error if `dev_id` is invalid.

Fixes #1413

## Testing

* Built successfully using:

  ```
  make -j$(nproc)
  ```

* No format errors according to `git diff --check`.

* Failed to run `make check` because of existing problem with the environment (could not find `libruntimestubs.la`).