### PR TITLE
fix(pdfixed): validate device ID bounds in PRE and mirroring APIs

### DIFF
--- a/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
+++ b/pdfixed/include/bm/pdfixed/int/pd_conn_mgr.h
@@ -19,6 +19,7 @@
 #include <thrift/protocol/TMultiplexedProtocol.h>
 
 #include <bm/thrift/stdcxx.h>
+#include <bm/pdfixed/pd_common.h>
 
 #include <mutex>
 #include <iostream>
@@ -27,8 +28,6 @@
 #include <unordered_map>
 #include <typeindex>
 #include <string>
-
-#define NUM_DEVICES 256
 
 template <typename A>
 struct Client {
@@ -78,7 +77,7 @@ struct PdConnMgr {
   virtual int client_close(int dev_id) = 0;
 
  protected:
-  std::array<detail::ClientState, NUM_DEVICES> clients;
+  std::array<detail::ClientState, PD_MAX_DEVICES> clients;
   detail::TypeMapper mapper{};
 };
 
@@ -195,7 +194,5 @@ struct PdConnMgr_ : public PdConnMgr {
 };
 
 }  // namespace detail
-
-#undef NUM_DEVICES
 
 #endif  // BM_PDFIXED_INT_PD_CONN_MGR_H_

--- a/pdfixed/include/bm/pdfixed/pd_common.h
+++ b/pdfixed/include/bm/pdfixed/pd_common.h
@@ -20,6 +20,19 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+}
+#endif
+
+// C++ only: maximum number of devices supported by pdfixed
+#ifdef __cplusplus
+constexpr int PD_MAX_DEVICES = 256;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint32_t p4_pd_status_t;
 
 typedef uint32_t p4_pd_sess_hdl_t;

--- a/pdfixed/src/pd_mirroring.cpp
+++ b/pdfixed/src/pd_mirroring.cpp
@@ -52,6 +52,10 @@ int p4_pd_mirror_session_create(p4_pd_sess_hdl_t shdl,
   (void) shdl; (void) type; (void) dir; (void) max_pkt_len; (void) cos;
   (void) c2c; (void) extract_len; (void) timeout_usec; (void) int_hdr;
   (void) int_hdr_len;
+  if (dev_tgt.device_id < 0 || dev_tgt.device_id >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << dev_tgt.device_id << "\n";
+    return 1;
+  }
   return client(dev_tgt.device_id).c->mirroring_mapping_add(id, egr_port);
 }
 
@@ -72,6 +76,10 @@ int p4_pd_mirror_session_update(p4_pd_sess_hdl_t shdl,
   (void) shdl; (void) type; (void) dir; (void) max_pkt_len; (void) cos;
   (void) c2c; (void) extract_len; (void) timeout_usec; (void) int_hdr;
   (void) int_hdr_len; (void) enable;
+  if (dev_tgt.device_id < 0 || dev_tgt.device_id >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << dev_tgt.device_id << "\n";
+    return 1;
+  }
   return client(dev_tgt.device_id).c->mirroring_mapping_add(id, egr_port);
 }
 
@@ -85,6 +93,10 @@ int p4_pd_mirror_session_delete(p4_pd_sess_hdl_t shdl,
                                 p4_pd_dev_target_t dev_tgt,
                                 p4_pd_mirror_id_t mirror_id) {
   (void) shdl;
+  if (dev_tgt.device_id < 0 || dev_tgt.device_id >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << dev_tgt.device_id << "\n";
+    return 1;
+  }
   return client(dev_tgt.device_id).c->mirroring_mapping_delete(mirror_id);
 }
 

--- a/pdfixed/src/pd_notifications.cpp
+++ b/pdfixed/src/pd_notifications.cpp
@@ -10,6 +10,7 @@
 
 #include <bm/bm_sim/nn.h>
 #include <bm/pdfixed/int/pd_notifications.h>
+#include <bm/pdfixed/pd_common.h>
 
 #include <nanomsg/pubsub.h>
 
@@ -20,8 +21,6 @@
 #include <type_traits>
 #include <functional>
 #include <cstring>
