### PR TITLE
Update tag name for Ubuntu 24.04 third-party docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
     # Ideally, we would update the image every time the base image (p4lang/pi)
     # is updated, but we deem this good enough.
     - cron: '15 3-23/4 * * *' # "At minute 15 past every 4th hour from 3 through 23."
+  workflow_dispatch: # Allows manual runs
 
 jobs:
   build:

--- a/Dockerfile.noPI
+++ b/Dockerfile.noPI
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM p4lang/third-party:latest-24
+FROM p4lang/third-party:latest
 LABEL maintainer="P4 Developers <p4-dev@lists.p4.org>"
 LABEL description="This Docker image does not have any dependency on PI or P4 \
 Runtime, it only builds bmv2 simple_switch."


### PR DESCRIPTION
It was changed via a recent commit in the p4lang/third-party repo to no longer have a suffix of "-24" in its name.