### PR TITLE
Use proper upstream workflow file

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   monthly-release:
     if: ${{ github.repository == 'p4lang/behavioral-model' }}
-    uses: p4lang/.github/.github/workflows/bump-version.yml@main
+    uses: p4lang/.github/.github/workflows/monthly-release.yml@main
     with:
       tag_prefix: ""
       branch_pattern: "release/{version}"


### PR DESCRIPTION
Argh. Same as https://github.com/p4lang/ptf/pull/266. I changed shared workflow file names right in the midst of *using* those names in a bunch of repos. This fixes https://github.com/p4lang/behavioral-model/actions/runs/28520180211.