### PR TITLE
use get_data_size in prsr short packet checks

### DIFF
--- a/src/bm_sim/parser.cpp
+++ b/src/bm_sim/parser.cpp
@@ -257,7 +257,7 @@ void extract_VL(Header *hdr,
   // get_nbytes_packet counts the VL field in the header as 0 bits
   auto bytes_to_extract = static_cast<size_t>(
       hdr->get_nbytes_packet() + nbits / 8);
-  if (pkt->get_ingress_length() - *bytes_parsed < bytes_to_extract)
+  if (pkt->get_data_size() - *bytes_parsed < bytes_to_extract)
     throw parser_exception_core(ErrorCodeMap::Core::PacketTooShort);
 
   if (max_header_bytes != 0 && max_header_bytes < bytes_to_extract)
@@ -433,7 +433,7 @@ struct ParserOpShift : ParserOp {
   void operator()(Packet *pkt, const char *data,
                   size_t *bytes_parsed) const override {
     (void) data;
-    if (pkt->get_ingress_length() - *bytes_parsed < shift_bytes)
+    if (pkt->get_data_size() - *bytes_parsed < shift_bytes)
       throw parser_exception_core(ErrorCodeMap::Core::PacketTooShort);
     *bytes_parsed += shift_bytes;
   }
@@ -465,7 +465,7 @@ ParserOpAdvance<Data>::operator()(Packet *pkt, const char *data,
   }
   const auto shift_bytes_uint = shift_bits_uint / 8;
   BMLOG_DEBUG_PKT(*pkt, "Advancing by {} bytes", shift_bytes_uint);
-  if (pkt->get_ingress_length() - *bytes_parsed < shift_bytes_uint)
+  if (pkt->get_data_size() - *bytes_parsed < shift_bytes_uint)
     throw parser_exception_core(ErrorCodeMap::Core::PacketTooShort);
   *bytes_parsed += shift_bytes_uint;
 }
@@ -489,7 +489,7 @@ ParserOpAdvance<ArithExpression>::operator()(Packet *pkt, const char *data,
   }
   const auto shift_bytes_uint = shift_bits_uint / 8;
   BMLOG_DEBUG_PKT(*pkt, "Advancing by {} bytes", shift_bytes_uint);
-  if (pkt->get_ingress_length() - *bytes_parsed < shift_bytes_uint)
+  if (pkt->get_data_size() - *bytes_parsed < shift_bytes_uint)
     throw parser_exception_core(ErrorCodeMap::Core::PacketTooShort);
   *bytes_parsed += shift_bytes_uint;
 }
@@ -512,7 +512,7 @@ ParserOpAdvance<field_t>::operator()(Packet *pkt, const char *data,
   }
   const auto shift_bytes_uint = shift_bits_uint / 8;
   BMLOG_DEBUG_PKT(*pkt, "Advancing by {} bytes", shift_bytes_uint);
-  if (pkt->get_ingress_length() - *bytes_parsed < shift_bytes_uint)
+  if (pkt->get_data_size() - *bytes_parsed < shift_bytes_uint)
     throw parser_exception_core(ErrorCodeMap::Core::PacketTooShort);
   *bytes_parsed += shift_bytes_uint;
 }


### PR DESCRIPTION
Replace `get_ingress_length()` with `get_data_size()` in parser checks to verify that there is sufficient packet data for the operation.

To provide a little more detail on this change:

1. `get_data_size()` returns the minimum of the _current_ data size and the truncated length. If a device truncates the packet prior to ingress parsing, or if the egress parser is running after ingress deparser changes the packet size, then `get_data_size()` will return a different value to `get_ingress_length()`

2. `get_data_size()` was already used in two places:
   * [`ParserOpSet<ParserLookAhead>::operator()(...)`](https://github.com/p4lang/behavioral-model/blob/b79ffdbcecb3b7feaf3afc6ee1349b6d5946d7d9/src/bm_sim/parser.cpp#L86)
   * [`check_enough_data_for_extract(...)`](https://github.com/p4lang/behavioral-model/blob/b79ffdbcecb3b7feaf3afc6ee1349b6d5946d7d9/src/bm_sim/parser.cpp#L229)