### PR TITLE
Fix LAG member selection using packet data hash

### DIFF
--- a/include/bm/bm_sim/simple_pre.h
+++ b/include/bm/bm_sim/simple_pre.h
@@ -62,6 +62,14 @@ class McSimplePre {
   struct McIn {
     //! Multicast group id to use for replication
     mgrp_t mgid;
+    //! Hash value used by LAG-aware PRE implementations (see
+    //! McSimplePreLAG) to select a member port within a LAG. Callers
+    //! replicating over a LAG should populate this with a hash of
+    //! per-packet data (e.g. the packet's header fields) so that traffic
+    //! is spread across LAG members instead of always resolving to the
+    //! same one. Implementations which do not support LAGs ignore this
+    //! field. Defaults to 0.
+    uint64_t hash{0};
   };
 
   //! Output of replicate() method

--- a/src/bm_sim/simple_pre_lag.cpp
+++ b/src/bm_sim/simple_pre_lag.cpp
@@ -137,7 +137,11 @@ McSimplePreLAG::replicate(const McSimplePre::McIn ingress_info) const {
   std::vector<McSimplePre::McOut> egress_info_list;
   egress_port_t port_id;
   lag_id_t lag_index;
-  int lag_hash = 0xFF;  // TODO(unknown): get lag hash from metadata
+  // Hash used to pick a member within a LAG. This is supplied by the
+  // caller (e.g. derived from a hash of packet header fields) so that
+  // packets are actually spread across LAG members rather than always
+  // resolving to the same one.
+  const uint64_t lag_hash = ingress_info.hash;
   int port_count1 = 0, port_count2 = 0;
   McSimplePre::McOut egress_info;
   std::shared_lock<std::shared_mutex> lock(mutex);
@@ -175,7 +179,7 @@ McSimplePreLAG::replicate(const McSimplePre::McIn ingress_info) const {
                                lag_index);
           continue;
         }
-        port_count1 = (lag_hash % lag_entry.member_count) + 1;
+        port_count1 = static_cast<int>(lag_hash % lag_entry.member_count) + 1;
         port_count2 = 0;
         for (port_id = 0; port_id < port_map.size(); port_id++) {
           if (port_map[port_id]) {

--- a/targets/psa_switch/psa_switch.cpp
+++ b/targets/psa_switch/psa_switch.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <bm/bm_sim/calculations.h>
 #include <bm/bm_sim/parser.h>
 #include <bm/bm_sim/tables.h>
 #include <bm/bm_sim/logger.h>
@@ -339,7 +340,12 @@ PsaSwitch::enqueue(port_t egress_port, std::unique_ptr<Packet> &&packet) {
 void
 PsaSwitch::multicast(Packet *packet, unsigned int mgid, PktInstanceType path, unsigned int class_of_service) {
   auto phv = packet->get_phv();
-  const auto pre_out = pre->replicate({mgid});
+  // Hash the packet data to obtain per-packet entropy for LAG member
+  // selection, so that replication across a LAG's member ports is
+  // actually spread out instead of always picking the same member.
+  const uint64_t lag_hash =
+      bm::hash::xxh64(packet->data(), packet->get_data_size());
+  const auto pre_out = pre->replicate({mgid, lag_hash});
   auto &f_eg_cos = phv->get_field("psa_egress_input_metadata.class_of_service");
   auto &f_instance = phv->get_field("psa_egress_input_metadata.instance");
   auto &f_packet_path = phv->get_field("psa_egress_parser_input_metadata.packet_path");

--- a/targets/simple_switch/simple_switch.cpp
+++ b/targets/simple_switch/simple_switch.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <bm/bm_sim/_assert.h>
+#include <bm/bm_sim/calculations.h>
 #include <bm/bm_sim/parser.h>
 #include <bm/bm_sim/tables.h>
 #include <bm/bm_sim/logger.h>
@@ -454,7 +455,12 @@ void
 SimpleSwitch::multicast(Packet *packet, unsigned int mgid) {
   auto *phv = packet->get_phv();
   auto &f_rid = phv->get_field("intrinsic_metadata.egress_rid");
-  const auto pre_out = pre->replicate({mgid});
+  // Hash the packet data to obtain per-packet entropy for LAG member
+  // selection, so that replication across a LAG's member ports is
+  // actually spread out instead of always picking the same member.
+  const uint64_t lag_hash =
+      bm::hash::xxh64(packet->data(), packet->get_data_size());
+  const auto pre_out = pre->replicate({mgid, lag_hash});
   auto packet_size =
       packet->get_register(RegisterAccess::PACKET_LENGTH_REG_IDX);
   for (const auto &out : pre_out) {

--- a/tests/test_pre.cpp
+++ b/tests/test_pre.cpp
@@ -14,6 +14,7 @@
 #include <bm/bm_sim/simple_pre_lag.h>
 
 #include <bitset>
+#include <set>
 #include <vector>
 
 using namespace bm;
@@ -384,6 +385,44 @@ TEST(McSimplePreLAG, ResetState) {
   ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_mgrp_create(1, &mgrp));
   auto mc_out_3 = pre.replicate({1});
   ASSERT_EQ(0u, mc_out_3.size());
+}
+
+TEST(McSimplePreLAG, LAGHashSelectsMember) {
+  // Regression test: the member of a LAG selected during replication must
+  // depend on the hash value supplied in McIn, so that traffic is spread
+  // across LAG members instead of always resolving to the same one.
+  McSimplePreLAG pre;
+  McSimplePreLAG::mgrp_t mgid = 0x400;
+  McSimplePreLAG::mgrp_hdl_t mgrp;
+  McSimplePreLAG::l1_hdl_t l1h;
+  McSimplePreLAG::rid_t rid = 0x200;
+  McSimplePreLAG::lag_id_t lag_id = 2;
+  std::vector<McSimplePre::egress_port_t> members = {10, 11, 12, 13};
+
+  McSimplePreLAG::PortMap lag_port_map;
+  for (const auto &m : members) lag_port_map[m] = 1;
+
+  McSimplePreLAG::LagMap lag_map;
+  lag_map[lag_id] = 1;
+
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_mgrp_create(mgid, &mgrp));
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_node_create(rid, {}, lag_map, &l1h));
+  ASSERT_EQ(McSimplePre::SUCCESS, pre.mc_node_associate(mgrp, l1h));
+  ASSERT_EQ(McSimplePre::SUCCESS,
+            pre.mc_set_lag_membership(lag_id, lag_port_map));
+
+  // Every member should be reachable for some hash value (i.e. the member
+  // selection is not stuck on a single port), and the selection should
+  // match the expected (hash % member_count) mapping.
+  std::set<McSimplePre::egress_port_t> selected_ports;
+  for (uint64_t hash = 0; hash < members.size(); hash++) {
+    McSimplePre::McIn ingress_info{mgid, hash};
+    auto egress_info = pre.replicate(ingress_info);
+    ASSERT_EQ(1u, egress_info.size());
+    selected_ports.insert(egress_info[0].egress_port);
+    EXPECT_EQ(members[hash % members.size()], egress_info[0].egress_port);
+  }
+  EXPECT_EQ(members.size(), selected_ports.size());
 }
 
 TEST(McSimplePreLAG, LAGMembershipNotSet) {


### PR DESCRIPTION
### Problem
 
In `McSimplePreLAG::replicate()` (`src/bm_sim/simple_pre_lag.cpp`), the value used to pick a member port within a LAG was a hardcoded constant:
 
```cpp
int lag_hash = 0xFF;  // TODO(unknown): get lag hash from metadata
...
port_count1 = (lag_hash % lag_entry.member_count) + 1;
```
 
Since `lag_hash` never varies, every packet replicated through a given LAG always resolves to the same member index, defeating the entire point of a LAG (spreading traffic across members).
 
### Fix
 
- `McSimplePre::McIn` (`include/bm/bm_sim/simple_pre.h`) gains a new `uint64_t hash{0}` field. Callers that replicate over a LAG populate it with a hash derived from per-packet data; callers/targets that don't care about LAGs (e.g. `l2_switch`, which uses plain `McSimplePre`) are unaffected because it defaults to 0.
- `McSimplePreLAG::replicate()` now uses `ingress_info.hash` instead of the hardcoded `0xFF`.
- `simple_switch` and `psa_switch` (the two targets that use `McSimplePreLAG`) now compute a hash of the packet's bytes with the existing `bm::hash::xxh64` helper and pass it through: `pre->replicate({mgid, lag_hash})`. Hashing the packet's own bytes (rather than e.g. a monotonic counter) means packets from the same flow keep landing on the same LAG member, which is the behavior real LAG hashing is expected to have.
- 
### Testing
 
- Added `McSimplePreLAG.LAGHashSelectsMember` in `tests/test_pre.cpp`: creates a 4-member LAG and calls `replicate()` with several different `hash` values, asserting that the selected member follows the expected `hash % member_count` mapping and that all 4 members are reachable (this test would have failed before the fix, since every hash value used to resolve to the same member).
- Built and ran the full test suite locally (`cmake` + `ctest`, with `WITH_THRIFT=ON -DWITH_NANOMSG=ON -DWITH_TARGETS=ON`): 46/47 tests pass. The one failure (`test_switch`/`SerializeState2`) is unrelated to this
  change, it's an environment issue (missing Python `thrift` module for `runtime_CLI.py` in the sandbox used to test this), not a regression.
- Verified `simple_switch` and `psa_switch` (the two targets touched) build and their own test suites (`test_packet_redirect`, `test_swap`, `test_queueing`, `test_recirc`, `test_parser_error`, `test_hash`, `test_internet_checksum`) pass unchanged.
- Ran `tools/cpplint.py` on all changed files; confirmed zero new lint warnings versus the pre-change baseline (the warnings cpplint reports in `psa_switch.cpp` and `simple_pre.h` are pre-existing, unrelated to the lines touched here).
- 
### Files changed
- `include/bm/bm_sim/simple_pre.h`
- `src/bm_sim/simple_pre_lag.cpp`
- `targets/simple_switch/simple_switch.cpp`
- `targets/psa_switch/psa_switch.cpp`
- `tests/test_pre.cpp`
 