### PR TITLE
pna_nic/psa_switch: Add bounds check for meter and counter externs

### DIFF
--- a/targets/pna_nic/externs/pna_counter.cpp
+++ b/targets/pna_nic/externs/pna_counter.cpp
@@ -10,6 +10,8 @@
 
 
 #include "pna_counter.h"
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/packet.h>
 
 namespace bm {
 
@@ -17,8 +19,18 @@ namespace pna {
 
 void
 PNA_Counter::count(const Data &index) {
-  _counter->get_counter(
-      index.get<size_t>()).increment_counter(get_packet());
+  auto idx = index.get<size_t>();
+#ifndef NDEBUG
+  if (idx >= size()) {
+    BMLOG_ERROR_PKT(get_packet(),
+                    "Attempted to update counter '{}' with size {}"
+                    " at out-of-bounds index {}."
+                    "  No counters were updated.",
+                    get_name(), size(), idx);
+    return;
+  }
+#endif  // NDEBUG
+  _counter->get_counter(idx).increment_counter(get_packet());
 }
 
 Counter &

--- a/targets/pna_nic/externs/pna_meter.cpp
+++ b/targets/pna_nic/externs/pna_meter.cpp
@@ -9,6 +9,8 @@
  */
 
 #include "pna_meter.h"
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/packet.h>
 #include <iostream>
 
 namespace bm {
@@ -33,7 +35,19 @@ PNA_Meter::init() {
 
 void
 PNA_Meter::execute(const Data &index, Data &value) {
-    auto color_out = _meter->execute_meter(get_packet(), index.get<size_t>(), static_cast<unsigned int>(0));
+    auto idx = index.get<size_t>();
+#ifndef NDEBUG
+    if (idx >= size()) {
+        BMLOG_ERROR_PKT(get_packet(),
+                        "Attempted to execute meter '{}' with size {}"
+                        " at out-of-bounds index {}."
+                        "  No meters were updated, and neither was"
+                        " the value field.",
+                        get_name(), size(), idx);
+        return;
+    }
+#endif  // NDEBUG
+    auto color_out = _meter->execute_meter(get_packet(), idx, static_cast<unsigned int>(0));
 
     // color adjustment for PNA:
     // bmv2 meter implementation assign higher value for busier flow:

--- a/targets/pna_nic/tests/CMakeLists.txt
+++ b/targets/pna_nic/tests/CMakeLists.txt
@@ -24,4 +24,26 @@ target_include_directories(test_parse_pna PRIVATE
 
 add_test(NAME pna_nic/test_parse_pna COMMAND test_parse_pna)
 
+add_executable(pna_nic_test_meter_counter_bounds
+  main.cpp
+  test_meter_counter_bounds.cpp
+)
+
+target_link_libraries(pna_nic_test_meter_counter_bounds
+  pnanic
+  gtest
+  bmapps
+)
+
+target_include_directories(pna_nic_test_meter_counter_bounds PRIVATE
+  ..
+)
+
+set_target_properties(pna_nic_test_meter_counter_bounds PROPERTIES
+  OUTPUT_NAME test_meter_counter_bounds
+)
+
+add_test(NAME pna_nic/test_meter_counter_bounds
+  COMMAND pna_nic_test_meter_counter_bounds)
+
 # FIXME: do we want the test_all target?

--- a/targets/pna_nic/tests/Makefile.am
+++ b/targets/pna_nic/tests/Makefile.am
@@ -18,15 +18,17 @@ $(top_builddir)/src/bm_apps/libbmapps.la
 
 # Define unit tests
 common_source = main.cpp
-TESTS = test_parse_pna
+TESTS = test_parse_pna test_meter_counter_bounds
 
 check_PROGRAMS = $(TESTS) test_all
 
 # Sources for tests
 test_parse_pna_SOURCES = $(common_source) test_parse_pna.cpp
+test_meter_counter_bounds_SOURCES = $(common_source) test_meter_counter_bounds.cpp
 
 test_all_SOURCES = $(common_source) \
-test_parse_pna.cpp
+test_parse_pna.cpp \
+test_meter_counter_bounds.cpp
 
 EXTRA_DIST = \
 testdata/pna-demo-L2-one-table.json

--- a/targets/pna_nic/tests/test_meter_counter_bounds.cpp
+++ b/targets/pna_nic/tests/test_meter_counter_bounds.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_sim/extern.h>
+#include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/phv.h>
+#include <bm/bm_sim/phv_source.h>
+
+#include "externs/pna_counter.h"
+#include "externs/pna_meter.h"
+
+using namespace bm;
+
+namespace {
+
+// Minimal packet fixture for testing extern execution without header parsing.
+class PNA_MeterCounterBoundsTest : public ::testing::Test {
+ protected:
+  PHVFactory phv_factory;
+  std::unique_ptr<PHVSourceIface> phv_source{PHVSourceIface::make_phv_source()};
+  std::unique_ptr<Packet> packet{nullptr};
+
+  virtual void SetUp() {
+    phv_source->set_phv_factory(0, &phv_factory);
+    packet = std::unique_ptr<Packet>(new Packet(Packet::make_new(
+        64, PacketBuffer(128), phv_source.get())));
+  }
+};
+
+}  // namespace
+
+TEST_F(PNA_MeterCounterBoundsTest, MeterOutOfBoundsIndex) {
+  pna::PNA_Meter meter;
+  meter._register_attributes();
+  meter._set_attribute<Data>("n_meters", Data(4));
+  meter._set_attribute<std::string>("type", "packets");
+  meter._set_attribute<Data>("rate_count", Data(1));
+  meter._set_name_and_id("test_meter", 0);
+  meter.init();
+  meter._set_packet_ptr(packet.get());
+
+  ASSERT_EQ(4u, meter.size());
+
+  Data index(10);  // Out-of-bounds index (valid: 0..3)
+  Data value(0xff);
+  EXPECT_NO_THROW(meter.execute(index, value));
+  // Verify output value remains unmodified
+  EXPECT_EQ(Data(0xff), value);
+}
+
+TEST_F(PNA_MeterCounterBoundsTest, CounterOutOfBoundsIndex) {
+  pna::PNA_Counter counter;
+  counter._register_attributes();
+  counter._set_attribute<Data>("n_counters", Data(4));
+  counter._set_name_and_id("test_counter", 0);
+  counter.init();
+  counter._set_packet_ptr(packet.get());
+
+  ASSERT_EQ(4u, counter.size());
+
+  Data index(10);  // Out-of-bounds index (valid: 0..3)
+  EXPECT_NO_THROW(counter.count(index));
+  // Verify counter state remains unmutated
+  Counter::counter_value_t bytes = 0, packets = 0;
+  counter.get_counter(0).query_counter(&bytes, &packets);
+  EXPECT_EQ(0u, bytes);
+  EXPECT_EQ(0u, packets);
+}

--- a/targets/psa_switch/externs/psa_counter.cpp
+++ b/targets/psa_switch/externs/psa_counter.cpp
@@ -10,6 +10,8 @@
 
 
 #include "psa_counter.h"
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/packet.h>
 
 namespace bm {
 
@@ -17,8 +19,18 @@ namespace psa {
 
 void
 PSA_Counter::count(const Data &index) {
-  _counter->get_counter(
-      index.get<size_t>()).increment_counter(get_packet());
+  auto idx = index.get<size_t>();
+#ifndef NDEBUG
+  if (idx >= size()) {
+    BMLOG_ERROR_PKT(get_packet(),
+                    "Attempted to update counter '{}' with size {}"
+                    " at out-of-bounds index {}."
+                    "  No counters were updated.",
+                    get_name(), size(), idx);
+    return;
+  }
+#endif  // NDEBUG
+  _counter->get_counter(idx).increment_counter(get_packet());
 }
 
 Counter &

--- a/targets/psa_switch/externs/psa_meter.cpp
+++ b/targets/psa_switch/externs/psa_meter.cpp
@@ -8,6 +8,8 @@
  */
 
 #include "psa_meter.h"
+#include <bm/bm_sim/logger.h>
+#include <bm/bm_sim/packet.h>
 #include <iostream>
 
 namespace bm {
@@ -32,7 +34,19 @@ PSA_Meter::init() {
 
 void
 PSA_Meter::execute(const Data &index, Data &value) {
-    auto color_out = _meter->execute_meter(get_packet(), index.get<size_t>(), static_cast<unsigned int>(0));
+    auto idx = index.get<size_t>();
+#ifndef NDEBUG
+    if (idx >= size()) {
+        BMLOG_ERROR_PKT(get_packet(),
+                        "Attempted to execute meter '{}' with size {}"
+                        " at out-of-bounds index {}."
+                        "  No meters were updated, and neither was"
+                        " the value field.",
+                        get_name(), size(), idx);
+        return;
+    }
+#endif  // NDEBUG
+    auto color_out = _meter->execute_meter(get_packet(), idx, static_cast<unsigned int>(0));
 
     // color adjustment for PSA:
     // bmv2 meter implementation assign higher value for busier flow:

--- a/targets/psa_switch/tests/CMakeLists.txt
+++ b/targets/psa_switch/tests/CMakeLists.txt
@@ -6,7 +6,7 @@
 add_definitions(-DTESTDATADIR="${CMAKE_CURRENT_SOURCE_DIR}/testdata")
 
 set(COMMON_SRCS main.cpp)
-set(TESTS test_internet_checksum test_hash)
+set(TESTS test_internet_checksum test_hash test_meter_counter_bounds)
 foreach(TEST_NAME ${TESTS})
   add_executable(${TEST_NAME}
     ${COMMON_SRCS}
@@ -35,6 +35,7 @@ add_executable(psa_switch_test_all
   ${COMMON_SRCS}
   test_internet_checksum.cpp
   test_hash.cpp
+  test_meter_counter_bounds.cpp
 )
 
 target_link_libraries(psa_switch_test_all

--- a/targets/psa_switch/tests/Makefile.am
+++ b/targets/psa_switch/tests/Makefile.am
@@ -16,14 +16,17 @@ $(top_builddir)/src/bm_apps/libbmapps.la
 # Define unit tests
 common_source = main.cpp
 TESTS = test_internet_checksum \
-test_hash
+test_hash \
+test_meter_counter_bounds
 
 check_PROGRAMS = $(TESTS) test_all
 
 # Sources for tests
 test_internet_checksum_SOURCES = $(common_source) test_internet_checksum.cpp
 test_hash_SOURCES = $(common_source) test_hash.cpp
+test_meter_counter_bounds_SOURCES = $(common_source) test_meter_counter_bounds.cpp
 
 test_all_SOURCES = $(common_source) \
 test_internet_checksum.cpp \
-test_hash.cpp
+test_hash.cpp \
+test_meter_counter_bounds.cpp

--- a/targets/psa_switch/tests/test_meter_counter_bounds.cpp
+++ b/targets/psa_switch/tests/test_meter_counter_bounds.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <bm/bm_sim/extern.h>
+#include <bm/bm_sim/packet.h>
+#include <bm/bm_sim/phv.h>
+#include <bm/bm_sim/phv_source.h>
+
+#include "externs/psa_counter.h"
+#include "externs/psa_meter.h"
+
+using namespace bm;
+
+namespace {
+
+// Minimal packet fixture for testing extern execution without header parsing.
+class PSA_MeterCounterBoundsTest : public ::testing::Test {
+ protected:
+  PHVFactory phv_factory;
+  std::unique_ptr<PHVSourceIface> phv_source{PHVSourceIface::make_phv_source()};
+  std::unique_ptr<Packet> packet{nullptr};
+
+  virtual void SetUp() {
+    phv_source->set_phv_factory(0, &phv_factory);
+    packet = std::unique_ptr<Packet>(new Packet(Packet::make_new(
+        64, PacketBuffer(128), phv_source.get())));
+  }
+};
+
+}  // namespace
+
+TEST_F(PSA_MeterCounterBoundsTest, MeterOutOfBoundsIndex) {
+  psa::PSA_Meter meter;
+  meter._register_attributes();
+  meter._set_attribute<Data>("n_meters", Data(4));
+  meter._set_attribute<std::string>("type", "packets");
+  meter._set_attribute<Data>("rate_count", Data(1));
+  meter._set_name_and_id("test_meter", 0);
+  meter.init();
+  meter._set_packet_ptr(packet.get());
+
+  ASSERT_EQ(4u, meter.size());
+
+  Data index(10);  // Out-of-bounds index (valid: 0..3)
+  Data value(0xff);
+  EXPECT_NO_THROW(meter.execute(index, value));
+  // Verify output value remains unmodified
+  EXPECT_EQ(Data(0xff), value);
+}
+
+TEST_F(PSA_MeterCounterBoundsTest, CounterOutOfBoundsIndex) {
+  psa::PSA_Counter counter;
+  counter._register_attributes();
+  counter._set_attribute<Data>("n_counters", Data(4));
+  counter._set_name_and_id("test_counter", 0);
+  counter.init();
+  counter._set_packet_ptr(packet.get());
+
+  ASSERT_EQ(4u, counter.size());
+
+  Data index(10);  // Out-of-bounds index (valid: 0..3)
+  EXPECT_NO_THROW(counter.count(index));
+  // Verify counter state remains unmutated
+  Counter::counter_value_t bytes = 0, packets = 0;
+  counter.get_counter(0).query_counter(&bytes, &packets);
+  EXPECT_EQ(0u, bytes);
+  EXPECT_EQ(0u, packets);
+}


### PR DESCRIPTION
### Summary
Adds out-of-bounds index validation for PNA_Counter, PNA_Meter, PSA_Counter, and PSA_Meter extern functions in targets/pna_nic and targets/psa_switch.

### Description of Changes
- Bounds Checking: Added #ifndef NDEBUG guards in PNA_Counter::count(), PNA_Meter::execute(), PSA_Counter::count(), and PSA_Meter::execute() to mirror the safe handling convention used in simple_switch.
- Error Handling: When an invalid index (idx >= size()) is encountered, an error is logged using BMLOG_ERROR_PKT and execution returns early, keeping underlying arrays and output fields untouched.
- Unit Testing: Introduced test_meter_counter_bounds.cpp unit tests under both targets/pna_nic/tests/ and targets/psa_switch/tests/ to verify out-of-bounds safety, and updated CMakeLists.txt and Makefile.am accordingly.