### PR TITLE
fix off-by-one error in LAG index validation (re-opening #1440)

### DIFF
--- a/src/bm_sim/simple_pre_lag.cpp
+++ b/src/bm_sim/simple_pre_lag.cpp
@@ -77,7 +77,7 @@ McSimplePreLAG::mc_set_lag_membership(const lag_id_t lag_index,
                                       const PortMap &port_map) {
   std::unique_lock<std::shared_mutex> lock(mutex);
   uint16_t member_count = 0;
-  if (lag_index > LAG_MAX_ENTRIES) {
+  if (lag_index >= LAG_MAX_ENTRIES) {
     Logger::get()->error("lag membership set failed, invalid lag index");
     return ERROR;
   }


### PR DESCRIPTION
### Summary
fixes an off-by-one error in McSimplePreLAG::mc_set_lag_membership where lag_index validation used > instead of >=.

This replaces and re-opens the changes from closed PR #1440 onto a clean branch.

### Context & Solution
In C++, 0-based indexing for fixed-size structures means that for LAG_MAX_ENTRIES, valid indices are 0 through LAG_MAX_ENTRIES - 1. Passing lag_index == LAG_MAX_ENTRIES bypassed the previous lag_index > LAG_MAX_ENTRIES boundary check, leading to potential out-of-bounds access.

Updating the check to lag_index >= LAG_MAX_ENTRIES correctly catches this edge case and returns ERROR.

### Changes Made
- Modified src/bm_sim/simple_pre_lag.cpp: Updated lag_index > LAG_MAX_ENTRIES check to >=.