### PR TITLE
Remove CLA Verbiage from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 You can fork the repo and submit a pull request in Github. For more information
 send us an email (p4-dev@lists.p4.org).
 
-### Apache CLA
-
-All developers must sign the [P4.org](http://p4.org) CLA and return it to
-(membership@p4.org) before making contributions. The CLA is available
-[here](https://p4.org/assets/P4_Language_Consortium_Membership_Agreement.pdf).
-
 ### Coding guidelines
 
 Any contribution to the C++ core code (in particular the [bm_sim](src/bm_sim)


### PR DESCRIPTION
The P4 organization no longer uses a CLA for contributions.