### PR TITLE
Fix unsigned underflow in StackP4_16::pop_front

### DIFF
--- a/src/bm_sim/stacks.cpp
+++ b/src/bm_sim/stacks.cpp
@@ -103,8 +103,11 @@ StackP4_16<T>::pop_front(size_t num) {
   auto size = this->elements.size();
   this->next -= std::min(this->next, num);
   size_t i = 0;
-  for (; i < size - num; i++) {
-    this->elements[i].get().swap_values(&this->elements[i + num].get());
+  // Avoid unsigned underflow when num >= size
+  if (num < size) {
+    for (; i < size - num; i++) {
+      this->elements[i].get().swap_values(&this->elements[i + num].get());
+    }
   }
   for (; i < size; i++) {
     this->elements[i].get().mark_invalid();

--- a/tests/test_header_stacks.cpp
+++ b/tests/test_header_stacks.cpp
@@ -371,6 +371,53 @@ TEST_F(HeaderStackP4_16Test, PopFront) {
   EXPECT_FALSE(h2.is_valid());
 }
 
+// Regression test for unsigned underflow when num >= stack size
+TEST_F(HeaderStackP4_16Test, PopFrontLargeNum) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
+
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
+
+  ASSERT_EQ(2u, stack.push_front(2));
+  h0.mark_valid();
+  h1.mark_valid();
+  ASSERT_EQ(2u, stack.get_count());
+
+  size_t num_to_pop = 5;  // exceeds stack depth
+  EXPECT_EQ(std::min(num_to_pop, this->stack_depth),
+            stack.pop_front(num_to_pop));
+
+  EXPECT_FALSE(h0.is_valid());
+  EXPECT_FALSE(h1.is_valid());
+  EXPECT_FALSE(h2.is_valid());
+  EXPECT_EQ(0u, stack.get_count());
+}
+
+// Boundary case: pop exactly stack depth elements
+TEST_F(HeaderStackP4_16Test, PopFrontExactDepth) {
+  auto &stack = this->stack;
+  auto *phv = this->phv.get();
+
+  auto &h0 = phv->get_header(this->testHeader_0);
+  auto &h1 = phv->get_header(this->testHeader_1);
+  auto &h2 = phv->get_header(this->testHeader_2);
+
+  ASSERT_EQ(3u, stack.push_front(3));
+  h0.mark_valid();
+  h1.mark_valid();
+  h2.mark_valid();
+  ASSERT_EQ(3u, stack.get_count());
+
+  EXPECT_EQ(3u, stack.pop_front(3));
+
+  EXPECT_FALSE(h0.is_valid());
+  EXPECT_FALSE(h1.is_valid());
+  EXPECT_FALSE(h2.is_valid());
+  EXPECT_EQ(0u, stack.get_count());
+}
+
 }  // namespace testing
 
 }  // namespace bm


### PR DESCRIPTION
## Summary

`StackP4_16::pop_front(size_t num)` computes the loop bound using `size - num`, where `size` is an unsigned value. When `num` is greater than the stack size, this subtraction underflows, resulting in an invalid loop bound and out-of-bounds access.

This change avoids the underflow by skipping the swap loop when `num >= size` and directly invalidating the remaining headers. The existing behavior for valid inputs is preserved.

## Before

* `pop_front()` computed `size - num` unconditionally.
* Calling `pop_front()` with `num > stack size` caused unsigned integer underflow.
* Running the new regression test against the original implementation reproduced the issue with a `std::vector::operator[]` assertion failure.

## After

* The swap loop executes only when `num < size`.
* For `num >= size`, all headers are invalidated directly.
* No unsigned underflow occurs.
* `pop_front()` safely handles requests larger than the stack size.

## Testing

* Added `HeaderStackP4_16Test.PopFrontLargeNum` regression test.
* Added `HeaderStackP4_16Test.PopFrontExactDepth` boundary test.
* Verified that `PopFrontLargeNum` reproduces the failure with the original implementation.
* Verified that both new tests pass with the fix.
* Ran the complete `test_header_stacks` suite successfully.
* Ran the full CTest suite. The only remaining failure was the existing `test_switch` test due to a missing Python `thrift` dependency, which is unrelated to this change.