-
-#define NUM_DEVICES 256
 
 namespace {
 
@@ -137,14 +136,14 @@ class NotificationsListener {
   NotificationCb learn_cb{};
 };
 
-NotificationsListener *listeners[NUM_DEVICES];
+NotificationsListener *listeners[PD_MAX_DEVICES];
 
 }  // namespace
 
 int pd_notifications_add_device(int dev_id, const char *notifications_addr,
                                 NotificationCb ageing_cb,
                                 NotificationCb learning_cb) {
-  if (dev_id < 0 || dev_id >= NUM_DEVICES) {
+  if (dev_id < 0 || dev_id >= PD_MAX_DEVICES) {
     std::cerr << "Invalid device id " << dev_id << "\n";
     return -1;
   }
@@ -157,7 +156,7 @@ int pd_notifications_add_device(int dev_id, const char *notifications_addr,
 }
 
 int pd_notifications_remove_device(int dev_id) {
-  if (dev_id < 0 || dev_id >= NUM_DEVICES) {
+  if (dev_id < 0 || dev_id >= PD_MAX_DEVICES) {
     std::cerr << "Invalid device id " << dev_id << "\n";
     return -1;
   }

--- a/pdfixed/src/pd_pre.cpp
+++ b/pdfixed/src/pd_pre.cpp
@@ -13,6 +13,7 @@
 
 #include <bm/pdfixed/pd_pre.h>
 #include <bm/pdfixed/pd_static.h>
+#include <bm/pdfixed/pd_common.h>
 #include <bm/pdfixed/int/pd_conn_mgr.h>
 
 #include <string>
@@ -65,6 +66,10 @@ p4_pd_status_t
 p4_pd_mc_mgrp_create(p4_pd_sess_hdl_t session, int device,
                      mgrp_id_t mgid, p4_pd_entry_hdl_t *mgrp_hdl) {
   (void) session;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   *mgrp_hdl = client(device).c->bm_mc_mgrp_create(0, mgid);
   return 0;  // TODO(unknown)
 }
@@ -73,6 +78,10 @@ p4_pd_status_t
 p4_pd_mc_mgrp_destroy(p4_pd_sess_hdl_t session, int device,
                       p4_pd_entry_hdl_t mgrp_hdl) {
   (void) session;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   client(device).c->bm_mc_mgrp_destroy(0, mgrp_hdl);
   return 0;  // TODO(unknown)
 }
@@ -82,6 +91,10 @@ p4_pd_mc_node_create(p4_pd_sess_hdl_t session, int device,
                      mgrp_rid_t rid, const uint8_t *port_map,
                      const uint8_t *lag_map, p4_pd_entry_hdl_t *node_hdl) {
   (void) session;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   std::string port_map_ = convert_map(port_map, PRE_PORTS_MAX);
   std::string lag_map_ = convert_map(lag_map, PRE_LAG_MAX);
   *node_hdl = client(device).c->bm_mc_node_create(0, rid, port_map_, lag_map_);
@@ -93,6 +106,10 @@ p4_pd_mc_associate_node(p4_pd_sess_hdl_t session, int device,
                         p4_pd_entry_hdl_t mgrp_hdl, p4_pd_entry_hdl_t hdl,
                         uint16_t xid, bool xid_valid) {
   (void) session; (void) xid; (void) xid_valid;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   client(device).c->bm_mc_node_associate(0, mgrp_hdl, hdl);
   return 0;  // TODO(unknown)
 }
@@ -110,6 +127,10 @@ p4_pd_status_t
 p4_pd_mc_node_destroy(p4_pd_sess_hdl_t session, int device,
                       p4_pd_entry_hdl_t node_hdl) {
   (void) session;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   client(device).c->bm_mc_node_destroy(0, node_hdl);
   return 0;  // TODO(unknown)
 }
@@ -119,6 +140,10 @@ p4_pd_mc_node_update(p4_pd_sess_hdl_t session, int device,
                      p4_pd_entry_hdl_t node_hdl, const uint8_t *port_map,
                      const uint8_t *lag_map) {
   (void) session;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   std::string port_map_ = convert_map(port_map, PRE_PORTS_MAX);
   std::string lag_map_ = convert_map(lag_map, PRE_LAG_MAX);
   client(device).c->bm_mc_node_update(0, node_hdl, port_map_, lag_map_);
@@ -129,6 +154,10 @@ p4_pd_status_t
 p4_pd_mc_set_lag_membership(p4_pd_sess_hdl_t session, int device,
                             mgrp_lag_id_t lag_id, const uint8_t *port_map) {
   (void) session;
+  if (device < 0 || device >= PD_MAX_DEVICES) {
+    std::cerr << "Invalid device id " << device << "\n";
+    return 1;
+  }
   std::string port_map_ = convert_map(port_map, PRE_PORTS_MAX);
   client(device).c->bm_mc_set_lag_membership(0, lag_id, port_map_);
   return 0;  // TODO(unknown)


### PR DESCRIPTION
## Summary

This change adds defensive device ID bounds validation to the PRE and mirroring APIs before accessing the underlying `clients[]` array.

The affected APIs accept an `int` device identifier and use it to access `clients[dev_id]` through `PdConnMgr::get()` without verifying that the device ID is within the valid range.

This patch adds bounds checks to reject invalid device IDs and return an error before the array access occurs.

The validation pattern follows the approach recently introduced for the notification APIs in PR #1414.

### PRE APIs

- `p4_pd_mc_mgrp_create()`
- `p4_pd_mc_mgrp_destroy()`
- `p4_pd_mc_node_create()`
- `p4_pd_mc_associate_node()`
- `p4_pd_mc_node_destroy()`
- `p4_pd_mc_node_update()`
- `p4_pd_mc_set_lag_membership()`

### Mirroring APIs

- `p4_pd_mirror_session_create()`
- `p4_pd_mirror_session_update()`
- `p4_pd_mirror_session_delete()`

## Testing

Built successfully using:

```bash
make -j$(nproc)
```

Verified:

- `git diff --check`
- Valid device IDs continue to behave as expected.
- Invalid device IDs (`-1`, `500`, and `1000`) now return an error before accessing the underlying `clients[]` array.