### PR TITLE
Reject unknown direct_meters references in table JSON instead of silently using a null meter

### DIFF
--- a/src/bm_sim/P4Objects.cpp
+++ b/src/bm_sim/P4Objects.cpp
@@ -1784,7 +1784,15 @@ P4Objects::init_pipelines(const Json::Value &cfg_root,
       if (cfg_table.isMember("direct_meters") &&
           !cfg_table["direct_meters"].isNull()) {
         const std::string meter_name = cfg_table["direct_meters"].asString();
-        const DirectMeterArray &direct_meter = direct_meters[meter_name];
+        const auto direct_meter_it = direct_meters.find(meter_name);
+        if (direct_meter_it == direct_meters.end()) {
+          throw json_exception(
+              EFormat() << "Table '" << table_name
+                        << "' refers to unknown direct meter array '"
+                        << meter_name << "'",
+              cfg_table);
+        }
+        const DirectMeterArray &direct_meter = direct_meter_it->second;
         table->get_match_table()->set_direct_meters(
             direct_meter.meter, direct_meter.header, direct_meter.offset);
       }

--- a/tests/test_p4objects.cpp
+++ b/tests/test_p4objects.cpp
@@ -140,6 +140,18 @@ TEST(P4Objects, UnknownHashSelector) {
   EXPECT_EQ(expected, os.str());
 }
 
+TEST(P4Objects, UnknownDirectMeter) {
+  // NOLINTNEXTLINE(whitespace/line_length)
+  std::istringstream is("{\"actions\":[{\"name\":\"_drop\",\"id\":2,\"runtime_data\":[],\"primitives\":[{\"op\":\"drop\",\"parameters\":[]}]}],\"pipelines\":[{\"name\":\"ingress\",\"id\":0,\"init_table\":\"t1\",\"tables\":[{\"name\":\"t1\",\"id\":0,\"match_type\":\"exact\",\"type\":\"simple\",\"max_size\":1024,\"with_counters\":false,\"key\":[],\"actions\":[\"_drop\"],\"next_tables\":{\"_drop\":null},\"default_action\":null,\"direct_meters\":\"bad_meter\"}],\"conditionals\":[]}]}");
+  std::stringstream os;
+  LookupStructureFactory factory;
+  P4Objects objects(os);
+  std::string expected(
+      "Table 't1' refers to unknown direct meter array 'bad_meter'\n");
+  ASSERT_NE(0, objects.init_objects(&is, &factory));
+  EXPECT_EQ(expected, os.str());
+}
+
 TEST(P4Objects, RequiredField) {
   std::istringstream is("{}");
   std::set<P4Objects::header_field_pair> required_fields;


### PR DESCRIPTION
### Summary
When a table's JSON config specifies a direct_meters attribute, P4Objects::init_pipelines previously looked up the referenced meter with unordered_map::operator[]. If the name did not match any meter array declared with is_direct: true, operator[] silently default-constructed a DirectMeterArray with a null meter pointer.
That null pointer was then passed to MatchTableAbstract::set_direct_meters(), which only guards it with an assert() (compiled out in release builds). The first packet that hits the table can then dereference a null pointer.
Other malformed-reference cases in this function already throw a json_exception and abort loading cleanly. Unknown direct-meter references should behave the same way.

### Fix
Replace the operator[] lookup with .find() and throw a json_exception when the referenced direct-meter array does not exist. The error includes both the table name and missing meter name.

### Testing
Added TEST(P4Objects, UnknownDirectMeter) to tests/test_p4objects.cpp. The test constructs a minimal configuration with a table referencing an unknown direct meter and verifies that initialization fails with the expected error message.
Both the modified source file and test compile successfully with g++ -std=c++17 -fsyntax-only against the project's required headers.
