### PR TITLE
Refactor EventLogger to a multi-observer registry (NFC)

### DIFF
--- a/include/bm/bm_sim/event_logger.h
+++ b/include/bm/bm_sim/event_logger.h
@@ -22,28 +22,11 @@
 #include <utility>
 
 #include "device_id.h"
+#include "event_observer.h"
 #include "phv_forward.h"
 #include "transport.h"
 
 namespace bm {
-
-class Packet;
-
-// Forward declarations of P4 object classes. This is ugly, but:
-// 1) I don't have to worry about circular dependencies
-// 2) If I decide to switch from id to name for msgs, I won't have to modify the
-// EventLogger interface
-class Parser;
-class Deparser;
-class MatchTableAbstract;
-class MatchEntry;
-class ActionFn;
-struct ActionData;
-class Conditional;
-class Checksum;
-class Pipeline;
-
-using entry_handle_t = uint32_t;
 
 //! Signals significant packet event by publishing a message on a
 //! transport. This is meant to be used with the nanomsg PUB/SUB transport.
@@ -58,41 +41,39 @@ using entry_handle_t = uint32_t;
 //! responsible of generated "packet in" and "packet out" messages (when a
 //! packet is received / transmitted). Obviously, this is optional and you do
 //! not have to do it if you are not interested in using the event logger.
-class EventLogger {
+class EventLogger : public EventObserverIface {
  public:
   explicit EventLogger(std::unique_ptr<TransportIface> transport,
                        device_id_t device_id = 0)
       : transport_instance(std::move(transport)), device_id(device_id) { }
 
-  // we need the ingress / egress ports, but they are part of the Packet
-  //! Signal that a packet was received by the switch
-  void packet_in(const Packet &packet);
-  //! Signal that a packet was transmitted by the switch
-  void packet_out(const Packet &packet);
+  void packet_in(const Packet& packet) override;
+  void packet_out(const Packet& packet) override;
 
-  void parser_start(const Packet &packet, const Parser &parser);
-  void parser_done(const Packet &packet, const Parser &parser);
-  void parser_extract(const Packet &packet, header_id_t header);
+  void parser_start(const Packet& packet, const Parser& parser) override;
+  void parser_done(const Packet& packet, const Parser& parser) override;
+  void parser_extract(const Packet& packet, header_id_t header) override;
 
-  void deparser_start(const Packet &packet, const Deparser &deparser);
-  void deparser_done(const Packet &packet, const Deparser &deparser);
-  void deparser_emit(const Packet &packet, header_id_t header);
+  void deparser_start(const Packet& packet, const Deparser& deparser) override;
+  void deparser_done(const Packet& packet, const Deparser& deparser) override;
+  void deparser_emit(const Packet& packet, header_id_t header) override;
 
-  void checksum_update(const Packet &packet, const Checksum &checksum);
+  void checksum_update(const Packet& packet, const Checksum& checksum) override;
 
-  void pipeline_start(const Packet &packet, const Pipeline &pipeline);
-  void pipeline_done(const Packet &packet, const Pipeline &pipeline);
+  void pipeline_start(const Packet& packet, const Pipeline& pipeline) override;
+  void pipeline_done(const Packet& packet, const Pipeline& pipeline) override;
 
-  void condition_eval(const Packet &packet,
-                      const Conditional &cond, bool result);
-  void table_hit(const Packet &packet,
-                 const MatchTableAbstract &table, entry_handle_t handle);
-  void table_miss(const Packet &packet, const MatchTableAbstract &table);
+  void condition_eval(const Packet& packet, const Conditional& cond,
+                      bool result) override;
+  void table_hit(const Packet& packet, const MatchTableAbstract& table,
+                 entry_handle_t handle) override;
+  void table_miss(const Packet& packet,
+                  const MatchTableAbstract& table) override;
 
-  void action_execute(const Packet &packet,
-                      const ActionFn &action_fn, const ActionData &action_data);
+  void action_execute(const Packet& packet, const ActionFn& action_fn,
+                      const ActionData& action_data) override;
 
-  void config_change();
+  void config_change() override;
 
   static EventLogger *get() {
     static EventLogger event_logger(TransportIface::make_dummy());
@@ -103,6 +84,7 @@ class EventLogger {
                    device_id_t device_id = 0) {
     get()->transport_instance = std::move(transport);
     get()->device_id = device_id;
+    EventObserverRegistry::get()->register_observer(get());
   }
 
  private:
@@ -111,18 +93,5 @@ class EventLogger {
 };
 
 }  // namespace bm
-
-//! Log an event with the event logger.
-//! For example:
-//! @code
-//! BMELOG(packet_in, packet);
-//! // packet processing
-//! BMELOG(packet_out, packet);
-//! @endcode
-#ifdef BM_ELOG_ON
-#define BMELOG(fn, ...) bm::EventLogger::get()->fn(__VA_ARGS__)
-#else
-#define BMELOG(fn, ...)
-#endif
 
 #endif  // BM_BM_SIM_EVENT_LOGGER_H_

--- a/include/bm/bm_sim/event_observer.h
+++ b/include/bm/bm_sim/event_observer.h
@@ -19,10 +19,9 @@
 
 namespace bm {
 
-// Forward declarations of P4 object classes. This is ugly, but:
-// 1) I don't have to worry about circular dependencies
-// 2) If I decide to switch from id to name for msgs, I won't have to modify the
-// EventObserverIface
+// Forward declarations of P4 object classes. Don't need their full definitions
+// because this file only uses references to them and doesn't require their
+// implementation/layout details.
 class ActionFn;
 class Checksum;
 class Conditional;
@@ -107,7 +106,12 @@ class EventObserverRegistry {
 }  // namespace bm
 
 //! Dispatch an event to all registered observers.
-//! Usage: BMELOG(parser_start, *pkt, *this);
+//! For example:
+//! @code
+//! BMELOG(packet_in, packet);
+//! // packet processing
+//! BMELOG(packet_out, packet);
+//! @endcode
 #if defined(BM_ELOG_ON) || defined(BM_PACKET_TRACE_ON)
 #define BMELOG(fn, ...)                                                 \
   do {                                                                  \

--- a/include/bm/bm_sim/event_observer.h
+++ b/include/bm/bm_sim/event_observer.h
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Yuao Ma
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! @file event_observer.h
+
+#ifndef BM_BM_SIM_EVENT_OBSERVER_H_
+#define BM_BM_SIM_EVENT_OBSERVER_H_
+
+#include <bm/config.h>
+
+#include <vector>
+
+#include "device_id.h"
+#include "phv_forward.h"
+#include "transport.h"
+
+namespace bm {
+
+// Forward declarations of P4 object classes. This is ugly, but:
+// 1) I don't have to worry about circular dependencies
+// 2) If I decide to switch from id to name for msgs, I won't have to modify the
+// EventObserverIface
+class ActionFn;
+class Checksum;
+class Conditional;
+class Deparser;
+class MatchEntry;
+class MatchTableAbstract;
+class Packet;
+class Parser;
+class Pipeline;
+struct ActionData;
+
+using entry_handle_t = uint32_t;
+
+//! Abstract observer interface for pipeline events.
+//! Each backend (nanomsg, trace, etc.) implements this interface.
+class EventObserverIface {
+ public:
+  virtual ~EventObserverIface() = default;
+
+  // we need the ingress / egress ports, but they are part of the Packet
+  //! Signal that a packet was received by the switch
+  virtual void packet_in(const Packet& packet) = 0;
+  //! Signal that a packet was transmitted by the switch
+  virtual void packet_out(const Packet& packet) = 0;
+
+  virtual void parser_start(const Packet& packet, const Parser& parser) = 0;
+  virtual void parser_done(const Packet& packet, const Parser& parser) = 0;
+  virtual void parser_extract(const Packet& packet, header_id_t header) = 0;
+
+  virtual void deparser_start(const Packet& packet,
+                              const Deparser& deparser) = 0;
+  virtual void deparser_done(const Packet& packet,
+                             const Deparser& deparser) = 0;
+  virtual void deparser_emit(const Packet& packet, header_id_t header) = 0;
+
+  virtual void checksum_update(const Packet& packet,
+                               const Checksum& checksum) = 0;
+
+  virtual void pipeline_start(const Packet& packet,
+                              const Pipeline& pipeline) = 0;
+  virtual void pipeline_done(const Packet& packet,
+                             const Pipeline& pipeline) = 0;
+
+  virtual void condition_eval(const Packet& packet, const Conditional& cond,
+                              bool result) = 0;
+  virtual void table_hit(const Packet& packet, const MatchTableAbstract& table,
+                         entry_handle_t handle) = 0;
+  virtual void table_miss(const Packet& packet,
+                          const MatchTableAbstract& table) = 0;
+
+  virtual void action_execute(const Packet& packet, const ActionFn& action_fn,
+                              const ActionData& action_data) = 0;
+
+  virtual void config_change() = 0;
+};
+
+//! Singleton registry of event observers.
+//! All registered observers receive every event via the BMELOG macro.
+class EventObserverRegistry {
+ public:
+  static EventObserverRegistry* get() {
+    static EventObserverRegistry instance;
+    return &instance;
+  }
+
+  void register_observer(EventObserverIface* obs) {
+    for (auto* existing : observers_) {
+      if (existing == obs) return;
+    }
+    observers_.push_back(obs);
+  }
+
+  const std::vector<EventObserverIface*>& observers() const {
+    return observers_;
+  }
+
+ private:
+  EventObserverRegistry() = default;
+  std::vector<EventObserverIface*> observers_;
+};
+
+}  // namespace bm
+
+//! Dispatch an event to all registered observers.
+//! Usage: BMELOG(parser_start, *pkt, *this);
+#if defined(BM_ELOG_ON) || defined(BM_PACKET_TRACE_ON)
+#define BMELOG(fn, ...)                                                 \
+  do {                                                                  \
+    for (auto* _obs_ : bm::EventObserverRegistry::get()->observers()) { \
+      _obs_->fn(__VA_ARGS__);                                           \
+    }                                                                   \
+  } while (0)
+#else
+#define BMELOG(fn, ...)
+#endif
+
+#endif  // BM_BM_SIM_EVENT_OBSERVER_H_


### PR DESCRIPTION
Previously the `BMELOG` macro dispatched every event directly to a single hardcoded `EventLogger`. This refactor introduces an observer abstraction so multiple backends (the nanomsg `EventLogger`, and the upcoming Protobuf `PacketTracer`) can receive the same events.